### PR TITLE
CODEOWNERS: initialize file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @grafana/cloud-release will be requested for review when
+# someone opens a pull request.
+* @grafana/cloud-release
+
+# Cloud Release
+/.github/workflows/publish-techdocs.yaml @grafana/cloud-release


### PR DESCRIPTION
@grafana/cloud-release will be the default reviewers of PRs. A team can set themselves/their team to own certain workflows.