### PR TITLE
fix(publish-techdocs): remove cache from setup-python

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.11
-          cache: 'pip'
 
       - name: Install mkdocs and mkdocs plugins
         run: python -m pip install mkdocs-techdocs-core==1.*


### PR DESCRIPTION
Setting this pip cache requires a `requirements.txt` file somewhere in the project or the step fails. Remove the `cache` input as not all projects will have a `requirements.txt`.