### PR TITLE
fix(publish-techdocs): remove `cache` from `setup python` step name

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install techdocs-cli
         run: sudo npm install -g @techdocs/cli
 
-      - name: setup python cache
+      - name: setup python
         uses: actions/setup-python@v2
         with:
           python-version: 3.11


### PR DESCRIPTION
Remove `cache` from the step name as we are no longer setting up cache.