### PR TITLE
Bump python action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "monthly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
     directory: "/"
     schedule:
       # Check for updates to GitHub Actions every week
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -39,7 +39,7 @@ jobs:
         run: sudo npm install -g @techdocs/cli
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
 

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -39,7 +39,7 @@ jobs:
         run: sudo npm install -g @techdocs/cli
 
       - name: setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v2
         with:
           python-version: 3.11
 


### PR DESCRIPTION
![SCR-20230901-m2j](https://github.com/grafana/shared-workflows/assets/580672/e5976c4c-8095-48ca-b54f-20d25d360286)

This add a dependabot workflow that should lead to opening a PR to bump the python workflow that will eventually make this warning go away once merged. 