### PR TITLE
GAR: Add option to push multiple tags

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -24,9 +24,8 @@ jobs:
         id: push-to-gar
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev
-          project: "<YOUR-GCP-PROJECT>" 
-          repository: "<YOUR_REPOSITORY>" 
-          image_name: "<YOUR_IMAGE_NAME>" 
-          tag: "<YOUR_TAG>" # e.g. X.Y.Z or latest
+          tags: |-
+            "<IMAGE_NAME>:<IMAGE_TAG>"
+            "<IMAGE_NAME>:latest"
           build_path: "<YOUR_BUILD_PATH>" # e.g. "." - where the Dockerfile is
 ```

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -34,7 +34,6 @@ runs:
       with:
         context: ${{ inputs.build_path }}
         push: ${{ github.event_name == 'push' }}
-        tags: |
-          ${{ inputs.tags }}
+        tags: ${{ inputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -6,7 +6,7 @@ inputs:
       Google Artifact Registry to store docker images in.
   tags:
     description: |
-      Docker image tags.
+      List of Docker images to be pushed.
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -4,18 +4,9 @@ inputs:
   registry:
     description: |
       Google Artifact Registry to store docker images in.
-  project:
+  tags:
     description: |
-      The project which organises the Google Cloud resources.
-  repository:
-    description: |
-      Repository to store the docker image.
-  image_name:
-    description: |
-      The name of the Docker image to be created.
-  tag:
-    description: |
-      Docker image tag.
+      Docker image tags.
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.
@@ -44,6 +35,6 @@ runs:
         context: ${{ inputs.build_path }}
         push: ${{ github.event_name == 'push' }}
         tags: |
-          ${{ inputs.registry }}/${{ inputs.project }}/${{ inputs.repository }}/${{ inputs.image_name }}:${{ inputs.tag }}
+          ${{ inputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max


### PR DESCRIPTION
Instead of passing just one docker image, the workflow should be able to push more than one tags for the same image, but also more than one images even if they're different. 

Related PR: https://github.com/grafana/grafana-backstage/pull/148