### PR TITLE
trigger-argo-workflow: Don't re-split parameters

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -136,7 +136,7 @@ runs:
           --log-level "${{ inputs.log_level }}" \
           --namespace "${{ inputs.namespace }}" \
           --instance "${{ inputs.instance }}" \
-          ${parameters[@]} \
+          "${parameters[@]}" \
           submit \
           ${{ inputs.extra_args }}
       env:


### PR DESCRIPTION
If a paremeter has spaces in it, they're being passed separately to the program, like `[--parameter, foo=, bar, baz]` instead of `[--parameter, foo=barbaz]`. This fails to run.