### PR TITLE
OIDC: Construct service account based on input

### DIFF
--- a/actions/push-to-dockerhub/README.md
+++ b/actions/push-to-dockerhub/README.md
@@ -23,7 +23,7 @@ jobs:
         uses: grafana/shared-workflows/actions/push-to-dockerhub@main
         with:
           repository: ${{ github.repository }} # or any other dockerhub repository
-          build_path: .
+          context: .
           tags: |-
             "2024-04-01-abcd1234"
             "latest"

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -9,6 +9,11 @@ trigger these composite workflows.
 name: CI
 on: 
   pull_request:
+    
+env:
+  ENVIRONMENT: "dev" # can be either dev/prod
+  ROOT_REPO: ${{ github.event.repository.name }} # must be explicitly set like this - composite actions cannot get callers' payload, required
+  IMAGE_NAME: "backstage" # name of the image to be published, required
 
 # These permissions are needed to assume roles from Github's OIDC.
 permissions:
@@ -23,7 +28,7 @@ jobs:
       - uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         id: push-to-gar
         with:
-          registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev
+          registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
           tags: |-
             "<IMAGE_NAME>:<IMAGE_TAG>"
             "<IMAGE_NAME>:latest"

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -32,5 +32,5 @@ jobs:
           tags: |-
             "<IMAGE_TAG>"
             "latest"
-          context: "<YOUR_BUILD_PATH>" # e.g. "." - where the Dockerfile is
+          context: "<YOUR_CONTEXT>" # e.g. "." - where the Dockerfile is
 ```

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
           tags: |-
-            "<IMAGE_NAME>:<IMAGE_TAG>"
-            "<IMAGE_NAME>:latest"
+            "<IMAGE_TAG>"
+            "latest"
           context: "<YOUR_BUILD_PATH>" # e.g. "." - where the Dockerfile is
 ```

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -8,9 +8,11 @@ inputs:
   tags:
     description: |
       List of Docker images to be pushed.
+    required: true
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.
+    default: "."
   environment:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
@@ -18,6 +20,7 @@ inputs:
   image_name:
     description: |
       Name of the image to be pushed to GAR.
+    required: true
 
 runs:
   using: composite
@@ -41,7 +44,7 @@ runs:
       run: |
         tags=(${{ inputs.tags }})
         image_uris=()
-        IFS=$'\n' read -r -a tags_array <<< "tags"
+        IFS=$'\n' read -r -a tags_array <<< "$tags"
         
         for tag in ${tags_array[@]}; do
           image_uri="${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}:$tag"

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -43,10 +43,8 @@ runs:
       shell: bash
       run: |
         tags=(${{ inputs.tags }})
-        image_uris=()
-        IFS=$'\n' read -r -a tags_array <<< "$tags"
         
-        for tag in ${tags_array[@]}; do
+        for tag in ${tags[@]}; do
           image_uri="${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}:$tag"
           image_uris+=("$image_uri")
         done

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -35,11 +35,25 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
-    - name: Echo project
-      id: echo-project
+    - name: Resolve tags
+      id: resolve-tags
+      shell: bash
+      run: |
+        tags=(${{ inputs.tags }})
+        image_uris=()
+        
+        for tag in ${tags[@]}; do
+          image_uri="${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}:$tag"
+          image_uris+=("$image_uri")
+        done
+        
+        IFS=, image_uris_string="${image_uris[*]}"
+        echo "images=${image_uris_string}" >> ${GITHUB_OUTPUT}
+    - name: Echo tags
+      id: echo-tags
       shell: sh
       run: |
-        echo ${{ steps.resolve-project.outputs.project }}
+        echo ${{ steps.resolve-tags.outputs.images }}
     - name: Construct service account
       id: construct-service-account
       shell: sh
@@ -66,6 +80,6 @@ runs:
       with:
         context: ${{ inputs.build_path }}
         push: ${{ github.event_name == 'push' }}
-        tags: ${{ inputs.tags }}
+        tags: ${{ steps.resolve-tags.outputs.images }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -32,7 +32,7 @@ runs:
       with:
         token_format: access_token
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: ${{ steps.construct-service-account.output.service_account }}
+        service_account: ${{ steps.construct-service-account.outputs.service_account }}
         create_credentials_file: false
     - name: Login to GAR
       uses: docker/login-action@v3

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -44,11 +44,6 @@ runs:
       with:
         images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
-    - name: Echo tags
-      id: echo-tags
-      shell: sh
-      run: |
-        echo ${{ steps.meta.outputs.images }}
     - name: Construct service account
       id: construct-service-account
       shell: sh

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -75,6 +75,6 @@ runs:
       with:
         context: ${{ inputs.context }}
         push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.meta.outputs.images }}
+        tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -10,9 +10,6 @@ inputs:
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.
-  root_repo:
-    description: |
-      The repository from which this composite action was called.
   environment:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
@@ -25,7 +22,7 @@ runs:
       id: construct-service-account
       shell: sh
       run: |
-        SERVICE_ACCOUNT="github-${{ inputs.root_repo }}-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        SERVICE_ACCOUNT="github-${ROOT_REPO}-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@v1
       id: gcloud-auth

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -41,8 +41,9 @@ runs:
       run: |
         tags=(${{ inputs.tags }})
         image_uris=()
+        IFS=$'\n' read -r -a tags_array <<< "tags"
         
-        for tag in ${tags[@]}; do
+        for tag in ${tags_array[@]}; do
           image_uri="${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}:$tag"
           image_uris+=("$image_uri")
         done

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -75,6 +75,6 @@ runs:
       with:
         context: ${{ inputs.context }}
         push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.resolve-tags.outputs.images }}
+        tags: ${{ steps.meta.outputs.images }}
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -10,6 +10,9 @@ inputs:
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.
+  root_repo:
+    description: |
+      The repository from which this composite action was called.
   environment:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
@@ -18,12 +21,18 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Construct service account
+      id: construct-service-account
+      shell: sh
+      run: |
+        SERVICE_ACCOUNT="github-${{ inputs.root_repo }}-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        echo "service_account=$SERVICE_ACCOUNT" >> $GITHUB_ENV
     - uses: google-github-actions/auth@v1
       id: gcloud-auth
       with:
         token_format: access_token
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: "github-docker-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        service_account: $service_account
         create_credentials_file: false
     - name: Login to GAR
       uses: docker/login-action@v3

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -38,24 +38,17 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
-    - name: Resolve tags
-      id: resolve-tags
-      shell: bash
-      run: |
-        tags=(${{ inputs.tags }})
-        
-        for tag in ${tags[@]}; do
-          image_uri="${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}:$tag"
-          image_uris+=("$image_uri")
-        done
-        
-        IFS=, image_uris_string="${image_uris[*]}"
-        echo "images=${image_uris_string}" >> ${GITHUB_OUTPUT}
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      with:
+        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${ROOT_REPO}-${{ inputs.environment }}/${{ inputs.image_name }}"
+        tags: ${{ inputs.tags }}
     - name: Echo tags
       id: echo-tags
       shell: sh
       run: |
-        echo ${{ steps.resolve-tags.outputs.images }}
+        echo ${{ steps.meta.outputs.images }}
     - name: Construct service account
       id: construct-service-account
       shell: sh

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: |
       List of Docker images to be pushed.
     required: true
-  build_path:
+  context:
     description: |
       Path to Dockerfile, which is used to build the image.
     default: "."
@@ -80,7 +80,7 @@ runs:
     - name: Build the container
       uses: docker/build-push-action@v5.0.0
       with:
-        context: ${{ inputs.build_path }}
+        context: ${{ inputs.context }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.resolve-tags.outputs.images }}
         cache-from: type=gha

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -26,13 +26,13 @@ runs:
       shell: sh
       run: |
         SERVICE_ACCOUNT="github-${{ inputs.root_repo }}-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
-        echo "service_account=$SERVICE_ACCOUNT" >> $GITHUB_ENV
+        echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@v1
       id: gcloud-auth
       with:
         token_format: access_token
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: $service_account
+        service_account: ${{ steps.construct-service-account.output.service_account }}
         create_credentials_file: false
     - name: Login to GAR
       uses: docker/login-action@v3

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -4,6 +4,7 @@ inputs:
   registry:
     description: |
       Google Artifact Registry to store docker images in.
+    default: "us-docker.pkg.dev"
   tags:
     description: |
       List of Docker images to be pushed.
@@ -14,15 +15,36 @@ inputs:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
     default: dev
+  image_name:
+    description: |
+      Name of the image to be pushed to GAR.
 
 runs:
   using: composite
   steps:
+    - name: Resolve GCP project
+      id: resolve-project
+      shell: bash
+      run: |
+        if [ "${{ inputs.environment }}" == 'dev' ]; then
+          PROJECT="grafanalabs-dev"
+        elif [ "${{ inputs.environment }}" == 'prod' ]; then
+          PROJECT="grafanalabs-global"
+        else
+          echo "Invalid environment. Valid environment variable inputs: dev, prod"
+          exit 1
+        fi
+        echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
+    - name: Echo project
+      id: echo-project
+      shell: sh
+      run: |
+        echo ${{ steps.resolve-project.outputs.project }}
     - name: Construct service account
       id: construct-service-account
       shell: sh
       run: |
-        SERVICE_ACCOUNT="github-${ROOT_REPO}-dev@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        SERVICE_ACCOUNT="github-${ROOT_REPO}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@v1
       id: gcloud-auth


### PR DESCRIPTION
Instead of having a hardcoded service account, we should have it constructed based on the attributes of the caller repository. 
This way we can make sure that the caller workflow can only push artifacts to the registry it means to, using the service account which was created for this purpose only.