### PR TITLE
OIDC auth: Add `environment` input variable

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -10,6 +10,9 @@ inputs:
   build_path:
     description: |
       Path to Dockerfile, which is used to build the image.
+  environment:
+    description: |
+      Environment for pushing artifacts (can be either dev or prod).
 
 runs:
   using: composite

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -13,6 +13,7 @@ inputs:
   environment:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
+    default: dev
 
 runs:
   using: composite


### PR DESCRIPTION
Part of: https://github.com/grafana/deployment_tools/issues/110276

We need this input variable for automating the `github-<REPO_NAME>-<ENV_NAME>@...` service account construction.

Can be either dev/prod, defaults to dev.

Will be revisited - ideally we should just add `dev` or `prod` to the initial GHA caller workflow and everything should be resolved to the appropriate projects and envs.