### PR TITLE
Dockerhub: Add `push-to-dockerhub` action

### DIFF
--- a/actions/push-to-dockerhub/README.md
+++ b/actions/push-to-dockerhub/README.md
@@ -1,0 +1,30 @@
+# push-to-dockerhub
+
+This is a composite GitHub Action, used to push docker images to DockerHub.
+It uses `get-vault-secrets` action to get the DockerHub username and password from Vault.
+
+Example of how to use this action in a repository:
+
+```yaml
+name: Push to DockerHub
+on:
+  pull_request:
+    
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: push-to-dockerhub
+        uses: grafana/shared-workflows/actions/push-to-dockerhub@main
+        with:
+          repository: ${{ github.repository }} # or any other dockerhub repository
+          build_path: .
+          tags: |-
+            "2024-04-01-abcd1234"
+            "latest"
+```

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -9,7 +9,7 @@ inputs:
     description: |
       List of Docker images to be pushed.
     required: true
-  build_path:
+  context:
     description: |
       Path to Dockerfile, which is used to build the image.
     default: "."
@@ -44,7 +44,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
-        context: ${{ inputs.build_path }}
+        context: ${{ inputs.context }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -42,5 +42,5 @@ runs:
         context: .
         file: ./Dockerfile
         push: true
-        tags: ${{ input.tags }}
+        tags: ${{ inputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -36,10 +36,24 @@ runs:
       with:
         images: ${{ inputs.repository }}
 
+    - name: Resolve tags
+      id: resolve-tags
+      shell: bash
+      run: |
+        tags=(${{ inputs.tags }})
+
+        for tag in ${tags[@]}; do
+          image_uri="${{ inputs.repository }}:$tag"
+          image_uris+=("$image_uri")
+        done
+
+        IFS=, image_uris_string="${image_uris[*]}"
+        echo "images=${image_uris_string}" >> ${GITHUB_OUTPUT}
+
     - name: Build and push Docker image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
         context: .
         push: true
-        tags: ${{ inputs.tags }}
+        tags: ${{ steps.resolve-tags.outputs.images }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -40,7 +40,6 @@ runs:
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
         context: .
-        file: ./Dockerfile
         push: true
         tags: ${{ inputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: |
       List of Docker images to be pushed.
     required: true
+  build_path:
+    description: |
+      Path to Dockerfile, which is used to build the image.
+    default: "."
 
 runs:
   using: composite
@@ -53,7 +57,7 @@ runs:
     - name: Build and push Docker image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
-        context: .
-        push: true
+        context: ${{ inputs.build_path }}
+        push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.resolve-tags.outputs.images }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -39,25 +39,12 @@ runs:
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
         images: ${{ inputs.repository }}
-
-    - name: Resolve tags
-      id: resolve-tags
-      shell: bash
-      run: |
-        tags=(${{ inputs.tags }})
-
-        for tag in ${tags[@]}; do
-          image_uri="${{ inputs.repository }}:$tag"
-          image_uris+=("$image_uri")
-        done
-
-        IFS=, image_uris_string="${image_uris[*]}"
-        echo "images=${image_uris_string}" >> ${GITHUB_OUTPUT}
+        tags: ${{ inputs.tags }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
         context: ${{ inputs.build_path }}
         push: ${{ github.event_name == 'push' }}
-        tags: ${{ steps.resolve-tags.outputs.images }}
+        tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-dockerhub/action.yaml
+++ b/actions/push-to-dockerhub/action.yaml
@@ -1,0 +1,46 @@
+name: Publish Docker image
+description: Publish docker images to DockerHub
+
+inputs:
+  repository:
+    description: |
+      The caller workflow's repository
+  tags:
+    description: |
+      List of Docker images to be pushed.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check out the repo
+      uses: actions/checkout@v4
+
+    - name: Get secrets for DockerHub login
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      with:
+        common_secrets: |
+          DOCKERHUB_USERNAME=dockerhub:username
+          DOCKERHUB_PASSWORD=dockerhub:password
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      with:
+        images: ${{ inputs.repository }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: ${{ input.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -27,5 +27,5 @@ jobs:
           tags: |-
             "<IMAGE_NAME>:<IMAGE_TAG>"
             "<IMAGE_NAME>:latest"
-          build_path: "<YOUR_BUILD_PATH>" # e.g. "." - where the Dockerfile is
+          context: "<YOUR_BUILD_PATH>" # e.g. "." - where the Dockerfile is
 ```


### PR DESCRIPTION
Part of: https://github.com/grafana/deployment_tools/issues/108822

Along with OIDC way of pushing to GAR through GitHub actions, we need a workflow to push Docker images to DockerHub.
We need to make sure that DockerHub will only contain the end-product images (i.e. `grafana/grafana`, `grafana/mimir` etc.) and all the other images which are used for tooling should be pushed to GAR.

The DockerHub credentials are being fetched from vault.