### PR TITLE
`push-to-gar-docker` action: Add `build-args` when building the image

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -21,7 +21,7 @@ inputs:
     description: |
       Name of the image to be pushed to GAR.
     required: true
-  build_args:
+  build-args:
     description: |
       List of arguments necessary for the Docker image to be built.
     required: false
@@ -73,7 +73,7 @@ runs:
       uses: docker/build-push-action@v5.0.0
       with:
         context: ${{ inputs.context }}
-        build-args: ${{ inputs.build_args }}
+        build-args: ${{ inputs.build-args }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -24,7 +24,7 @@ inputs:
   build-args:
     description: |
       List of arguments necessary for the Docker image to be built.
-    required: false
+    default: ""
 
 runs:
   using: composite

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -21,6 +21,10 @@ inputs:
     description: |
       Name of the image to be pushed to GAR.
     required: true
+  build_args:
+    description: |
+      List of arguments necessary for the Docker image to be built.
+    required: false
 
 runs:
   using: composite
@@ -69,6 +73,7 @@ runs:
       uses: docker/build-push-action@v5.0.0
       with:
         context: ${{ inputs.context }}
+        build-args: ${{ inputs.build_args }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
         cache-from: type=gha


### PR DESCRIPTION
Adds `build-args` as an input argument, in case they are needed to build the image.