### PR TITLE
`push-to-gar-docker`: Remove ROOT_REPO, add github.repository from context

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -12,7 +12,6 @@ on:
     
 env:
   ENVIRONMENT: "dev" # can be either dev/prod
-  ROOT_REPO: ${{ github.event.repository.name }} # must be explicitly set like this - composite actions cannot get callers' payload, required
   IMAGE_NAME: "backstage" # name of the image to be published, required
 
 # These permissions are needed to assume roles from Github's OIDC.

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -46,7 +46,7 @@ runs:
       id: get-repository-name
       shell: bash
       run: |
-        REPO_NAME=$(echo ${{ github.repository }} | awk -F'/' '{print $2}')"
+        REPO_NAME=$(echo ${{ github.repository }} | awk -F'/' '{print $2}')
         echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -42,17 +42,22 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
+    - name: Get repository name
+      id: get-repository-name
+      shell: bash
+      run: |
+        echo "::set-output name=repo_name::$(echo ${{ github.repository }} | awk -F'/' '{print $2}')"
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
-        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${{ github.repository }}-${{ inputs.environment }}/${{ inputs.image_name }}"
+        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
     - name: Construct service account
       id: construct-service-account
       shell: sh
       run: |
-        SERVICE_ACCOUNT="github-${{ github.repository }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        SERVICE_ACCOUNT="github-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@v1
       id: gcloud-auth

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -46,7 +46,8 @@ runs:
       id: get-repository-name
       shell: bash
       run: |
-        echo "::set-output name=repo_name::$(echo ${{ github.repository }} | awk -F'/' '{print $2}')"
+        REPO_NAME=$(echo ${{ github.repository }} | awk -F'/' '{print $2}')"
+        echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -46,13 +46,13 @@ runs:
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
-        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${{ env.ROOT_REPO }}-${{ inputs.environment }}/${{ inputs.image_name }}"
+        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${{ github.repository }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
     - name: Construct service account
       id: construct-service-account
       shell: sh
       run: |
-        SERVICE_ACCOUNT="github-${ROOT_REPO}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        SERVICE_ACCOUNT="github-${{ github.repository }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@v1
       id: gcloud-auth


### PR DESCRIPTION
The name of the caller repo can be fetched from the `github` context. This PR replaces the `ROOT_REPO` env var, with `${{ github.repository }}`. Part of: https://github.com/grafana/shared-workflows/issues/30