### PR TITLE
feat: Rename push-to-dockerhub-action

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -1,6 +1,6 @@
-# push-to-dockerhub
+# build-push-to-dockerhub
 
-This is a composite GitHub Action, used to push docker images to DockerHub.
+This is a composite GitHub Action, used to build Docker images and push them to DockerHub.
 It uses `get-vault-secrets` action to get the DockerHub username and password from Vault.
 
 Example of how to use this action in a repository:
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - id: push-to-dockerhub
-        uses: grafana/shared-workflows/actions/push-to-dockerhub@main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main
         with:
           repository: ${{ github.repository }} # or any other dockerhub repository
           context: .

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: |
       Path to Dockerfile, which is used to build the image.
     default: "."
+  push:
+    description: |
+      Push the generated images also to DockerHub
+    default: "false"
 
 runs:
   using: composite
@@ -45,6 +49,6 @@ runs:
       uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
       with:
         context: ${{ inputs.context }}
-        push: ${{ github.event_name == 'push' }}
+        push: ${{ inputs.push }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This follows the naming of the underlying Docker action and adds a "push" input so that users can control whether the image should be pushed or not.