### PR TITLE
`push-to-gar-docker`: Add `docker-` prefix to image name

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -52,7 +52,7 @@ runs:
       id: meta
       uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
       with:
-        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
+        images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/docker-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
     - name: Construct service account
       id: construct-service-account


### PR DESCRIPTION
Since we are moving towards a pattern where each GAR repository should have its own prefix based on the format of the repository (docker, npm, rpm, deb), we need to make this change to make sure that the artifacts end up in the right registry.