### PR TITLE
Add `dockerhub-login` composite action

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -24,19 +24,12 @@ runs:
     - name: Check out the repo
       uses: actions/checkout@v4
 
-    - name: Get secrets for DockerHub login
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+    - name: Login to DockerHub
+      uses: grafana/shared-workflows/actions/dockerhub-login@main
       with:
         common_secrets: |
           DOCKERHUB_USERNAME=dockerhub:username
           DOCKERHUB_PASSWORD=dockerhub:password
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
-      with:
-        username: ${{ env.DOCKERHUB_USERNAME }}
-        password: ${{ env.DOCKERHUB_PASSWORD }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/actions/dockerhub-login/README.md
+++ b/actions/dockerhub-login/README.md
@@ -1,0 +1,26 @@
+# dockerhub-login
+
+This is a composite GitHub Action, used to login to the grafanabot DockerHub account
+It uses `get-vault-secrets` action to get the DockerHub username and password from Vault.
+
+Example of how to use this action in a repository:
+
+```yaml
+name: Push to DockerHub
+on:
+  pull_request:
+    
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@main
+      - name: Build and push
+        run: make build && make push
+```

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -1,0 +1,19 @@
+name: Login to DockerHub
+description: Using the shared Grafana Labs DockerHub credentials, log in to DockerHub
+
+runs:
+  using: composite
+  steps:
+    - name: Get secrets for DockerHub login
+      id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      with:
+        common_secrets: |
+          DOCKERHUB_USERNAME=dockerhub:username
+          DOCKERHUB_PASSWORD=dockerhub:password
+
+    - name: Log in to Docker Hub
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_PASSWORD }}


### PR DESCRIPTION
To be used for workflows that don't use the same process as the `build-push-to-dockerhub` action