### PR TITLE
all: Always reference actions by commit SHA

### DIFF
--- a/.github/workflows/build-trigger-argo-workflow.yaml
+++ b/.github/workflows/build-trigger-argo-workflow.yaml
@@ -19,9 +19,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
-      - uses: actions/setup-go@v5.0.0
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491  # v5.0.0
         with:
           check-latest: true
           cache-dependency-path: |
@@ -29,7 +29,7 @@ jobs:
           go-version-file: "actions/trigger-argo-workflow/go.mod"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.7.0
+        uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           version: latest
           working-directory: actions/trigger-argo-workflow

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -13,10 +13,10 @@ on:
         required: true
         type: string
       default-working-directory:
-        description: 'The working directory to use for doc generation. Useful for cases without an mkdocs.yml file at the project root.'
+        description: "The working directory to use for doc generation. Useful for cases without an mkdocs.yml file at the project root."
         required: false
         type: string
-        default: '.'
+        default: "."
 
 jobs:
   generate-and-publish-docs:
@@ -27,11 +27,11 @@ jobs:
     steps:
       - id: checkout
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - id: auth
         name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@v2.1.0
+        uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
         with:
           create_credentials_file: true
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROVIDER }}
@@ -41,7 +41,7 @@ jobs:
         run: sudo npm install -g @techdocs/cli
 
       - name: setup python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
           python-version: 3.11
 

--- a/.github/workflows/test-get-vault-secrets.yaml
+++ b/.github/workflows/test-get-vault-secrets.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Test Vault Action
         id: test-vault-action
@@ -58,10 +58,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup BATS testing framework
-        uses: mig4/setup-bats@v1.2.0
+        uses: mig4/setup-bats@af9a00deb21b5d795cabfeaa8d9060410377686d # v1.2.0
 
       - name: Run tests
         run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # shared-workflows
-A public-facing, centralized place to store reusable GitHub workflows used by Grafana Labs.
+
+A public-facing, centralized place to store reusable GitHub workflows and action
+used by Grafana Labs. See the `actions/` directory for the individual actions
+themselves.
+
+## Notes
+
+### Pin versions
+
+When referencing third-party actions, [always pin the version to a specific
+commit hash][hardening]. This ensures that the workflow will always use the same
+version of the action, even if the action's maintainers release a new version or
+if the tag itself is updated.
+
+Dependabot can update these SHA references when there are new versions. If you
+include a tag in a commend after the SHA, it can update the comment too. For
+example:
+
+```yaml
+- uses: action/foo@abcdef0123456789abcdef0123456789 # v1.2.3
+```
+
+[hardening]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: composite
   steps:
     - name: Check out the repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Login to DockerHub
       uses: grafana/shared-workflows/actions/dockerhub-login@main
@@ -34,21 +34,21 @@ runs:
     # If platforms is specified then also initialize buildx and qemu:
     - name: Set up QEMU
       if: inputs.platforms
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
     - name: Set up Docker Buildx
       if: inputs.platforms
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5.5.1
       with:
         images: ${{ inputs.repository }}
         tags: ${{ inputs.tags }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v5.1.0
       with:
         context: ${{ inputs.context }}
         platforms: ${{ inputs.platforms }}

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -13,7 +13,7 @@ runs:
           DOCKERHUB_PASSWORD=dockerhub:password
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v3.0.0
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ env.DOCKERHUB_PASSWORD }}

--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -37,8 +37,7 @@ runs:
         echo "Invalid value for vault_instance input: ${{ inputs.vault_instance }}. Must be 'dev' or 'ops'."
         exit 1
     - id: vault-iap-auth
-      # v2.1.0
-      uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363
+      uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
       with:
         # Note that these aren't secrets, login is secured through Github's OIDC integrations with GCP and Vault.
         # Get with:
@@ -66,8 +65,7 @@ runs:
       # Get the secrets
     - name: Import Secrets
       id: import-secrets
-      # v2.7.5
-      uses: hashicorp/vault-action@e3d5714d59e151ca80233142880b9da9d983a48c
+      uses: hashicorp/vault-action@e3d5714d59e151ca80233142880b9da9d983a48c # v2.8.0
       with:
         url: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net/"
         role: vault-github-actions

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -50,7 +50,7 @@ runs:
         echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5.5.1
       with:
         images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/docker-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
@@ -60,7 +60,7 @@ runs:
       run: |
         SERVICE_ACCOUNT="github-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
-    - uses: google-github-actions/auth@v1
+    - uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
       id: gcloud-auth
       with:
         token_format: access_token
@@ -68,15 +68,15 @@ runs:
         service_account: ${{ steps.construct-service-account.outputs.service_account }}
         create_credentials_file: false
     - name: Login to GAR
-      uses: docker/login-action@v3
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v3.0.0
       with:
         registry: ${{ inputs.registry }}
         username: oauth2accesstoken
         password: ${{ steps.gcloud-auth.outputs.access_token }}
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3.0.0
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
     - name: Build the container
-      uses: docker/build-push-action@v5.0.0
+      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v5.1.0
       with:
         context: ${{ inputs.context }}
         build-args: ${{ inputs.build-args }}

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -54,15 +54,14 @@ runs:
         # https://docs.github.com/en/actions/learn-github-actions/contexts
         action_repo: ${{ github.action_repository }}
         action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@v4.1.1
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
 
     - name: Restore cache
       id: restore
-      # v4.0.0
-      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ github.workspace }}/bin
         key: argo-linux-amd64-${{ steps.argo-version.outputs.version }}
@@ -70,7 +69,7 @@ runs:
     - name: Fetch Github Release Asset
       id: fetch_asset
       if: steps.restore.outputs.cache-hit != 'true'
-      uses: dsaltares/fetch-gh-release-asset@1.1.1
+      uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # 1.1.1
       with:
         repo: "argoproj/argo-workflows"
         version: "tags/v${{ steps.argo-version.outputs.version }}"
@@ -88,8 +87,7 @@ runs:
     - name: Save to cache
       id: save
       if: steps.gunzip.outcome == 'success'
-      # v4.0.0
-      uses: actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2
+      uses: actions/cache/save@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: ${{ github.workspace }}/bin
         key: ${{ steps.restore.outputs.cache-primary-key }}
@@ -100,8 +98,7 @@ runs:
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
     - name: Setup go
-      # v5.0.0
-      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         check-latest: true
         cache-dependency-path: |


### PR DESCRIPTION
This is following [security recommendations][hardening] from GitHub. For readability, We add a comment showing which tag the SHA refers to, as [Dependabot supports updating this when it makes PRs][update-comment].

[hardening]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions
[update-comment]: https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/