### PR TITLE
fix: Make file argument optional in docker build actions

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -24,7 +24,7 @@ inputs:
   file:
     description: |
       The dockerfile to use.
-    default: "Dockerfile"
+    required: false
 
 runs:
   using: composite

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -28,7 +28,7 @@ inputs:
   file:
     description: |
       The dockerfile to use.
-    default: "Dockerfile"
+    required: false
 
 runs:
   using: composite


### PR DESCRIPTION
This should fix the backward-compat issue reported in https://github.com/grafana/shared-workflows/pull/47