### PR TITLE
chore: Bump upstream docker actions

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -46,13 +46,13 @@ runs:
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5.5.1
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
         images: ${{ inputs.repository }}
         tags: ${{ inputs.tags }}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       with:
         context: ${{ inputs.context }}
         platforms: ${{ inputs.platforms }}

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -13,7 +13,7 @@ runs:
           DOCKERHUB_PASSWORD=dockerhub:password
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v3.0.0
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         username: ${{ env.DOCKERHUB_USERNAME }}
         password: ${{ env.DOCKERHUB_PASSWORD }}

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -54,7 +54,7 @@ runs:
         echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
-      uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # v5.5.1
+      uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
         images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/docker-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
@@ -72,7 +72,7 @@ runs:
         service_account: ${{ steps.construct-service-account.outputs.service_account }}
         create_credentials_file: false
     - name: Login to GAR
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # v3.0.0
+      uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
       with:
         registry: ${{ inputs.registry }}
         username: oauth2accesstoken
@@ -80,7 +80,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
     - name: Build the container
-      uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671 # v5.1.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       with:
         context: ${{ inputs.context }}
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
This should resolve NodeJS 16 deprecation warnings like this:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7, docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a, docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

The version comments should now propery represent the commits.