### PR TITLE
Add clean option to build-push-to-dockerhub

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -9,7 +9,7 @@ Example of how to use this action in a repository:
 name: Push to DockerHub
 on:
   pull_request:
-    
+
 permissions:
   contents: read
   id-token: write
@@ -33,10 +33,12 @@ jobs:
 
 | Name | Type | Description |
 |------|------|-------------|
+| `clean_repo` | Bool | Whether to execute `git clean -ffdx && git reset --hard HEAD` before fetching (default: `false`) |
 | `context` | String | Path to the Dockerfile (default: `.`) |
+| `file` | String | The dockerfile to use. (default: `${context}/Dockerfile`) |
 | `platforms` | List | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`) |
 | `push` | Bool | Push the generated image (default: `false`) |
-| `repository`| String | Docker repository name |
+| `repository` | String | Docker repository name |
 | `tags` | List | Tags that should be used for the image (see the [metadata-action][mda] for details) |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -25,12 +25,18 @@ inputs:
     description: |
       The dockerfile to use.
     required: false
+  clean_repo:
+    description: |
+      Whether to run `git clean -ffdx && git reset --hard HEAD`.
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Check out the repo
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        clean: ${{ inputs.clean_repo }}
 
     - name: Login to DockerHub
       uses: grafana/shared-workflows/actions/dockerhub-login@main


### PR DESCRIPTION
Adding `clean_repo` input to `actions/build-push-to-dockerhub/action.yaml` in order to allow upstream workflows the option to preserve changes to a checked out repository.