### PR TITLE
`push-to-gar-docker`: Replace `github.repository` with `github.repository_id`

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -62,7 +62,7 @@ runs:
       id: construct-service-account
       shell: sh
       run: |
-        SERVICE_ACCOUNT="github-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        SERVICE_ACCOUNT="github-${{ github.repository_id }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@5a50e581162a13f4baa8916d01180d2acbc04363 # v2.1.0
       id: gcloud-auth


### PR DESCRIPTION
Replaces repository name with repository ID to fix issue created by: https://github.com/hashicorp/terraform-provider-google/issues/7443