### PR TITLE
docs: update pr linter docs

### DIFF
--- a/actions/lint-pr-title/README.md
+++ b/actions/lint-pr-title/README.md
@@ -36,7 +36,7 @@ So, it's recommended to start the path definition with `${{ github.workspace }}/
 but this `config-path` parameter is optional. If you don't want to define it, the action will use the following rules by default:
 
 ```
-{
+module.exports = {
   'body-leading-blank': [1, 'always'],
   'body-max-line-length': [2, 'always', 100],
   'footer-leading-blank': [1, 'always'],


### PR DESCRIPTION
The config file in the docs is missing the module.exports and makes the action to fail.
I am updating the docs to have the default example that works with the action.