### PR TITLE
Build-push-to-dockerhub: Remove checkout step

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -9,7 +9,7 @@ Example of how to use this action in a repository:
 name: Push to DockerHub
 on:
   pull_request:
-    
+
 permissions:
   contents: read
   id-token: write
@@ -31,13 +31,14 @@ jobs:
 
 ## Inputs
 
-| Name | Type | Description |
-|------|------|-------------|
-| `context` | String | Path to the Dockerfile (default: `.`) |
-| `platforms` | List | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`) |
-| `push` | Bool | Push the generated image (default: `false`) |
-| `repository`| String | Docker repository name |
-| `tags` | List | Tags that should be used for the image (see the [metadata-action][mda] for details) |
+| Name         | Type   | Description                                                                          |
+|--------------|--------|--------------------------------------------------------------------------------------|
+| `context`    | String | Path to the Dockerfile (default: `.`)                                                |
+| `platforms`  | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
+| `push`       | Bool   | Push the generated image (default: `false`)                                          |
+| `repository` | String | Docker repository name                                                               |
+| `tags`       | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)  |
+| `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 
@@ -45,3 +46,5 @@ jobs:
 ## Notes
 
 - If you specify `platforms` then the action will use buildx to build the image.
+- You must create a Dockerhub repo before you are able to push to it.
+- Most projects should be using Google Artifact Registry (instead of Dockerhub) to store their images. You can see more about that in the push-to-gar-docker shared workflow.

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -29,9 +29,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check out the repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
     - name: Login to DockerHub
       uses: grafana/shared-workflows/actions/dockerhub-login@main
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -2,14 +2,14 @@
 
 This is a composite GitHub Action, used to push docker images to Google Artifact Registry (GAR).
 It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
-which means that only workflows which get triggered based on certain rules can 
+which means that only workflows which get triggered based on certain rules can
 trigger these composite workflows.
 
 ```yaml
 name: CI
-on: 
+on:
   pull_request:
-    
+
 env:
   ENVIRONMENT: "dev" # can be either dev/prod
   IMAGE_NAME: "backstage" # name of the image to be published, required
@@ -33,3 +33,15 @@ jobs:
             "latest"
           context: "<YOUR_CONTEXT>" # e.g. "." - where the Dockerfile is
 ```
+
+## Inputs
+
+| Name          | Type   | Description                                                                          |
+|---------------|--------|--------------------------------------------------------------------------------------|
+| `registry`    | String | Google Artifact Registry to store docker images in.                                  |
+| `tags`        | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)  |
+| `context`     | List   | Path to the Docker build context.                                                    |
+| `environment` | Bool   | Environment for pushing artifacts (can be either dev or prod).                       |
+| `image_name`  | String | Name of the image to be pushed to GAR.                                               |
+| `build-args`  | String | List of arguments necessary for the Docker image to be built.                        |
+| `file`        | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |


### PR DESCRIPTION
Removed checkout step from `actions/build-push-to-dockerhub` to match convention with `push-to-gar-docker`, and to reduce complexity. Also updated docs for both actions to include inputs and (light) instruction for using dockerhub repos.