### PR TITLE
feat(build-push-to-gar): Expose platforms parameter

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -45,3 +45,4 @@ jobs:
 | `image_name`  | String | Name of the image to be pushed to GAR.                                               |
 | `build-args`  | String | List of arguments necessary for the Docker image to be built.                        |
 | `file`        | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
+| `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -89,3 +89,4 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         file: ${{ inputs.file }}
+        platforms: ${{ inputs.platforms }}

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -29,6 +29,10 @@ inputs:
     description: |
       The dockerfile to use.
     required: false
+  platforms:
+    description: |
+      List of platforms to build the image for
+    required: false
 
 runs:
   using: composite


### PR DESCRIPTION
This PR is inspired by: 
- https://github.com/grafana/shared-workflows/tree/main/actions/build-push-to-dockerhub

It exposes the `platforms` parameter and will allow to make builds for multiple platforms/architectures.