### PR TITLE
`push-to-gar-docker`: Add caching options

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -46,3 +46,5 @@ jobs:
 | `build-args`  | String | List of arguments necessary for the Docker image to be built.                        |
 | `file`        | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
 | `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
+| `cache-from`   | String   | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
+| `cache-to`   | String   | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))   |

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -33,6 +33,14 @@ inputs:
     description: |
       List of platforms to build the image for
     required: false
+  cache-from:
+    description: |
+      Where cache should be fetched from
+    required: false
+  cache-to:
+    description: |
+      Where cache should be stored to
+    required: false
 
 runs:
   using: composite
@@ -50,6 +58,14 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
+    - name: Resolve caches
+      id: resolve-caches
+      shell: bash
+      run: |
+        CACHE_FROM="${{ inputs.cache-from:-'type=gha' }}"
+        CACHE_TO="${{ inputs.cache-to:-'type=gha,mode=max' }}"
+        echo "cache-from=${CACHE_FROM}" >> ${GITHUB_OUTPUT}
+        echo "cache-to=${CACHE_TO}" >> ${GITHUB_OUTPUT}    
     - name: Get repository name
       id: get-repository-name
       shell: bash
@@ -90,7 +106,7 @@ runs:
         build-args: ${{ inputs.build-args }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: ${{ steps.resolve-caches.outputs.cache-from }}
+        cache-to: ${{ steps.resolve-caches.outputs.cache-to }}
         file: ${{ inputs.file }}
         platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
Adds caching options for container cache. Defaults to `type=gha` if no cache is provided.