### PR TITLE
push-to-gar-docker: Fix cache inputs

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -37,10 +37,12 @@ inputs:
     description: |
       Where cache should be fetched from
     required: false
+    default: "type=gha"
   cache-to:
     description: |
       Where cache should be stored to
     required: false
+    default: "type=gha,mode=max"
 
 runs:
   using: composite
@@ -58,14 +60,6 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" >> ${GITHUB_OUTPUT}
-    - name: Resolve caches
-      id: resolve-caches
-      shell: bash
-      run: |
-        CACHE_FROM="${{ inputs.cache-from:-'type=gha' }}"
-        CACHE_TO="${{ inputs.cache-to:-'type=gha,mode=max' }}"
-        echo "cache-from=${CACHE_FROM}" >> ${GITHUB_OUTPUT}
-        echo "cache-to=${CACHE_TO}" >> ${GITHUB_OUTPUT}    
     - name: Get repository name
       id: get-repository-name
       shell: bash
@@ -106,7 +100,7 @@ runs:
         build-args: ${{ inputs.build-args }}
         push: ${{ github.event_name == 'push' }}
         tags: ${{ steps.meta.outputs.tags }}
-        cache-from: ${{ steps.resolve-caches.outputs.cache-from }}
-        cache-to: ${{ steps.resolve-caches.outputs.cache-to }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}
         file: ${{ inputs.file }}
         platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
The way they were being validated was wrong. But we don't need a step to resolve them using a fallback value - we can achieve the same with `default` on the input instead.