### PR TITLE
push-to-gar-docker: add outputs for ease-of-use

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -46,3 +46,18 @@ jobs:
 | `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
 | `cache-from`   | String   | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
 | `cache-to`   | String   | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))   |
+
+## Outputs
+
+The following outputs are exposed from [`docker/metadata-action`](https://github.com/docker/metadata-action?tab=readme-ov-file#outputs) and [`docker/build-push-action`](https://github.com/docker/build-push-action?tab=readme-ov-file#outputs):
+
+| Name      | Type   | Description                    | From |
+|-----------|--------|--------------------------------|------|
+| `version` | String | Generated Docker image version | `docker/metadata-action` |
+| `tags`    | String | Generated Docker tags    | `docker/metadata-action` |
+| `labels`  | String | Generated Docker labels  | `docker/metadata-action` |
+| `annotations` | String | Generated annotations | `docker/metadata-action` |
+| `json`    | String | JSON output of tags and labels | `docker/metadata-action` |
+| `imageid` | String | Image ID | `docker/build-push-action` |
+| `digest`  | String | Image digest | `docker/build-push-action` |
+| `metadata`| String | Build result metadata | `docker/build-push-action` |

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -44,6 +44,32 @@ inputs:
     required: false
     default: "type=gha,mode=max"
 
+outputs:
+  version:
+    description: 'Generated Docker image version (from docker/metadata-action)'
+    value: ${{ steps.meta.outputs.version }}
+  tags:
+    description: 'Generated Docker tags (from docker/metadata-action)'
+    value: ${{ steps.meta.outputs.tags }}
+  labels:
+    description: 'Generated Docker labels (from docker/metadata-action)'
+    value: ${{ steps.meta.outputs.labels }}
+  annotations:
+    description: 'Generated annotations (from docker/metadata-action)'
+    value: ${{ steps.meta.outputs.annotations }}
+  json:
+    description: 'JSON output of tags and labels (from docker/metadata-action)'
+    value: ${{ steps.meta.outputs.json }}
+  imageid:
+    description: 'Image ID (from docker/build-push-action)'
+    value: ${{ steps.build.outputs.imageid }}
+  digest:
+    description: 'Image digest (from docker/build-push-action)'
+    value: ${{ steps.build.outputs.digest }}
+  metadata:
+    description: 'Build result metadata (from docker/build-push-action)'
+    value: ${{ steps.build.outputs.metadata }}
+
 runs:
   using: composite
   steps:
@@ -95,6 +121,7 @@ runs:
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
     - name: Build the container
       uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
+      id: build
       with:
         context: ${{ inputs.context }}
         build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Exposing the 3 outputs from [`docker/build-push-action`](https://github.com/docker/build-push-action?tab=readme-ov-file#outputs), as well as a few from [`docker/metadata-action`](https://github.com/docker/metadata-action?tab=readme-ov-file#outputs), for simpler downstream use.