### PR TITLE
`push-to-gar-docker`: Add `ssh` input

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -46,7 +46,7 @@ jobs:
 | `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
 | `cache-from`   | String   | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
 | `cache-to`   | String   | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))   |
-| `ssh`   | List   | List of SSH agent socket or keys to expose to the build     |
+| `ssh`   | List   | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs))    |
 
 ## Outputs
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -46,6 +46,7 @@ jobs:
 | `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
 | `cache-from`   | String   | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
 | `cache-to`   | String   | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))   |
+| `ssh`   | List   | List of SSH agent socket or keys to expose to the build     |
 
 ## Outputs
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -43,6 +43,9 @@ inputs:
       Where cache should be stored to
     required: false
     default: "type=gha,mode=max"
+  ssh:
+    desctiption: |
+      List of SSH agent socket or keys to expose to the build
 
 outputs:
   version:
@@ -131,3 +134,4 @@ runs:
         cache-to: ${{ inputs.cache-to }}
         file: ${{ inputs.file }}
         platforms: ${{ inputs.platforms }}
+        ssh: ${{ inputs.ssh }}


### PR DESCRIPTION
Adds `ssh` input as per: https://github.com/docker/build-push-action?tab=readme-ov-file#inputs