### PR TITLE
`push-to-gar-docker`: Remove default cache values

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -37,12 +37,10 @@ inputs:
     description: |
       Where cache should be fetched from
     required: false
-    default: "type=gha"
   cache-to:
     description: |
       Where cache should be stored to
     required: false
-    default: "type=gha,mode=max"
   ssh:
     desctiption: |
       List of SSH agent socket or keys to expose to the build


### PR DESCRIPTION
Removes the default values for `cache-to` and `cache-from`