### PR TITLE
all: Fix according to editorconfig / markdownlint style

### DIFF
--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -6,7 +6,7 @@ on:
     types: [closed]
 
 jobs:
-  build-lin-pr-title:
+  build-lint-pr-title:
     if: ${{ github.event.pull_request.merged == true && contains(github.head_ref || github.ref_name, 'dependabot-npm') }}
     runs-on: ubuntu-latest
     steps:
@@ -28,11 +28,11 @@ jobs:
       - name: Commit lint-pr-title changes and create new pull request
         uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
-          commit-message: 'Update code on lint-pr-title action'
-          branch: 'update-lint-pr-code'
+          commit-message: "Update code on lint-pr-title action"
+          branch: "update-lint-pr-code"
           delete-branch: true
           branch-suffix: timestamp
-          title: 'Update code on lint-pr-title action'
-          body: 'This PR contains the code built after dependabot updated dependencies on lint-pr-title action'
+          title: "Update code on lint-pr-title action"
+          body: "This PR contains the code built after dependabot updated dependencies on lint-pr-title action"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-trigger-argo-workflow.yaml
+++ b/.github/workflows/build-trigger-argo-workflow.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
-      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491  # v5.0.0
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           check-latest: true
           cache-dependency-path: |

--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -1,0 +1,16 @@
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3.0
+        with:
+          dry: true
+          prettier_options: "--check ."

--- a/.github/workflows/publish-techdocs.md
+++ b/.github/workflows/publish-techdocs.md
@@ -13,12 +13,12 @@ on:
     branches:
       - main
     paths:
-      - 'docs/**'
-      - 'mkdocs.yml'
-      - 'catalog-info.yaml'
-      - '.github/workflows/publish-docs.yml'
+      - "docs/**"
+      - "mkdocs.yml"
+      - "catalog-info.yaml"
+      - ".github/workflows/publish-docs.yml"
 concurrency:
-  group: '${{ github.workflow }}-${{ github.ref }}'
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 jobs:
   publish-docs:
@@ -32,10 +32,10 @@ jobs:
 
 ## Inputs
 
-| Name | Type | Description |
-|-|-|-|
-| `namespace` | string | The entity's namespace within EngHub (usually `default`) |
-| `kind` | string | The kind of the entity in EngHub (usually `component`) |
-| `name` | string | The name of the entity in EngHub (usually matches the name of the repository) |
-| `default-working-directory` | string | The directory where the techdocs-cli should be run (default: `.`) |
-| `checkout-repo` | boolean | Should this workflow also check out the current repository? (default: `true`) |
+| Name                        | Type    | Description                                                                   |
+| --------------------------- | ------- | ----------------------------------------------------------------------------- |
+| `namespace`                 | string  | The entity's namespace within EngHub (usually `default`)                      |
+| `kind`                      | string  | The kind of the entity in EngHub (usually `component`)                        |
+| `name`                      | string  | The name of the entity in EngHub (usually matches the name of the repository) |
+| `default-working-directory` | string  | The directory where the techdocs-cli should be run (default: `.`)             |
+| `checkout-repo`             | boolean | Should this workflow also check out the current repository? (default: `true`) |

--- a/.github/workflows/test-login-to-gar.yaml
+++ b/.github/workflows/test-login-to-gar.yaml
@@ -6,12 +6,12 @@ on:
       - main
     paths:
       - "actions/login-to-gar/**"
-      - ".github/workflows/test-login-to-gar.yml"
+      - ".github/workflows/test-login-to-gar.yaml"
 
   pull_request:
     paths:
       - "actions/login-to-gar/**"
-      - ".github/workflows/test-login-to-gar.yml"
+      - ".github/workflows/test-login-to-gar.yaml"
 
 permissions:
   contents: read

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+actions/lint-pr-title/dist/**

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,1 @@
+trailingComma: all

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ themselves.
 
 ## Notes
 
+### Configure your IDE to run Prettier
+
+[Prettier] will run in CI to ensure that files are formatted correctly. To ensure
+that your code is formatted correctly before you commit, set up your IDE to run
+Prettier on save.
+
+Or from the commandline, you can run Prettier using [`npx`][npx]:
+
+```sh
+npx prettier --check .
+```
+
+Or, of course, install it in any other way you want.
+
+[npx]: https://www.npmjs.com/package/npx
+[prettier]: https://prettier.io/
+
 ### Pin versions
 
 When referencing third-party actions, [always pin the version to a specific

--- a/actions/aws-auth/README.md
+++ b/actions/aws-auth/README.md
@@ -24,7 +24,7 @@ jobs:
           role-arn: "arn:aws:iam::366620023056:role/github-actions/s3-test-access"
           pass-claims: "repository_owner, repository_name, job_workflow_ref"
           set-creds-in-environment: true
-      
+
       - id: cat-file-from-s3-bucket
         run: |
           aws s3 cp 's3://grafanalabs-github-actions-test-repo/test.txt' 'test.txt'
@@ -33,13 +33,17 @@ jobs:
 
 ## Inputs
 
-| Name                       | Type   | Description                                                                                                                                                                           |
-|----------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `aws-region`               | String | Specify AWS region to use that contain your resources (default: `us-east-2`)                                                                                                          |
-| `role-arn`                 | String | Specify custom workload role. Role ARN must be prefixed with `github-actions` e.g. `arn:aws:iam::366620023056:role/github-actions/s3-test-access` [^1]                                |
+<!-- markdownlint-disable no-space-in-code -->
+
+| Name                       | Type   | Description                                                                                                                                                                                                                                                                                                                                                    |
+| -------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `aws-region`               | String | Specify AWS region to use that contain your resources (default: `us-east-2`)                                                                                                                                                                                                                                                                                   |
+| `role-arn`                 | String | Specify custom workload role. Role ARN must be prefixed with `github-actions` e.g. `arn:aws:iam::366620023056:role/github-actions/s3-test-access` [^1]                                                                                                                                                                                                         |
 | `pass-claims`              | String | `, `-separated list of [GitHub Actions claims](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#understanding-the-oidc-token) (session tags) to make available to `role-arn`. Currently supported claims (default): `"repository_owner, repository_name, job_workflow_ref"` [^2] |
-| `set-creds-in-environment` | Bool   | Set environment variables for AWS CLI and SDKs (default: `true`)                                                                                                                      |
-| `role-duration-seconds`    | String | Role duration in seconds (default: `"3600"`)                                                                                                                                          |
+| `set-creds-in-environment` | Bool   | Set environment variables for AWS CLI and SDKs (default: `true`)                                                                                                                                                                                                                                                                                               |
+| `role-duration-seconds`    | String | Role duration in seconds (default: `"3600"`)                                                                                                                                                                                                                                                                                                                   |
+
+<!-- markdownlint-restore -->
 
 [^1]: See [Setting up Workload Role](#setting-up-workload-role) for an example
 [^2]: GitHub OIDC token claims must be mapped to the Cognito Identity Pool before they can be used. If you would like to use a claim that is not listed, file an issue in this repo or reach out to `@platform-productivity` in `#platform`.
@@ -65,26 +69,24 @@ As this defines which GitHub Actions runs are allowed to use the role's permissi
 In this case, permissions are only granted when the `job_workflow_ref` tag matches the workflow that initiated the action.
 
 Example trust policy:
+
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::590183704419:role/github-actions-oidc-jump-role"
-            },
-            "Action": [
-                "sts:AssumeRole",
-                "sts:TagSession"
-            ],
-            "Condition": {
-                "StringEquals": {
-                    "aws:PrincipalTag/job_workflow_ref": "grafana/<REPO>/.github/workflows/<WORKFLOW_FILE>@refs/heads/main"
-                }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::590183704419:role/github-actions-oidc-jump-role"
+      },
+      "Action": ["sts:AssumeRole", "sts:TagSession"],
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalTag/job_workflow_ref": "grafana/<REPO>/.github/workflows/<WORKFLOW_FILE>@refs/heads/main"
         }
-    ]
+      }
+    }
+  ]
 }
 ```
 
@@ -93,17 +95,16 @@ Example trust policy:
 This is where you define the minimum permissions necessary to do a specific operation.
 
 Example permissions policy:
+
 ```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": "arn:aws:s3:::grafanalabs-github-actions-${aws:PrincipalTag/repository_name}/*"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject"],
+      "Resource": "arn:aws:s3:::grafanalabs-github-actions-${aws:PrincipalTag/repository_name}/*"
+    }
+  ]
 }
 ```

--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -15,7 +15,7 @@ inputs:
     required: true
     description: "`, `-separated claims from GitHub ID token to make available to `role-arn`"
   set-creds-in-environment:
-    default: true
+    default: "true"
     required: false
     description: "Set environment variables for AWS CLI and SDKs"
   role-duration-seconds:
@@ -56,7 +56,7 @@ runs:
         chain-role-duration-seconds: "${{ inputs.role-duration-seconds }}"
         chain-pass-claims: "${{ inputs.pass-claims }}"
         chain-set-in-environment: "${{ inputs.set-creds-in-environment }}"
-    
+
     - id: aws_region # Pulled from catnekaise/cognito-idpool-auth/action.yml
       shell: bash
       env:
@@ -73,7 +73,7 @@ runs:
           echo "Unable to resolve what AWS Region to use"
           exit 1
         fi
-        
+
         # Some-effort validation of aws region
         if echo "$value" | grep -Eqv "^[a-z]{2}-[a-z]{4,9}-[0-9]$"; then
           echo "Resolved value for AWS Region is invalid"

--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -32,7 +32,7 @@ jobs:
 ## Inputs
 
 | Name         | Type   | Description                                                                          |
-|--------------|--------|--------------------------------------------------------------------------------------|
+| ------------ | ------ | ------------------------------------------------------------------------------------ |
 | `context`    | String | Path to the Dockerfile (default: `.`)                                                |
 | `platforms`  | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
 | `push`       | Bool   | Push the generated image (default: `false`)                                          |
@@ -41,7 +41,6 @@ jobs:
 | `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
-
 
 ## Notes
 

--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -7,7 +7,7 @@ Example workflow:
 
 ```yaml
 name: CI
-on: 
+on:
   pull_request:
 
 # These permissions are needed to assume roles from Github's OIDC.
@@ -30,11 +30,10 @@ jobs:
           repo_secrets: |
             ENVVAR2=test-secret:key1
 
-    # Use the secrets
-    # You can use the envvars directly in scripts or use the `${{ env.* }}` accessor in the workflow
+      # Use the secrets
+      # You can use the envvars directly in scripts or use the `${{ env.* }}` accessor in the workflow
       - name: echo
         run: |
           echo "$ENVVAR1"
           echo "${{ env.ENVVAR2 }}"
-
 ```

--- a/actions/lint-pr-title/README.md
+++ b/actions/lint-pr-title/README.md
@@ -8,7 +8,7 @@ This is helpful when using the "Squash and merge" strategy, Github will suggest 
 
 If you make any change on the `index.js` file, you should build the code before to commit the changes using the command:
 
-```
+```console
 yarn build
 ```
 
@@ -25,39 +25,55 @@ This action can receive the `commitlint.config.js` file using the input paramete
 This parameter should contain the absolute path of the file.
 So, it's recommended to start the path definition with `${{ github.workspace }}/`. See example below:
 
+```yml
+---
+uses: grafana/shared-workflows/actions/lint-pr-title@main
+with:
+  config-path: "${{ github.workspace }}/dir1/dir2/commitlint.config.js"
 ```
-...
-    uses: grafana/shared-workflows/actions/lint-pr-title@main
-    with:
-      config-path: '${{ github.workspace }}/dir1/dir2/commitlint.config.js'
-...
 
-```
 but this `config-path` parameter is optional. If you don't want to define it, the action will use the following rules by default:
 
-```
+```javascript
 module.exports = {
-  'body-leading-blank': [1, 'always'],
-  'body-max-line-length': [2, 'always', 100],
-  'footer-leading-blank': [1, 'always'],
-  'footer-max-line-length': [2, 'always', 100],
-  'header-max-length': [2, 'always', 100],
-  'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
-  'subject-empty': [2, 'never'],
-  'subject-full-stop': [2, 'never', '.'],
-  'type-case': [2, 'always', 'lower-case'],
-  'type-empty': [2, 'never'],
-  'type-enum': [
+  "body-leading-blank": [1, "always"],
+  "body-max-line-length": [2, "always", 100],
+  "footer-leading-blank": [1, "always"],
+  "footer-max-line-length": [2, "always", 100],
+  "header-max-length": [2, "always", 100],
+  "subject-case": [
     2,
-    'always',
-    ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']
-  ]
-}
+    "never",
+    ["sentence-case", "start-case", "pascal-case", "upper-case"],
+  ],
+  "subject-empty": [2, "never"],
+  "subject-full-stop": [2, "never", "."],
+  "type-case": [2, "always", "lower-case"],
+  "type-empty": [2, "never"],
+  "type-enum": [
+    2,
+    "always",
+    [
+      "build",
+      "chore",
+      "ci",
+      "docs",
+      "feat",
+      "fix",
+      "perf",
+      "refactor",
+      "revert",
+      "style",
+      "test",
+    ],
+  ],
+};
 ```
 
 ## Example workflows
 
 ### Example with config path defined:
+
 In this example the `commitlint.config.js` file is located in the root directory from where the action is being executed.
 
 ```yml
@@ -74,11 +90,9 @@ jobs:
       - id: lint-pr-title
         uses: grafana/shared-workflows/actions/lint-pr-title@main
         with:
-          config-path: '${{ github.workspace }}/commitlint.config.js'
+          config-path: "${{ github.workspace }}/commitlint.config.js"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-
 ```
 
 ## Example without config path:

--- a/actions/lint-pr-title/action.yml
+++ b/actions/lint-pr-title/action.yml
@@ -2,11 +2,11 @@ name: Lint pull request title using Javascript
 description: Run lint on the PR title to check if It matches the commitlint specification.
 inputs:
   config-path:
-    description: 'Absolute path for the commitlint configuration file'
+    description: "Absolute path for the commitlint configuration file"
     required: false
 runs:
-  using: 'node20'
-  main: 'dist/index.js'
+  using: "node20"
+  main: "dist/index.js"
 branding:
-  icon: 'shield'
-  color: 'green'
+  icon: "shield"
+  color: "green"

--- a/actions/lint-pr-title/commitlint.config.js
+++ b/actions/lint-pr-title/commitlint.config.js
@@ -1,20 +1,36 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
+  extends: ["@commitlint/config-conventional"],
   rules: {
-    'body-leading-blank': [1, 'always'],
-    'body-max-line-length': [2, 'always', 100],
-    'footer-leading-blank': [1, 'always'],
-    'footer-max-line-length': [2, 'always', 100],
-    'header-max-length': [2, 'always', 100],
-    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
-    'subject-empty': [2, 'never'],
-    'subject-full-stop': [2, 'never', '.'],
-    'type-case': [2, 'always', 'lower-case'],
-    'type-empty': [2, 'never'],
-    'type-enum': [
+    "body-leading-blank": [1, "always"],
+    "body-max-line-length": [2, "always", 100],
+    "footer-leading-blank": [1, "always"],
+    "footer-max-line-length": [2, "always", 100],
+    "header-max-length": [2, "always", 100],
+    "subject-case": [
       2,
-      'always',
-      ['build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test']
-    ]
-  }
+      "never",
+      ["sentence-case", "start-case", "pascal-case", "upper-case"],
+    ],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test",
+      ],
+    ],
+  },
 };

--- a/actions/lint-pr-title/index.js
+++ b/actions/lint-pr-title/index.js
@@ -1,6 +1,6 @@
-const core = require('@actions/core');
-const github = require('@actions/github');
-const lint = require('@commitlint/lint').default;
+const core = require("@actions/core");
+const github = require("@actions/github");
+const lint = require("@commitlint/lint").default;
 
 async function run() {
   try {
@@ -8,24 +8,28 @@ async function run() {
 
     const contextPullRequest = github.context.payload.pull_request;
     if (!contextPullRequest) {
-      throw new Error("This action can only be invoked in `pull_request_target` or `pull_request` events. Otherwise the pull request can't be inferred.");
+      throw new Error(
+        "This action can only be invoked in `pull_request_target` or `pull_request` events. Otherwise the pull request can't be inferred.",
+      );
     }
-    const {data: pullRequest} = await octokit.rest.pulls.get({
+    const { data: pullRequest } = await octokit.rest.pulls.get({
       owner: contextPullRequest.base.user.login,
       repo: contextPullRequest.base.repo.name,
-      pull_number: contextPullRequest.number
+      pull_number: contextPullRequest.number,
     });
 
-    const configPath = core.getInput('config-path');
-    const config = configPath ? require(configPath) : require('./commitlint.config.js');
+    const configPath = core.getInput("config-path");
+    const config = configPath
+      ? require(configPath)
+      : require("./commitlint.config.js");
     const result = await lint(pullRequest.title, config.rules);
     if (!result.valid) {
       const errorMessages = result.errors.map((error) => error.message);
-      throw new Error(errorMessages.join('; '));
+      throw new Error(errorMessages.join("; "));
     }
   } catch (error) {
     core.setFailed(error.message);
   }
-};
+}
 
 run();

--- a/actions/login-to-gar/README.md
+++ b/actions/login-to-gar/README.md
@@ -6,9 +6,9 @@ which means that only workflows which get triggered based on certain rules can t
 
 ```yaml
 name: CI
-on: 
+on:
   pull_request:
-    
+
 env:
   ENVIRONMENT: "dev" # can be either dev/prod
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -34,31 +34,31 @@ jobs:
 
 ## Inputs
 
-| Name          | Type   | Description                                                                          |
-|---------------|--------|--------------------------------------------------------------------------------------|
-| `registry`    | String | Google Artifact Registry to store docker images in.                                  |
-| `tags`        | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)  |
-| `context`     | List   | Path to the Docker build context.                                                    |
-| `environment` | Bool   | Environment for pushing artifacts (can be either dev or prod).                       |
-| `image_name`  | String | Name of the image to be pushed to GAR.                                               |
-| `build-args`  | String | List of arguments necessary for the Docker image to be built.                        |
-| `file`        | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
-| `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
-| `cache-from`   | String   | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
-| `cache-to`   | String   | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))   |
-| `ssh`   | List   | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs))    |
+| Name          | Type   | Description                                                                                                                                                                    |
+| ------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `registry`    | String | Google Artifact Registry to store docker images in.                                                                                                                            |
+| `tags`        | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                                            |
+| `context`     | List   | Path to the Docker build context.                                                                                                                                              |
+| `environment` | Bool   | Environment for pushing artifacts (can be either dev or prod).                                                                                                                 |
+| `image_name`  | String | Name of the image to be pushed to GAR.                                                                                                                                         |
+| `build-args`  | String | List of arguments necessary for the Docker image to be built.                                                                                                                  |
+| `file`        | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                                           |
+| `platforms`   | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                                               |
+| `cache-from`  | String | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                 |
+| `cache-to`    | String | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                    |
+| `ssh`         | List   | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs)) |
 
 ## Outputs
 
 The following outputs are exposed from [`docker/metadata-action`](https://github.com/docker/metadata-action?tab=readme-ov-file#outputs) and [`docker/build-push-action`](https://github.com/docker/build-push-action?tab=readme-ov-file#outputs):
 
-| Name      | Type   | Description                    | From |
-|-----------|--------|--------------------------------|------|
-| `version` | String | Generated Docker image version | `docker/metadata-action` |
-| `tags`    | String | Generated Docker tags    | `docker/metadata-action` |
-| `labels`  | String | Generated Docker labels  | `docker/metadata-action` |
-| `annotations` | String | Generated annotations | `docker/metadata-action` |
-| `json`    | String | JSON output of tags and labels | `docker/metadata-action` |
-| `imageid` | String | Image ID | `docker/build-push-action` |
-| `digest`  | String | Image digest | `docker/build-push-action` |
-| `metadata`| String | Build result metadata | `docker/build-push-action` |
+| Name          | Type   | Description                    | From                       |
+| ------------- | ------ | ------------------------------ | -------------------------- |
+| `version`     | String | Generated Docker image version | `docker/metadata-action`   |
+| `tags`        | String | Generated Docker tags          | `docker/metadata-action`   |
+| `labels`      | String | Generated Docker labels        | `docker/metadata-action`   |
+| `annotations` | String | Generated annotations          | `docker/metadata-action`   |
+| `json`        | String | JSON output of tags and labels | `docker/metadata-action`   |
+| `imageid`     | String | Image ID                       | `docker/build-push-action` |
+| `digest`      | String | Image digest                   | `docker/build-push-action` |
+| `metadata`    | String | Build result metadata          | `docker/build-push-action` |

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -49,28 +49,28 @@ inputs:
 
 outputs:
   version:
-    description: 'Generated Docker image version (from docker/metadata-action)'
+    description: "Generated Docker image version (from docker/metadata-action)"
     value: ${{ steps.meta.outputs.version }}
   tags:
-    description: 'Generated Docker tags (from docker/metadata-action)'
+    description: "Generated Docker tags (from docker/metadata-action)"
     value: ${{ steps.meta.outputs.tags }}
   labels:
-    description: 'Generated Docker labels (from docker/metadata-action)'
+    description: "Generated Docker labels (from docker/metadata-action)"
     value: ${{ steps.meta.outputs.labels }}
   annotations:
-    description: 'Generated annotations (from docker/metadata-action)'
+    description: "Generated annotations (from docker/metadata-action)"
     value: ${{ steps.meta.outputs.annotations }}
   json:
-    description: 'JSON output of tags and labels (from docker/metadata-action)'
+    description: "JSON output of tags and labels (from docker/metadata-action)"
     value: ${{ steps.meta.outputs.json }}
   imageid:
-    description: 'Image ID (from docker/build-push-action)'
+    description: "Image ID (from docker/build-push-action)"
     value: ${{ steps.build.outputs.imageid }}
   digest:
-    description: 'Image digest (from docker/build-push-action)'
+    description: "Image digest (from docker/build-push-action)"
     value: ${{ steps.build.outputs.digest }}
   metadata:
-    description: 'Build result metadata (from docker/build-push-action)'
+    description: "Build result metadata (from docker/build-push-action)"
     value: ${{ steps.build.outputs.metadata }}
 
 runs:
@@ -84,7 +84,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: shared-workflows    
+        path: shared-workflows
     - name: Get repository name
       id: get-repository-name
       shell: bash

--- a/actions/syft-sbom-report/README.md
+++ b/actions/syft-sbom-report/README.md
@@ -14,10 +14,10 @@ jobs:
   syft-sbom:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Anchore SBOM Action
-      uses: anchore/sbom-action@v0.15.10
-      with:
-         artifact-name: ${{ github.event.repository.name }}-spdx.json
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Anchore SBOM Action
+        uses: anchore/sbom-action@v0.15.10
+        with:
+          artifact-name: ${{ github.event.repository.name }}-spdx.json
 ```

--- a/actions/syft-sbom-report/syft-sbom.yml
+++ b/actions/syft-sbom-report/syft-sbom.yml
@@ -7,9 +7,9 @@ jobs:
   syft-sbom:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.0.0
-    - name: Anchore SBOM Action
-      uses: anchore/sbom-action@ab5d7b5f48981941c4c5d6bf33aeb98fe3bae38c # 0.15.10
-      with:
-         artifact-name: ${{ github.event.repository.name }}-spdx.json
+      - name: Checkout
+        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.0.0
+      - name: Anchore SBOM Action
+        uses: anchore/sbom-action@ab5d7b5f48981941c4c5d6bf33aeb98fe3bae38c # 0.15.10
+        with:
+          artifact-name: ${{ github.event.repository.name }}-spdx.json

--- a/actions/trigger-argo-workflow/README.md
+++ b/actions/trigger-argo-workflow/README.md
@@ -18,11 +18,13 @@ to fork and modify to run on your own instances. See [#21][issue-21].
 - `instance`: The instance to use (`dev` or `ops`). Defaults to `ops`.
 - `namespace`: Required. The namespace to trigger the workflow in.
 - `parameters`: The newline-separated parameters to pass to the Argo workflow. Example:
+
 ```yaml
-  parameters: |
-    param1=value1
-    param2=value2
+parameters: |
+  param1=value1
+  param2=value2
 ```
+
 - `workflow_template`: The workflow template to use. Required if `command` is `submit` (the default).
 - `extra_args`: Extra arguments to pass to the Argo CLI. Example: `--generate-name foo-`
 - `log_level`: The log level to use. Choose from `debug`, `info`, `warn` or `error`. Defaults to `info`.
@@ -37,14 +39,14 @@ Here is an example of how to use this action:
 
 ```yaml
 steps:
-- name: Trigger Argo Workflow
+  - name: Trigger Argo Workflow
 uses: actions/trigger-argo-workflow@main
 with:
-  instance: 'ops'
-  namespace: 'mynamespace'
-  workflow_template: 'hello'
+  instance: "ops"
+  namespace: "mynamespace"
+  workflow_template: "hello"
   parameters: |
     message=world
-  extra_args: '--generate-name hello-world-'
-  log_level: 'debug'
+  extra_args: "--generate-name hello-world-"
+  log_level: "debug"
 ```


### PR DESCRIPTION
I noticed when writing #107 that my editor wanted to rewrite some of the quotes in the file because they weren't following our `.editorconfig`'s style.

Fix all files according to `prettier` and then run prettier during pushes / pull requests so we don't regress. Add something to the README too, to make people aware of this.