### PR TITLE
build-push-to-dockerhub, dockerhub-login: Use local action

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -56,18 +56,18 @@ jobs:
           repository: grafana/shared-workflows
           # TODO: Replace after merge
           ref: main
-          path: _shared-workflows
+          path: _shared-workflows-publish-techdocs
 
       - name: Rewrite relative links
         if: inputs.rewrite-relative-links || inputs.rewrite-relative-links-dry-run
-        uses: ./_shared-workflows/actions/techdocs-rewrite-relative-links
+        uses: ./_shared-workflows-publish-techdocs/actions/techdocs-rewrite-relative-links
         with:
           working-directory: "${{ inputs.default-working-directory }}"
           repo-url: "https://github.com/${{ github.repository }}"
           default-branch: "${{ github.event.repository.default_branch }}"
           dry-run: "${{ inputs.rewrite-relative-links-dry-run }}"
           checkout-action-repository: "false"
-          checkout-action-repository-path: _shared-workflows
+          checkout-action-repository-path: _shared-workflows-techdocs-rewrite-relative-links
 
       - id: auth
         name: Authenticate with Google Cloud

--- a/README.md
+++ b/README.md
@@ -39,3 +39,31 @@ example:
 ```
 
 [hardening]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+
+### Refer to other `shared-workflows` actions using relative paths
+
+When referencing other actions in this repository, use a relative path. This
+will ensure actions in this repo are always used at the same commit. To do this:
+
+```yaml
+- name: Checkout
+  env:
+    # In a composite action, these two need to be indirected via the
+    # environment, as per the GitHub actions documentation:
+    # https://docs.github.com/en/actions/learn-github-actions/contexts
+    action_repo: ${{ github.action_repository }}
+    action_ref: ${{ github.action_ref }}
+  uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  with:
+    repository: ${{ env.action_repo }}
+    ref: ${{ env.action_ref }}
+    # substitute your-action with a unique name (within `shared-repos` for your
+    # action), so if multiple actions check `shared-workflows` out, they don't
+    # overwrite each other
+    path: _shared-workflows-your-action
+
+- name: Use another action
+  uses: ./_shared-workflows-your-action/actions/some-action
+  with:
+    some-input: some-value
+```

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -29,8 +29,21 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout shared workflows
+      env:
+        # In a composite action, these two need to be indirected via the
+        # environment, as per the GitHub actions documentation:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        action_repo: ${{ github.action_repository }}
+        action_ref: ${{ github.action_ref }}
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: ${{ env.action_repo }}
+        ref: ${{ env.action_ref }}
+        path: _shared-workflows-build-push-to-dockerhub
+
     - name: Login to DockerHub
-      uses: grafana/shared-workflows/actions/dockerhub-login@main
+      uses: ./_shared-workflows-build-push-to-dockerhub/actions/dockerhub-login
 
     # If platforms is specified then also initialize buildx and qemu:
     - name: Set up QEMU

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -4,9 +4,22 @@ description: Using the shared Grafana Labs DockerHub credentials, log in to Dock
 runs:
   using: composite
   steps:
+    - name: Checkout shared workflows
+      env:
+        # In a composite action, these two need to be indirected via the
+        # environment, as per the GitHub actions documentation:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        action_repo: ${{ github.action_repository }}
+        action_ref: ${{ github.action_ref }}
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        repository: ${{ env.action_repo }}
+        ref: ${{ env.action_ref }}
+        path: _shared-workflows-dockerhub-login
+
     - name: Get secrets for DockerHub login
       id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      uses: ./_shared-workflows-dockerhub-login/actions/get-vault-secrets
       with:
         common_secrets: |
           DOCKERHUB_USERNAME=dockerhub:username

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -58,6 +58,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
+        path: _shared-workflows-trigger-argo-workflow
 
     - name: Restore cache
       id: restore
@@ -107,7 +108,7 @@ runs:
 
     - name: Get Argo Token
       id: get-argo-token
-      uses: "./actions/get-vault-secrets"
+      uses: ./_shared-workflows-trigger-argo-workflow/actions/get-vault-secrets
       with:
         vault_instance: ${{ inputs.instance }}
         repo_secrets: |
@@ -117,7 +118,7 @@ runs:
       id: run
       shell: bash
       run: |
-        cd actions/trigger-argo-workflow
+        cd _shared-workflows-trigger-argo-workflow/actions/trigger-argo-workflow
 
         # Split the parameters into an array and pass them to the action as --parameter PARAM
         while read -r line; do


### PR DESCRIPTION
Check the `shared-workflows` repo out and use a unique local path for all actions, instead of fetching `main`. This means that we are always internally compatible. Previously we would risk breaking backwards compatibility if someone had pinned a SHA, which is recommended.

We use a unique checkout path because `actions/checkout` removes the repository in a "post" step and we don't want to risk removing a checkout an "outer" action is using, in the case of nesting. Picture this scenario:

1. [outer] check shared-workflows out to `./_shared-workflows`
2. [nested] run a nested workflow which also checks shared-workflows out to the same path
3. [nested] do some work and then finish, running the "Post checkout" step to remove `./_shared-workflows`
4. [outer] try to do something in `./_shared-workflows` but oops, it's gone

We've gotten away with this up until now as we've not had a step trying to use a checkout after such a removal might have happened. But we might not be lucky forever so be safe now.

Add documentation for this.

Closes: #68