### PR TITLE
techdocs-rewrite-relative-links: Handle links with hashnames properly

### DIFF
--- a/actions/techdocs-rewrite-relative-links/main_test.go
+++ b/actions/techdocs-rewrite-relative-links/main_test.go
@@ -27,6 +27,14 @@ func TestUpdateRelativeLinks(t *testing.T) {
 			fileUnderTest:       "docs/README.md",
 			expectedFileContent: "Hello world [inside](./README.md) [outside](https://github.com/grafana/dummy/blob/main/README.md)\n",
 		},
+		"rewrites-outside-link-with-hashname": {
+			testDirectorySetup: func(fs afero.Fs, rootDir string) {
+				afero.WriteFile(fs, filepath.Join(rootDir, "README.md"), []byte("outside file"), 0600)
+				afero.WriteFile(fs, filepath.Join(rootDir, "docs/README.md"), []byte("Hello world [inside](./README.md) [outside](../README.md#somewhere)"), 0600)
+			},
+			fileUnderTest:       "docs/README.md",
+			expectedFileContent: "Hello world [inside](./README.md) [outside](https://github.com/grafana/dummy/blob/main/README.md#somewhere)\n",
+		},
 		"ignores-external-links": {
 			testDirectorySetup: func(fs afero.Fs, rootDir string) {
 				afero.WriteFile(fs, filepath.Join(rootDir, "docs/README.md"), []byte("Hello world [external](https://example.org)"), 0600)


### PR DESCRIPTION
The idea is that something like `../README.md#hello` should be rewritten to `https://github.com/grafana/repo/README.md#hello`. Previously that didn't work as the filesystem lookups also included the hashname and so they always failed.