### PR TITLE
techdocs-rewrite-relative-links: Level levels and no abort on file error

### DIFF
--- a/actions/techdocs-rewrite-relative-links/README.md
+++ b/actions/techdocs-rewrite-relative-links/README.md
@@ -57,3 +57,5 @@ Follow that up with the actions that should publish the docs to EngHub. See [the
 | `dry-run`                                              | boolean | Do not modify the files but print a diff                                                                       |
 | `checkout-action-repository-path` (default: `_action`) | string  | Folder where the repository should be checked out to for running the action or where a checkout already exists |
 | `checkout-action-repository` (default: `true`)         | boolean | If the workflow already checks out the shared-workflows repository, you can set this to false                  |
+| `verbose` (default `false`)                            | boolean | Log on info level                                                                                              |
+| `debug` (default `false`)                              | boolean | Log on debug level                                                                                             |

--- a/actions/techdocs-rewrite-relative-links/action.yaml
+++ b/actions/techdocs-rewrite-relative-links/action.yaml
@@ -26,6 +26,16 @@ inputs:
       set to false.
     required: false
     default: "true"
+  debug:
+    description: |
+      Log output on debug level
+    required: false
+    default: "false"
+  verbose:
+    description: |
+      Log output on info level
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -77,7 +87,7 @@ runs:
         go run . \
         --root-dir=${root_dir} \
         --default-branch=${{inputs.default-branch}} \
-        --repo-url=${{inputs.repo-url}} ${{ inputs.dry-run == 'true' && '--dry-run' || '' }}
+        --repo-url=${{inputs.repo-url}} ${{ inputs.dry-run == 'true' && '--dry-run' || '' }} ${{ inputs.debug == 'true' && '--debug' || '' }} ${{ inputs.verbose == 'true' && '--verbose' || '' }}
 
     - name: Cleanup
       if: ${{ always() && inputs.checkout-action-repository == 'true' }}


### PR DESCRIPTION
The default log level is now "warn" and the rewriting process is not aborted if there is a file-lookup error.