### PR TITLE
publish-techdocs: Fix the checkout path for `rewrite-relative-links`

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -67,7 +67,7 @@ jobs:
           default-branch: "${{ github.event.repository.default_branch }}"
           dry-run: "${{ inputs.rewrite-relative-links-dry-run }}"
           checkout-action-repository: "false"
-          checkout-action-repository-path: _shared-workflows-techdocs-rewrite-relative-links
+          checkout-action-repository-path: _shared-workflows-publish-techdocs
 
       - id: auth
         name: Authenticate with Google Cloud


### PR DESCRIPTION
We already have it checked out under `publish-techdocs`, so use that.