### PR TITLE
`trigger-argo-workflow`: Fix setup-go installation path

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -104,7 +104,7 @@ runs:
         check-latest: true
         cache-dependency-path: |
           actions/trigger-argo-workflow/go.sum
-        go-version-file: "actions/trigger-argo-workflow/go.mod"
+        go-version-file: "_shared-workflows-trigger-argo-workflow/actions/trigger-argo-workflow/go.mod"
 
     - name: Get Argo Token
       id: get-argo-token


### PR DESCRIPTION
Fix installation path, to use the relative path specified during checkout.