### PR TITLE
chore: Skip log in to DockerHub when not publishing, fail if trying to publish on anything but `push` events

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -29,6 +29,13 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check if push is allowed
+      if: ${{ inputs.push == 'true' && github.event_name != 'push' }}
+      run: |
+        >&2 echo "Publishing to DockerHub is only allowed on push events."
+        >&2 echo "If you still want to build images without pushing them, set the push input to false."
+        exit 1
+
     - name: Checkout shared workflows
       env:
         # In a composite action, these two need to be indirected via the

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -1,5 +1,5 @@
-name: Publish Docker image
-description: Publish docker images to DockerHub
+name: Build & Publish Docker image
+description: Build and publish docker images to DockerHub
 
 inputs:
   repository:
@@ -19,7 +19,7 @@ inputs:
     required: false
   push:
     description: |
-      Push the generated images also to DockerHub
+      Also push the generated images to DockerHub
     default: "false"
   file:
     description: |
@@ -43,6 +43,7 @@ runs:
         path: _shared-workflows-build-push-to-dockerhub
 
     - name: Login to DockerHub
+      if: inputs.push
       uses: ./_shared-workflows-build-push-to-dockerhub/actions/dockerhub-login
 
     # If platforms is specified then also initialize buildx and qemu:

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -31,6 +31,7 @@ runs:
   steps:
     - name: Check if push is allowed
       if: ${{ inputs.push == 'true' && github.event_name != 'push' }}
+      shell: sh
       run: |
         >&2 echo "Publishing to DockerHub is only allowed on push events."
         >&2 echo "If you still want to build images without pushing them, set the push input to false."


### PR DESCRIPTION
Skip logging in DockerHub if `inputs.push` is set to false.
Additionally, let the workflow fail early if run on any other event than `push` and `inputs.push` is set to true because of [what was discussed here](https://github.com/grafana/shared-workflows/pull/26#discussion_r1444280841) (TL;DR: we only want - at least for now - to only allow publishing to docker hub on push events).

I decided to fail instead of overriding silently the `push` to false input as it would be less confusing for user that may expect their image to be published. 
When it fails, this error is printed, which should help the action's users to understand why and how to move forward:
```
| Publishing to DockerHub is only allowed on push events.
| If you still want to build images without pushing them, set the push input to false.
```

Also changed the action name & description, plus the input description to be a bit more descriptive and reflect more accurately what the action is doing.

Fixes #27 


<details>
  <summary>
**How to test this**
</summary>
  
i've only tested this locally with [`act`](https://github.com/nektos/act).

add this workflow to `.github/workflows/test-build-push-to-dockerhub.yaml` and replace the `push` input in the last job according to the table that follows:

```yaml
name: Test build-push-to-dockerhub

on:
  push:
    branches:
      - main
    paths:
      - "actions/build-push-to-dockerhub/**"
      - ".github/workflows/test-build-push-to-dockerhub.yaml"

  pull_request:
    paths:
      - "actions/build-push-to-dockerhub/**"
      - ".github/workflows/test-build-push-to-dockerhub.yaml"

jobs:
  test:
    strategy:
      matrix:
        enviromnent:
          - dev
          # - prod
    runs-on: ubuntu-latest
    steps:
      - name: Checkout code
        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5

      - name: Test Build & Publish Docker image
        id: test-build-push-to-dockerhub
        uses: ./actions/build-push-to-dockerhub
        with:
          push: REPLACE ME
```

| Test |  command | 
| --- | --- | 
| Succeeds on `push` with `inputs.push=true` | `act -W '.github/workflows/test-build-push-to-dockerhub.yaml' push` |
| Succeeds on `push` with `inputs.push=false` | `act -W '.github/workflows/test-build-push-to-dockerhub.yaml' push` |
| Succeeds on `pull_request` with `inputs.push=false` | `act -W '.github/workflows/test-build-push-to-dockerhub.yaml' pull_request |`
| Fails on `pull_request` with `inputs.push=true` | `act -W '.github/workflows/test-build-push-to-dockerhub.yaml' pull_request` |




</details>
