### PR TITLE
build-push-to-dockerhub: Fix check for logging into Docker hub

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -51,7 +51,7 @@ runs:
         path: _shared-workflows-build-push-to-dockerhub
 
     - name: Login to DockerHub
-      if: inputs.push
+      if: ${{ inputs.push == 'true' }}
       uses: ./_shared-workflows-build-push-to-dockerhub/actions/dockerhub-login
 
     # If platforms is specified then also initialize buildx and qemu:


### PR DESCRIPTION
There's a truthiness problem here: inputs for composite actions are always strings, so `"false"` (which is the default) is evaluating to `true` for this conditional and we're logging into Docker Hub when we don't need to.

See [run with `main`][fail] with the default `push` value of `"false"`:

![image](https://github.com/grafana/shared-workflows/assets/321014/b3ba4c9f-3fbe-43c7-af33-96ffab62f0c5)

and [run with this branch][okay]

![image](https://github.com/grafana/shared-workflows/assets/321014/7b6e4c0c-9967-4cca-97b5-51234c819e4b)

I was trying to type this as a review comment but I was too slow :grin: 

[fail]: https://github.com/grafana/wait-for-github/actions/runs/9076711847/job/24940103015#step:4:254
[okay]: https://github.com/grafana/wait-for-github/actions/runs/9076920608/job/24940688779#step:4:252