### PR TITLE
feat(pub-techdocs): checkout submodules

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -57,6 +57,7 @@ jobs:
           # TODO: Replace after merge
           ref: main
           path: _shared-workflows-publish-techdocs
+          submodules: true
 
       - name: Rewrite relative links
         if: inputs.rewrite-relative-links || inputs.rewrite-relative-links-dry-run


### PR DESCRIPTION
For projects that submodule the GitHub wiki in docs, we need to set `submodules: true` on the checkout action.