### PR TITLE
feat(pub-techdocs): make checking out `submodules` configurable

### DIFF
--- a/.github/workflows/publish-techdocs.md
+++ b/.github/workflows/publish-techdocs.md
@@ -38,5 +38,5 @@ jobs:
 | `kind`                      | string  | The kind of the entity in EngHub (usually `component`)                                  |
 | `name`                      | string  | The name of the entity in EngHub (usually matches the name of the repository)           |
 | `default-working-directory` | string  | The directory where the techdocs-cli should be run (default: `.`)                       |
-| `publish`                   | boolean | Enable disable publishing the built docs to EngHub (default: `true`)                    |
+| `publish`                   | boolean | Whether to publish the built docs to EngHub (default: `true`)                           |
 | `checkout-submodules`       | string  | Checkout submodules in the repository (options: `false` (default), `true`, `recursive`) |

--- a/.github/workflows/publish-techdocs.md
+++ b/.github/workflows/publish-techdocs.md
@@ -32,11 +32,11 @@ jobs:
 
 ## Inputs
 
-| Name                        | Type    | Description                                                                   |
-| --------------------------- | ------- | ----------------------------------------------------------------------------- |
-| `namespace`                 | string  | The entity's namespace within EngHub (usually `default`)                      |
-| `kind`                      | string  | The kind of the entity in EngHub (usually `component`)                        |
-| `name`                      | string  | The name of the entity in EngHub (usually matches the name of the repository) |
-| `default-working-directory` | string  | The directory where the techdocs-cli should be run (default: `.`)             |
-| `checkout-repo`             | boolean | Should this workflow also check out the current repository? (default: `true`) |
-| `publish`                   | boolean | Enable disable publishing the built docs to EngHub (default: `true`)          |
+| Name                        | Type    | Description                                                                             |
+| --------------------------- | ------- | --------------------------------------------------------------------------------------- |
+| `namespace`                 | string  | The entity's namespace within EngHub (usually `default`)                                |
+| `kind`                      | string  | The kind of the entity in EngHub (usually `component`)                                  |
+| `name`                      | string  | The name of the entity in EngHub (usually matches the name of the repository)           |
+| `default-working-directory` | string  | The directory where the techdocs-cli should be run (default: `.`)                       |
+| `publish`                   | boolean | Enable disable publishing the built docs to EngHub (default: `true`)                    |
+| `checkout-submodules`       | string  | Checkout submodules in the repository (options: `false` (default), `true`, `recursive`) |

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -31,6 +31,11 @@ on:
         required: false
         type: boolean
         default: true
+      checkout-submodules:
+        description: "Checkout submodules in the repository. Options are `true` (checkout submodules), `false` (don't checkout submodules), or `recursive` (recursively checkout submodules)"
+        required: false
+        type: string
+        default: 'false'
 
 jobs:
   generate-and-publish-docs:
@@ -51,7 +56,7 @@ jobs:
           # TODO: Replace after merge
           ref: main
           path: _shared-workflows-publish-techdocs
-          submodules: true
+          submodules: "${{ inputs.checkout-submodules }}"
 
       - name: Rewrite relative links
         if: inputs.rewrite-relative-links || inputs.rewrite-relative-links-dry-run

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -35,7 +35,7 @@ on:
         description: "Checkout submodules in the repository. Options are `true` (checkout submodules), `false` (don't checkout submodules), or `recursive` (recursively checkout submodules)"
         required: false
         type: string
-        default: 'false'
+        default: "false"
 
 jobs:
   generate-and-publish-docs:


### PR DESCRIPTION
This allows the user to pass in different options to `actions/checkout` submodules option. Default is `false`.