### PR TITLE
lint-shared-workflows: Run for PRs

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -1,6 +1,8 @@
 on:
   push:
 
+  pull_request:
+
 permissions:
   contents: read
   actions: write
@@ -11,8 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Lint with Prettier
         uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3.0


### PR DESCRIPTION
This is a required check - we need to make sure it runs for pull requests.

Checking out `${{ github.head_ref }}` from a fork doesn't work either, so dropthat from the `lint` action and use the default. The problem is that[`pull_request` workflows for forks run in the base repository][pr-base]. Inparticular, `${{ github.repository }}` is the base. So for this commit we weretrying to check out `iainlane/pr` from `grafana/shared-workflows`. But thatbranch is not on that repository because it's from a fork: it's on`iainlane/shared-workflows`.

There is a way to check out PRs from only the base repository though, by using `${{ github.ref }}`. For PRs that is something like `pull/140/merge`. In fact, using that is the default for `actions/checkout`, so we'll drop the setting of the `ref` input altogether.

[pr-base]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories