### PR TITLE
aws-auth: Add `event_name` to the claims passed by default

### DIFF
--- a/actions/aws-auth/README.md
+++ b/actions/aws-auth/README.md
@@ -46,6 +46,7 @@ jobs:
 <!-- markdownlint-restore -->
 
 [^1]: See [Setting up Workload Role](#setting-up-workload-role) for an example
+
 [^2]: GitHub OIDC token claims must be mapped to the Cognito Identity Pool before they can be used. If you would like to use a claim that is not listed, file an issue in this repo or reach out to `@platform-productivity` in `#platform`.
 
 This uses the [`cognito-idpool-auth`](https://github.com/catnekaise/cognito-idpool-auth) action to perform authentication with an Amazon Cognito Identity Pool using the GitHub Actions OIDC access token.

--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
     description: "ARN of workload role"
   pass-claims:
-    default: "repository_owner, repository_name, job_workflow_ref"
+    default: "event_name, repository_owner, repository_name, job_workflow_ref"
     required: true
     description: "`, `-separated claims from GitHub ID token to make available to `role-arn`"
   set-creds-in-environment:


### PR DESCRIPTION
We've got some cases where we want to look at the event name now, so add this to the claims from the token that get set as tags on our eventual (workload) IAM role.