### PR TITLE
update inputs to `build-push-to-dockerhub` action

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -39,6 +39,8 @@ jobs:
 | `repository` | String | Docker repository name                                                               |
 | `tags`       | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)  |
 | `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
+| `build-args` | String | List of arguments necessary for the Docker image to be built.                        |
+| `target`     | String | Sets the target stage to build                                                       |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -31,16 +31,18 @@ jobs:
 
 ## Inputs
 
-| Name         | Type   | Description                                                                          |
-| ------------ | ------ | ------------------------------------------------------------------------------------ |
-| `context`    | String | Path to the Dockerfile (default: `.`)                                                |
-| `platforms`  | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)     |
-| `push`       | Bool   | Push the generated image (default: `false`)                                          |
-| `repository` | String | Docker repository name                                                               |
-| `tags`       | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)  |
-| `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`) |
-| `build-args` | String | List of arguments necessary for the Docker image to be built.                        |
-| `target`     | String | Sets the target stage to build                                                       |
+| Name         | Type   | Description                                                                                                                                                    |
+| ------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context`    | String | Path to the Dockerfile (default: `.`)                                                                                                                          |
+| `platforms`  | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                               |
+| `push`       | Bool   | Push the generated image (default: `false`)                                                                                                                    |
+| `repository` | String | Docker repository name                                                                                                                                         |
+| `tags`       | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                            |
+| `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                           |
+| `build-args` | String | List of arguments necessary for the Docker image to be built.                                                                                                  |
+| `target`     | String | Sets the target stage to build                                                                                                                                 |
+| `cache-from` | String | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/)) |
+| `cache-to`   | String | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -48,13 +48,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check if push is allowed
-      if: ${{ inputs.push == 'true' && github.event_name != 'push' }}
-      shell: sh
-      run: |
-        >&2 echo "Publishing to DockerHub is only allowed on push events."
-        >&2 echo "If you still want to build images without pushing them, set the push input to false."
-        exit 1
+    # - name: Check if push is allowed
+    #   if: ${{ inputs.push == 'true' && github.event_name != 'push' }}
+    #   shell: sh
+    #   run: |
+    #     >&2 echo "Publishing to DockerHub is only allowed on push events."
+    #     >&2 echo "If you still want to build images without pushing them, set the push input to false."
+    #     exit 1
 
     - name: Checkout shared workflows
       env:

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -34,6 +34,16 @@ inputs:
     description: |
       Target stage to build
     required: false
+  cache-from:
+    description: |
+      Where cache should be fetched from
+    required: false
+    default: "type=gha"
+  cache-to:
+    description: |
+      Where cache should be stored to
+    required: false
+    default: "type=gha,mode=max"
 
 runs:
   using: composite
@@ -90,3 +100,5 @@ runs:
         file: ${{ inputs.file }}
         build-args: ${{ inputs.build-args }}
         target: ${{ inputs.target }}
+        cache-from: ${{ inputs.cache-from }}
+        cache-to: ${{ inputs.cache-to }}

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -48,6 +48,8 @@ inputs:
 runs:
   using: composite
   steps:
+    # See this conversation for more context as to why we don't want to allow pushes on pull requests
+    # https://github.com/grafana/shared-workflows/pull/143#discussion_r1628314620
     - name: Check if push is allowed
       if: ${{ inputs.push == 'true' && github.event_name != 'pull_request' }}
       shell: sh

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -48,13 +48,13 @@ inputs:
 runs:
   using: composite
   steps:
-    # - name: Check if push is allowed
-    #   if: ${{ inputs.push == 'true' && github.event_name != 'push' }}
-    #   shell: sh
-    #   run: |
-    #     >&2 echo "Publishing to DockerHub is only allowed on push events."
-    #     >&2 echo "If you still want to build images without pushing them, set the push input to false."
-    #     exit 1
+    - name: Check if push is allowed
+      if: ${{ inputs.push == 'true' && github.event_name != 'pull_request' }}
+      shell: sh
+      run: |
+        >&2 echo "Publishing to DockerHub is not allowed on pull_request events."
+        >&2 echo "If you still want to build images without pushing them, set the push input to false."
+        exit 1
 
     - name: Checkout shared workflows
       env:

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -51,7 +51,7 @@ runs:
     # See this conversation for more context as to why we don't want to allow pushes on pull requests
     # https://github.com/grafana/shared-workflows/pull/143#discussion_r1628314620
     - name: Check if push is allowed
-      if: ${{ inputs.push == 'true' && github.event_name != 'pull_request' }}
+      if: ${{ inputs.push == 'true' && github.event_name == 'pull_request' }}
       shell: sh
       run: |
         >&2 echo "Publishing to DockerHub is not allowed on pull_request events."

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -25,6 +25,15 @@ inputs:
     description: |
       The dockerfile to use.
     required: false
+  build-args:
+    description: |
+      List of arguments necessary for the Docker image to be built.
+    required: false
+    default: ""
+  target:
+    description: |
+      Target stage to build
+    required: false
 
 runs:
   using: composite
@@ -79,3 +88,5 @@ runs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         file: ${{ inputs.file }}
+        build-args: ${{ inputs.build-args }}
+        target: ${{ inputs.target }}


### PR DESCRIPTION
- Adds the following inputs which are needed to migrate [this Drone pipeline in `grafana/oncall`](https://github.com/grafana/oncall/blob/dev/.drone.yml#L129-L135):
  - `build-args`
  - `target`
  - `cache-to`
  - `cache-from`
- Modifies the action to allow `push`ing images to Dockerhub from all GitHub Actions event types **except `pull_request`** (previously the logic here was to _only_ allow `push`ing on a build triggered from a `push` event)

Closes https://github.com/grafana/shared-workflows/issues/80