### PR TITLE
Add new action to find a PR for a commit

### DIFF
--- a/.github/workflows/test-find-pr-for-commit.yml
+++ b/.github/workflows/test-find-pr-for-commit.yml
@@ -1,0 +1,61 @@
+name: Test find-pr-for-commit action
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/find-pr-for-commit/**
+      - .github/workflows/test-find-pr-for-commit.yml
+
+  pull_request:
+    paths:
+      - actions/find-pr-for-commit/**
+      - .github/workflows/test-find-pr-for-commit.yml
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  test:
+    strategy:
+      max-parallel: 1
+      matrix:
+        include:
+          - test_name: "Test current commit by name (${{ github.event_name}})"
+            commitrev: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.number) || github.ref }}
+            # Anything, just checking it has a PR
+            pr_number_regex: "^[0-9]+$"
+
+          - test_name: "Test current commit by sha (${{ github.event_name}})"
+            commitrev: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+            pr_number_regex: "^${{ github.event_name == 'pull_request' && github.event.number || '[0-9]+' }}$"
+
+          - test_name: "Test commit with no PR"
+            commitrev: ""
+            pr_number_regex: "^$"
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: ${{ matrix.test_name }}
+        id: test-find-pr-for-commit
+        uses: ./actions/find-pr-for-commit
+        with:
+          commitrev: ${{ matrix.commitrev }}
+
+      - name: Check PR number
+        run: |
+          set -x
+
+          PR_NUMBER_REGEX='${{ matrix.pr_number_regex }}'
+
+          if ! [[ "${{ steps.test-find-pr-for-commit.outputs.pr_number }}" =~ ${PR_NUMBER_REGEX} ]]; then
+            echo "Test failed: PR number does not match expected value"
+            exit 1
+          fi
+
+          echo "Test passed: PR number matches expected value 🚀"

--- a/actions/find-pr-for-commit/README.md
+++ b/actions/find-pr-for-commit/README.md
@@ -1,0 +1,133 @@
+# Find PR for Commit
+
+This action is used to find the Pull Request associated with a specific commit
+reference.
+
+_Note:_ If there are multiple PRs associated with the commit reference, the
+action will return the most recently updated PR.
+
+## Inputs
+
+| Name        | Type   | Description                                                                                           | Default Value                    | Required |
+| ----------- | ------ | ----------------------------------------------------------------------------------------------------- | -------------------------------- | -------- |
+| `owner`     | String | The owner of the repository                                                                           | `${{ github.repository_owner }}` | No       |
+| `repo`      | String | The repository name                                                                                   | `${{ github.repository }}`       | No       |
+| `commitrev` | String | The commit SHA or revision name (like `refs/heads/main`) to find the PR for                           | `${{ github.sha }}`              | No       |
+| `token`     | String | The GitHub token to use for the query. Must have `contents:read` and `pull-requests:read` permissions | `${{ github.token }}`            | No       |
+
+## Outputs
+
+| Name        | Type   | Description                              |
+| ----------- | ------ | ---------------------------------------- |
+| `pr_number` | String | The PR number associated with the commit |
+
+## Usage
+
+Here is an example of how to use the `Find PR for Commit` action:
+
+### Find the PR for the current commit
+
+You might use this if you want to comment on a PR from a workflow triggered by a
+push event, e.g. after merging to `main`.
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  comment-on-pr-for-commit:
+    steps:
+      - name: Find PR for current commit
+        id: find-pr
+        uses: grafana/shared-workflows/actions/find-pr-for-commit@main
+
+      - name: Use PR number
+        run: echo "PR Number is ${{ steps.find-pr.outputs.pr_number }}"
+```
+
+### Find the PR for a specific commit
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  comment-on-pr-for-commit:
+    steps:
+      - name: Find PR for specific commit
+        id: find-pr
+        uses: grafana/shared-workflows/actions/find-pr-for-commit@main
+        with:
+          commitrev: "1234567890abcdef1234567890abcdef12345678"
+
+      - name: Use PR number
+        run: echo "PR Number is ${{ steps.find-pr.outputs.pr_number }}"
+```
+
+### Find the PR for a named revision
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  comment-on-pr-for-commit:
+    steps:
+      - name: Find PR for named revision
+        id: find-pr
+        uses: grafana/shared-workflows/actions/find-pr-for-commit@main
+        with:
+        commitrev: "HEAD~2"
+
+      - name: Use PR number
+        run: echo "PR Number is ${{ steps.find-pr.outputs.pr_number }}"
+```
+
+### Find the PR for a commit on another repository
+
+In this case you will need to supply the `owner` and `repo` inputs and a token
+in the `token` input, since the default token in Actions runs is scoped to the
+current repository only.
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+    comment-on-pr-for-commit:
+        steps:
+          - name: Find PR for commit in another repository
+              id: find-pr
+              uses: grafana/shared-workflows/actions/find-pr-for-commit@main
+              with:
+                owner: "grafana"
+                repo: "grafana"
+                commitrev: "1234567890abcdef1234567890abcdef12345678"
+                token: ${{ secrets.GRAFANA_READ_TOKEN }}
+
+        - name: Use PR number
+          run: echo "PR Number is ${{ steps.find-pr.outputs.pr_number }}"
+```
+
+Note that `permissions` are not required in this case, as they only affect the
+default `${{ github.token }}` and we are supplying our own.

--- a/actions/find-pr-for-commit/action.yaml
+++ b/actions/find-pr-for-commit/action.yaml
@@ -1,0 +1,62 @@
+name: Find PR for commit
+description: Find the PR associated with a commit
+
+inputs:
+  owner:
+    description: The owner of the repository
+    default: ${{ github.repository_owner }}
+    required: false
+
+  repo:
+    description: The repository name
+    default: ${{ github.event.repository.name }}
+    required: false
+
+  commitrev:
+    description: The commit SHA to find the PR for
+    # If this is a PR, use the PR head SHA. This is because `github.sha` is the
+    # merge commit SHA which will not have a PR associated with it. The PR head
+    # SHA is the commit that was pushed to the PR branch.
+    default: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+    required: false
+
+  token:
+    description: |
+      The GitHub token to use for the query. Must have `contents:read` and
+      `pull-requests:read` permissions on the target repository.
+    default: ${{ github.token }}
+    required: false
+
+outputs:
+  pr_number:
+    description: The PR number associated with the commit
+    value: ${{ fromjson(steps.find-commit-pr.outputs.data).repository.object.associatedPullRequests.edges[0].node.number }}
+
+runs:
+  using: composite
+  steps:
+    - id: find-commit-pr
+      uses: octokit/graphql-action@8ad880e4d437783ea2ab17010324de1075228110 # v2.3.2
+      with:
+        query: |
+          query associatedPRs($commitrev: String, $repo: String!, $owner: String!) {
+            repository(name: $repo, owner: $owner) {
+              object(expression: $commitrev) {
+              ... on Commit {
+                  associatedPullRequests(first: 1, orderBy: {field: UPDATED_AT, direction: DESC}) {
+                    edges {
+                      node {
+                        number
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        variables: |
+          owner: ${{ inputs.owner }}
+          repo: ${{ inputs.repo }}
+          commitrev: ${{ inputs.commitrev }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
Sometimes it's useful to be able to do things with a pull request after it gets merged. For example, maybe there's a build & deploy triggered on pushes to main and you want to report that back to the originating PR.

For that, you need to be able to go back from a commit to the PR that it came from. This simple action performs that lookup using GitHub's API. By default it will look up the current commit, so you can call the action with no inputs and it does the right thing in the common case. It also supports looking up other commits and working in other repositories, if a token is supplied.

A simple testsuite is also included to validate the workflow on changes.