### PR TITLE
dependabot: Enable for `trigger-argo-workflow` and `techdocs-rewrite-relative-links`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,23 @@ updates:
       interval: "daily"
     pull-request-branch-name:
       separator: "-"
+
+  - package-ecosystem: "gomod"
+    directory: "/actions/trigger-argo-workflow"
+    schedule:
+      interval: "weekly"
+    groups:
+      go:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/actions/techdocs-rewrite-relative-links"
+    schedule:
+      interval: "weekly"
+    groups:
+      go:
+        applies-to: "version-updates"
+        patterns:
+          - "*"


### PR DESCRIPTION
These are written in Go, and so we need to make sure that ecosystem is listed in `dependabot.yml` to keep their dependencies up to date.