### PR TITLE
build-push-to-dockerhub, push-to-gar-docker: Document checkout step

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: checkout
+        uses: actions/checkout@v4
+
       - id: push-to-dockerhub
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main
         with:

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -20,8 +20,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grafana/shared-workflows/actions/push-to-gar-docker@main
-        id: push-to-gar
+      - id: checkout
+        uses: actions/checkout@v4
+
+      - id: push-to-gar
+        uses: grafana/shared-workflows/actions/push-to-gar-docker@main
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
           tags: |-


### PR DESCRIPTION
These actions don't check the target repository out themselves, because the caller is likely to have done so already, and if they've changed anything before calling us then we would want that to be used for the build.

But we didn't document this in our examples, so do that.