### PR TITLE
push-to-gar-docker: Always use buildx

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -34,18 +34,19 @@ jobs:
 
 ## Inputs
 
-| Name         | Type   | Description                                                                                                                                                    |
-| ------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `context`    | String | Path to the Dockerfile (default: `.`)                                                                                                                          |
-| `platforms`  | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                               |
-| `push`       | Bool   | Push the generated image (default: `false`)                                                                                                                    |
-| `repository` | String | Docker repository name                                                                                                                                         |
-| `tags`       | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                            |
-| `file`       | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                           |
-| `build-args` | String | List of arguments necessary for the Docker image to be built.                                                                                                  |
-| `target`     | String | Sets the target stage to build                                                                                                                                 |
-| `cache-from` | String | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/)) |
-| `cache-to`   | String | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
+| Name                   | Type   | Description                                                                                                                                                    |
+| ---------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context`              | String | Path to the Dockerfile (default: `.`)                                                                                                                          |
+| `platforms`            | List   | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                               |
+| `push`                 | Bool   | Push the generated image (default: `false`)                                                                                                                    |
+| `repository`           | String | Docker repository name (**required**)                                                                                                                          |
+| `tags`                 | List   | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                            |
+| `file`                 | String | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                           |
+| `build-args`           | String | List of arguments necessary for the Docker image to be built.                                                                                                  |
+| `target`               | String | Sets the target stage to build                                                                                                                                 |
+| `cache-from`           | String | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/)) |
+| `cache-to`             | String | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))    |
+| `docker-buildx-driver` | String | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                   |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -44,6 +44,11 @@ inputs:
       Where cache should be stored to
     required: false
     default: "type=gha,mode=max"
+  docker-buildx-driver:
+    description: |
+      The driver to use for Docker Buildx
+    required: false
+    default: "docker-container"
 
 runs:
   using: composite
@@ -81,8 +86,9 @@ runs:
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
 
     - name: Set up Docker Buildx
-      if: inputs.platforms
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      with:
+        driver: ${{ inputs.docker-buildx-driver }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta


### PR DESCRIPTION
We use the `gha` cache by default, and caches require using a different driver. We currently only enable `buildx` when `platforms` is given, as it is required for that type of build too. What we should do is always enable it.

Do that, and add an input to allow the driver to be specified. That is what `push-to-gar-docker` (the Artifact Registry companion of this Docker Hub action) does, and the more similar we can have those be the better.