### PR TITLE
publish-techdocs: Workload identity provider and SA email aren't secrets

### DIFF
--- a/.github/publish-techdocs-testdata/docs/README.md
+++ b/.github/publish-techdocs-testdata/docs/README.md
@@ -1,0 +1,3 @@
+# Test docs
+
+Lovely stuff.

--- a/.github/publish-techdocs-testdata/mkdocs.yml
+++ b/.github/publish-techdocs-testdata/mkdocs.yml
@@ -1,0 +1,7 @@
+site_name: "test-docs"
+
+nav:
+  - Home: README.md
+
+plugins:
+  - techdocs-core

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -74,8 +74,8 @@ jobs:
         uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
         with:
           create_credentials_file: true
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROVIDER }}
-          service_account: ${{ secrets.BACKSTAGE_TECHDOCS_SA_EMAIL }}
+          workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+          service_account: github-backstage-techdocs@grafanalabs-workload-identity.iam.gserviceaccount.com
 
       # Pinning until resolved https://github.com/backstage/backstage/issues/25303
       - name: Install techdocs-cli

--- a/.github/workflows/test-publish-techdocs.yml
+++ b/.github/workflows/test-publish-techdocs.yml
@@ -1,0 +1,36 @@
+name: Publish TechDocs (test)
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/publish-techdocs-testdata/**
+      - .github/workflows/publish-techdocs.yaml
+      - .github/workflows/test-publish-techdocs.yml
+      - .github/workflows/test-techdocs-rewrite-relative-links.yml
+      - techdocs-rewrite-relative-links/**
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/publish-techdocs-testdata/**
+      - .github/workflows/publish-techdocs.yaml
+      - .github/workflows/test-publish-techdocs.yml
+      - .github/workflows/test-techdocs-rewrite-relative-links.yml
+      - techdocs-rewrite-relative-links/**
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  publish-docs:
+    uses: ./.github/workflows/publish-techdocs.yaml
+    secrets: inherit
+    with:
+      default-working-directory: ".github/publish-techdocs-testdata"
+      kind: component
+      name: ignored
+      namespace: default
+      publish: false


### PR DESCRIPTION
We don't need to get these from org secrets. Let's hardcode them.

If we can stop considering the bucket name a secret then we can remove the `secrets: inherit` requirement from our callers, which will be safer for them.
