### PR TITLE
get-vault-secrets: Use env var to get action path rather than `github` context

### DIFF
--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -56,7 +56,7 @@ runs:
     # Translate the secrets into a format that the Vault action can understand
     - id: translate-secrets
       shell: bash
-      run: ${{ github.action_path }}/translate-secrets.sh
+      run: "${GITHUB_ACTION_PATH}/translate-secrets.sh"
       env:
         REPO_SECRETS: ${{ inputs.repo_secrets }}
         COMMON_SECRETS: ${{ inputs.common_secrets }}


### PR DESCRIPTION
See [this `actions/runner` issue][issue]. The `${{ github.action_path }}` substitution we're using doesn't work properly when the action is run in a container job. The workaround folks are using is to use the `${GITHUB_ACTION_PATH}` _environment variable_ instead. We should start doing that too.

[issue]: https://github.com/actions/runner/issues/2185
