### PR TITLE
chore(pub-techdocs): make workload id provider and SA inputs

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -41,6 +41,16 @@ on:
         required: false
         type: string
         default: ops-us-east-0-backstage
+      workload-identity-provider:
+        description: "The GCP workload identity provider to use for authentication"
+        required: false
+        type: string
+        default: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
+      service-account:
+        description: "The GCP service account to use for authentication"
+        required: false
+        type: string
+        default: github-backstage-techdocs@grafanalabs-workload-identity.iam.gserviceaccount.com
 
 jobs:
   generate-and-publish-docs:
@@ -79,8 +89,8 @@ jobs:
         uses: google-github-actions/auth@71fee32a0bb7e97b4d33d548e7d957010649d8fa # v2.1.3
         with:
           create_credentials_file: true
-          workload_identity_provider: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
-          service_account: github-backstage-techdocs@grafanalabs-workload-identity.iam.gserviceaccount.com
+          workload_identity_provider: ${{ inputs.workload-identity-provider }}
+          service_account: ${{ inputs.service-account }}
 
       # Pinning until resolved https://github.com/backstage/backstage/issues/25303
       - name: Install techdocs-cli


### PR DESCRIPTION
This change allows consumers of this workflow to specify the workload identity provider and service account for GCP auth.

Move current values to defaults.

https://github.com/grafana/shared-workflows/pull/165 is a prerequisite.