### PR TITLE
`lint-shared-workflows`: Add `actionlint.yaml`

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,7 +4,3 @@ self-hosted-runner:
     - ubuntu-amd64*
     - ubuntu-x64*
     - ubuntu-arm64*
-# Configuration variables in array of strings defined in your repository or
-# organization. `null` means disabling configuration variables check.
-# Empty array means no configuration variable is allowed.
-config-variables: null

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,6 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of strings.
-  labels: 
+  labels:
     - ubuntu-amd64*
     - ubuntu-x64*
     - ubuntu-arm64*

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,10 @@
+self-hosted-runner:
+  # Labels of self-hosted runner in array of strings.
+  labels: 
+    - ubuntu-amd64*
+    - ubuntu-x64*
+    - ubuntu-arm64*
+# Configuration variables in array of strings defined in your repository or
+# organization. `null` means disabling configuration variables check.
+# Empty array means no configuration variable is allowed.
+config-variables: null


### PR DESCRIPTION
Upon testing [here](https://github.com/grafana/shared-workflows/actions/runs/9805007501/job/27073819964), I found that the lint fails if we don't specify the self-hosted runner names explicitly. 
Based on the error in that workflow, we need to create an actionlint.yaml file, which got generated when I ran:
`actionlint -init-config`. 
This list of labels will prevent this check from failing when we use our self-hosted runners.
We use the path.Match Glob syntax, as indicated [here](https://github.com/rhysd/actionlint/blob/main/docs/config.md).