### PR TITLE
`lint-shared-workflow`: Run action once, either on PR or push

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -1,5 +1,7 @@
 on:
   push:
+     branches:
+      - "main"
 
   pull_request:
 

--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -1,6 +1,6 @@
 on:
   push:
-     branches:
+    branches:
       - "main"
 
   pull_request:


### PR DESCRIPTION
Currently this action runs twice on a PR, because the triggers are `push` and `pull_request`. We need to be explicit to `push`, for the triggering to happen only when we push to main.

<img width="840" alt="image" src="https://github.com/grafana/shared-workflows/assets/15115078/c79e8cb5-c1a5-44df-b9d5-a233ac45ddaf">
