### PR TITLE
chore: remove `create_credentials_file` input

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -128,7 +128,6 @@ runs:
       with:
         images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/docker-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
-        create_credentials_file: false
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       with:


### PR DESCRIPTION
There's no such thing as `create_credentials_file` input in `docker/metadata-action` - [link](https://github.com/docker/metadata-action?tab=readme-ov-file#inputs).

Fixes a warning in github actions.