### PR TITLE
ci: add merge_group trigger

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -4,6 +4,7 @@ on:
       - "main"
 
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds `merge_group` trigger to the `lint-shared-workflows.yaml` action, since it's required.