### PR TITLE
ci: add merge_group trigger

### DIFF
--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
     types: [closed]
+  merge_group:
 
 jobs:
   build-lint-pr-title:

--- a/.github/workflows/build-trigger-argo-workflow.yaml
+++ b/.github/workflows/build-trigger-argo-workflow.yaml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "actions/trigger-argo-workflow/**"
+  merge_group:
 
 jobs:
   lint-test-build:

--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -4,6 +4,7 @@ on:
       - "main"
 
   pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test-find-pr-for-commit.yml
+++ b/.github/workflows/test-find-pr-for-commit.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - actions/find-pr-for-commit/**
       - .github/workflows/test-find-pr-for-commit.yml
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test-get-vault-secrets.yaml
+++ b/.github/workflows/test-get-vault-secrets.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - "actions/get-vault-secrets/**"
       - ".github/workflows/test-get-vault-secrets.yaml"
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test-login-to-gar.yaml
+++ b/.github/workflows/test-login-to-gar.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - "actions/login-to-gar/**"
       - ".github/workflows/test-login-to-gar.yaml"
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test-publish-techdocs.yml
+++ b/.github/workflows/test-publish-techdocs.yml
@@ -19,6 +19,7 @@ on:
       - .github/workflows/test-publish-techdocs.yml
       - .github/workflows/test-techdocs-rewrite-relative-links.yml
       - techdocs-rewrite-relative-links/**
+  merge_group:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"

--- a/.github/workflows/test-techdocs-rewrite-relative-links.yaml
+++ b/.github/workflows/test-techdocs-rewrite-relative-links.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - "actions/techdocs-rewrite-relative-links/**"
       - ".github/workflows/test-techdocs-rewrite-relative-links.yaml"
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
Adding `merge_group` trigger to actions, now that we have enabled merge queues for this repository.