### PR TITLE
ci(test-find-pr-for-commit): don't run for merge group events

### DIFF
--- a/.github/workflows/test-find-pr-for-commit.yml
+++ b/.github/workflows/test-find-pr-for-commit.yml
@@ -11,7 +11,6 @@ on:
     paths:
       - actions/find-pr-for-commit/**
       - .github/workflows/test-find-pr-for-commit.yml
-  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
This action-testing workflow doesn't make sense when run in the merge group, since the commits there aren't associated with PRs any more. It's failing.

We could in the future consider doing work to get the association back, but I don't think we have a need for it right now, so we can stop running the check there instead.
