### PR TITLE
ci: make build-lint-pr-title action run on every pr

### DIFF
--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -37,7 +37,7 @@ jobs:
           git diff > diff.txt
 
       - name: Upload diff
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
         with:
           name: git-diff-${{ github.sha }}
           path: diff.txt

--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Download diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: /tmp/diffs
           pattern: git-diff-*

--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -1,17 +1,24 @@
 name: Build Lint PR title
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [closed]
+    paths:
+      - .github/workflows/build-lint-pr.yml
+      - actions/lint-pr-title/**
+  pull_request:
+    paths:
+      - .github/workflows/build-lint-pr.yml
+      - actions/lint-pr-title/**
   merge_group:
 
 jobs:
   build-lint-pr-title:
-    if: ${{ github.event.pull_request.merged == true && contains(github.head_ref || github.ref_name, 'dependabot-npm') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
@@ -26,6 +33,50 @@ jobs:
         working-directory: ./actions/lint-pr-title
         run: yarn build
 
+      - name: Check for diff
+        id: check-for-diff
+        run: |
+          git diff > diff.txt
+
+      - name: Upload diff
+        uses: actions/upload-artifact@v4
+        with:
+          name: git-diff-${{ github.sha }}
+          path: diff.txt
+          if-no-files-found: error
+          retention-days: 1
+
+  check-for-diffs:
+    if: ${{ !contains(github.head_ref || github.ref_name, 'dependabot-npm') }}
+    needs: ["build-lint-pr-title"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Download diff
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/diffs
+          pattern: git-diff-*
+      - name: fail-if-diff
+        run: |
+          if [ -s /tmp/diffs/git-diff-${{ github.sha }}/diff.txt ]; then
+            echo "ERROR: Please run *yarn build* and commit your changes.";
+            exit 1
+          fi
+  create-pr-for-bots:
+    needs: ["build-lint-pr-title"]
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true && contains(github.head_ref || github.ref_name, 'dependabot-npm') }}
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Download diff
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/diffs
+          pattern: git-diff-*
+      - name: Apply git patch
+        run: |
+          git apply /tmp/diffs/git-diff-${{ github.sha }}/diff.txt
       - name: Commit lint-pr-title changes and create new pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:

--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Download diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: /tmp/diffs
           pattern: git-diff-*

--- a/.github/workflows/build-lint-pr.yml
+++ b/.github/workflows/build-lint-pr.yml
@@ -17,8 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3

--- a/actions/lint-pr-title/package.json
+++ b/actions/lint-pr-title/package.json
@@ -23,6 +23,5 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/actions/lint-pr-title/package.json
+++ b/actions/lint-pr-title/package.json
@@ -23,5 +23,6 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }


### PR DESCRIPTION
Currently, if the author of a PR forgets to run `yarn build` to make sure the changes appear in `dist/index.js` there's no way to find this out in CI.
`build-lint-pr.yml` runs only for closed PRs which means that updates yarn after the fact.
It's better to have a check to know when we need to run `yarn build` locally before pushing. 
The action should now run for all changes in the `actions/lint-pr-title` or the workflow itself. Also, the previous logic will still work, for pull requests that come from `dependabot-npm` bot. When this case exists, a PR will be created after a dependabot is merged (as happens already)

**How this works?**

* One job does `yarn build`, and does a `git diff`. A `diff.txt` file is pushed as a job artifact.
* Another job which runs for PRs/push events if they don't come from a bot, checks if there downloaded `diff.txt` is empty. If it is, the workflow is green. If it's not, the author gets a message in the logs that they need to do yarn build.
* When dependabot PRs happen, the reviewer can approve and merge. After the merge, a new PR will be created with all the necessary `yarn build` changes.