### PR TITLE
feat: expose workflow_url variable in send-slack-message action

### DIFF
--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -27,6 +27,9 @@ outputs:
   channel_id:
     value: ${{ steps.send-slack-message.outputs.channel_id }}
     description: "The channel id of the message that was posted into Slack"
+  workflow_url:
+    value: ${{ steps.export-gha-url.outputs.channel_id }}
+    description: "The full Github Action workflow to be used in slack messages"
 
 runs:
   using: composite
@@ -46,3 +49,9 @@ runs:
         update-ts: ${{ inputs.update-ts }}
       env:
         SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+    - name: Export GHA URL
+      id: export-gha-url
+      shell: bash
+      run: |
+        WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+        echo "workflow_url=${WORKFLOW_URL}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
It may be useful to be able to have the full workflow url to post the logs for GHA on slack. This PR creates a new output variable called `workflow_url` which can be used any time the `send-slack-message` is used.