### PR TITLE
fix: add repository_name input to push-to-gar-docker

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -53,6 +53,7 @@ jobs:
 | `ssh`                  | List    | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs)) |
 | `build-contexts`       | List    | List of additional [build contexts](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) (e.g., `name=path`)                                                 |
 | `docker-buildx-driver` | String  | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                                   |
+| `repository_name`      | String  | Override the 'repo_name' which is included as part of the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.       |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -62,7 +62,7 @@ inputs:
     default: "docker-container"
   repository_name:
     description: |
-      The name of the GAR repo to push to, in case it differs from the GitHub repo name.
+      Override the 'repo_name' used to construct the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.
     required: false
 
 outputs:

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -108,7 +108,7 @@ runs:
       shell: bash
       run: |
         REPO_NAME="${{ inputs.repository_name }}"
-        if [ -z "$REPOSITORY_NAME" ]; then
+        if [ -z "$REPO_NAME" ]; then
           REPO_NAME=$(echo "${{ github.repository }}" | awk -F'/' '{print $2}')
         fi
         echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -60,6 +60,10 @@ inputs:
       The driver to use for Docker Buildx
     required: false
     default: "docker-container"
+  repository_name:
+    description: |
+      The name of the GAR repo to push to, in case it differs from the GitHub repo name.
+    required: false
 
 outputs:
   version:
@@ -103,7 +107,10 @@ runs:
       id: get-repository-name
       shell: bash
       run: |
-        REPO_NAME=$(echo ${{ github.repository }} | awk -F'/' '{print $2}')
+        REPO_NAME="${{ inputs.repository_name }}"
+        if [ -z "$REPOSITORY_NAME" ]; then
+          REPO_NAME=$(echo "${{ github.repository }}" | awk -F'/' '{print $2}')
+        fi
         echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
     - name: Resolve GCP project
       id: resolve-project


### PR DESCRIPTION
In the event that the GAR includes a repo name that differs from the GitHub repository name, `push-to-gar-docker` will fail to authenticate.

To correct this I'm adding an optional input that allows us to set a different repo name which is used to construct the GAR to authenticate to.
