### PR TITLE
feat(push-to-gar-docker): replace underscores with hyphens in repo names

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -35,6 +35,13 @@ jobs:
           environment: "dev" # can be either dev/prod
 ```
 
+[Artifact Registry repositories can't container underscores][underscore-issue].
+As a convention, this action will replace any underscores in the repository name
+with hyphens. That behaviour can be overridden using the `repository_name`
+input.
+
+[underscore-issue]: https://issuetracker.google.com/issues/229159012
+
 ## Inputs
 
 | Name                   | Type    | Description                                                                                                                                                                    |

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -103,15 +103,20 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: shared-workflows
+
     - name: Get repository name
       id: get-repository-name
       shell: bash
       run: |
         REPO_NAME="${{ inputs.repository_name }}"
         if [ -z "$REPO_NAME" ]; then
-          REPO_NAME=$(echo "${{ github.repository }}" | awk -F'/' '{print $2}')
+          REPO_NAME="$(echo "${{ github.repository }}" | awk -F'/' '{print $2}')"
+          # In Artifact Registry, underscores are not allowed in repository
+          # names. By convention, we replace them with hyphens.
+          REPO_NAME="${REPO_NAME//_/-}"
         fi
-        echo "repo_name=${REPO_NAME}" >> ${GITHUB_OUTPUT}
+        echo "repo_name=${REPO_NAME}" >> "${GITHUB_OUTPUT}"
+
     - name: Resolve GCP project
       id: resolve-project
       shell: bash
@@ -125,20 +130,24 @@ runs:
           exit 1
         fi
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
+
     - name: Login to GAR
       uses: ./shared-workflows/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}
+
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
       with:
         images: "${{ inputs.registry }}/${{ steps.resolve-project.outputs.project }}/docker-${{ steps.get-repository-name.outputs.repo_name }}-${{ inputs.environment }}/${{ inputs.image_name }}"
         tags: ${{ inputs.tags }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       with:
         driver: ${{ inputs.docker-buildx-driver }}
+
     - name: Build the container
       uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       id: build


### PR DESCRIPTION
Since [GAR doesn't support underscores in repository names][issue], we might as well do _something_ by default when we come across this situation. Here we replace them with `-`s.

The input added in 264a3f2a5d4f756715d5c1f3b37f627689e70ab1 can be used to override this behaviour.

[issue]: https://issuetracker.google.com/issues/229159012
