### PR TITLE
fix: generate go client in a subdir

### DIFF
--- a/actions/generate-openapi-clients/action.yaml
+++ b/actions/generate-openapi-clients/action.yaml
@@ -33,13 +33,6 @@ inputs:
     required: false
     default: ""
 
-  # Language-specific inputs
-  go-submodule:
-    description: |
-      If true, the generated client will be generated in the <package-name> subdir. This makes the import path the same as the package name.
-    required: false
-    default: "true"
-
 runs:
   using: composite
   steps:
@@ -79,7 +72,6 @@ runs:
     - shell: bash
       run: ${GITHUB_ACTION_PATH}/generate.sh
       env:
-        GO_SUBMODULE: ${{ inputs.go-submodule }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
         PACKAGE_NAME: ${{ inputs.package-name }}
 

--- a/actions/generate-openapi-clients/action.yaml
+++ b/actions/generate-openapi-clients/action.yaml
@@ -33,6 +33,13 @@ inputs:
     required: false
     default: ""
 
+  # Language-specific inputs
+  go-submodule:
+    description: |
+      If true, the generated client will be generated in the <package-name> subdir. This makes the import path the same as the package name.
+    required: false
+    default: "true"
+
 runs:
   using: composite
   steps:
@@ -72,6 +79,7 @@ runs:
     - shell: bash
       run: ${GITHUB_ACTION_PATH}/generate.sh
       env:
+        GO_SUBMODULE: ${{ inputs.go-submodule }}
         OUTPUT_DIR: ${{ inputs.output-dir }}
         PACKAGE_NAME: ${{ inputs.package-name }}
 

--- a/actions/generate-openapi-clients/generate.sh
+++ b/actions/generate-openapi-clients/generate.sh
@@ -2,12 +2,8 @@
 set -euo pipefail
 
 # Generate Go client (TODO: Add support for other languages)
-GO_DIR="${OUTPUT_DIR}/go"
+GO_DIR="${OUTPUT_DIR}/go/${PACKAGE_NAME}"
 rm -rf "${GO_DIR}"
-
-if [[ ${GO_SUBMODULE} == true ]]; then
-  GO_DIR="${GO_DIR}/${PACKAGE_NAME}"
-fi
 java -jar openapi-generator-cli.jar generate \
   -i "${SPEC_PATH}" \
   -g go \
@@ -15,7 +11,7 @@ java -jar openapi-generator-cli.jar generate \
   --git-user-id "grafana" \
   --git-repo-id "${REPO_NAME}/go" \
   --package-name "${PACKAGE_NAME}" \
-  -p isGoSubmodule=${GO_SUBMODULE} \
+  -p isGoSubmodule=true \
   -p disallowAdditionalPropertiesIfNotPresent=false \
   -t "${GITHUB_ACTION_PATH}/templates/go"
 

--- a/actions/generate-openapi-clients/generate.sh
+++ b/actions/generate-openapi-clients/generate.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 # Generate Go client (TODO: Add support for other languages)
 GO_DIR="${OUTPUT_DIR}/go"
 rm -rf "${GO_DIR}"
+
+if [[ ${GO_SUBMODULE} == true ]]; then
+  GO_DIR="${GO_DIR}/${PACKAGE_NAME}"
+fi
 java -jar openapi-generator-cli.jar generate \
   -i "${SPEC_PATH}" \
   -g go \
@@ -11,6 +15,7 @@ java -jar openapi-generator-cli.jar generate \
   --git-user-id "grafana" \
   --git-repo-id "${REPO_NAME}/go" \
   --package-name "${PACKAGE_NAME}" \
+  -p isGoSubmodule=${GO_SUBMODULE} \
   -p disallowAdditionalPropertiesIfNotPresent=false \
   -t "${GITHUB_ACTION_PATH}/templates/go"
 


### PR DESCRIPTION
This makes importing the client easier

Currently: `github.com/grafana-com-public-clients/go` imports the `gcom` package so it's confusing. It's a go convention that the package name should match the dir name

This PR adds the package name to the generate path