### PR TITLE
fix(argo-lint): fallback to hardcode action repo

### DIFF
--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -21,22 +21,22 @@ runs:
 
   - name: Checkout
     env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: "grafana/shared-workflows"
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      with:
+      # In a composite action, these two need to be indirected via the
+      # environment, as per the GitHub actions documentation:
+      # https://docs.github.com/en/actions/learn-github-actions/contexts
+      action_repo: "grafana/shared-workflows"
+      action_ref: ${{ github.action_ref }}
+    uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: _shared-workflows-argo-lint
 
-    - name: Install argo-cli
-      uses: ./_shared-workflows-argo-lint/actions/install-argo-cli
+  - name: Install argo-cli
+    uses: ./_shared-workflows-argo-lint/actions/install-argo-cli
 
-    - name: Run
-      env:
-        WORKFLOW_PATH: ${{ inputs.path }}
-      shell: bash
-      run: argo lint --offline "${WORKFLOW_PATH}"
+  - name: Run
+    env:
+      WORKFLOW_PATH: ${{ inputs.path }}
+    shell: bash
+    run: argo lint --offline "${WORKFLOW_PATH}"

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -28,9 +28,9 @@ runs:
         action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-          repository: ${{ env.action_repo }}
-          ref: ${{ env.action_ref }}
-          path: _shared-workflows-argo-lint
+        repository: ${{ env.action_repo }}
+        ref: ${{ env.action_ref }}
+        path: _shared-workflows-argo-lint
 
     - name: Install argo-cli
       uses: ./_shared-workflows-argo-lint/actions/install-argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: grafana/shared-workflows
-        ref: ${{ github.action_ref }}
+        ref: ${{ github.action_ref || 'master' }}
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -12,16 +12,10 @@ runs:
 
   steps:
     - name: Checkout
-      env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
+        repository: ${{ github.action_repository }}
+        ref: ${{ github.action_ref }}
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-        repository: ${{ github.action_repository }}
+        repository: grafana/shared-workflows
         ref: ${{ github.action_ref }}
         path: _shared-workflows-argo-lint
 

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -24,7 +24,7 @@ runs:
       # In a composite action, these two need to be indirected via the
       # environment, as per the GitHub actions documentation:
       # https://docs.github.com/en/actions/learn-github-actions/contexts
-      action_repo: "grafana/shared-workflows"
+      action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
       action_ref: ${{ github.action_ref }}
     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     with:

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -24,7 +24,7 @@ runs:
         # In a composite action, these two need to be indirected via the
         # environment, as per the GitHub actions documentation:
         # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: grafana/shared-workflows
+        action_repo: "grafana/shared-workflows"
         action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -11,32 +11,32 @@ runs:
   using: composite
 
   steps:
-  - run: env
-    shell: bash
+    - run: env
+      shell: bash
 
-  - run: echo "$GITHUB_CONTEXT"
-    shell: bash
-    env:
-      GITHUB_CONTEXT: ${{ toJson(github) }}
+    - run: echo "$GITHUB_CONTEXT"
+      shell: bash
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
 
-  - name: Checkout
-    env:
-      # In a composite action, these two need to be indirected via the
-      # environment, as per the GitHub actions documentation:
-      # https://docs.github.com/en/actions/learn-github-actions/contexts
-      action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
-      action_ref: ${{ github.action_ref }}
-    uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-argo-lint
+    - name: Checkout
+      env:
+        # In a composite action, these two need to be indirected via the
+        # environment, as per the GitHub actions documentation:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
+        action_ref: ${{ github.action_ref }}
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+          repository: ${{ env.action_repo }}
+          ref: ${{ env.action_ref }}
+          path: _shared-workflows-argo-lint
 
-  - name: Install argo-cli
-    uses: ./_shared-workflows-argo-lint/actions/install-argo-cli
+    - name: Install argo-cli
+      uses: ./_shared-workflows-argo-lint/actions/install-argo-cli
 
-  - name: Run
-    env:
-      WORKFLOW_PATH: ${{ inputs.path }}
-    shell: bash
-    run: argo lint --offline "${WORKFLOW_PATH}"
+    - name: Run
+      env:
+        WORKFLOW_PATH: ${{ inputs.path }}
+      shell: bash
+      run: argo lint --offline "${WORKFLOW_PATH}"

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -11,12 +11,20 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout
+    - run: env
+      shell: bash
+
+    - run: echo "$GITHUB_CONTEXT"
+      shell: bash
       env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+
+  - name: Checkout
+    env:
         # In a composite action, these two need to be indirected via the
         # environment, as per the GitHub actions documentation:
         # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: ${{ github.action_repository }}
+        action_repo: grafana/shared-workflows
         action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: grafana/shared-workflows
-        ref: ${{ github.action_ref || 'master' }}
+        ref: master
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -12,10 +12,16 @@ runs:
 
   steps:
     - name: Checkout
+      env:
+        # In a composite action, these two need to be indirected via the
+        # environment, as per the GitHub actions documentation:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
+        action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-        repository: "${{ github.action_repository || 'grafana/shared-workflows' }}"
-        ref: ${{ github.action_ref }}
+        repository: ${{ env.action_repo }}
+        ref: ${{ env.action_ref }}
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -11,13 +11,13 @@ runs:
   using: composite
 
   steps:
-    - run: env
-      shell: bash
+  - run: env
+    shell: bash
 
-    - run: echo "$GITHUB_CONTEXT"
-      shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
+  - run: echo "$GITHUB_CONTEXT"
+    shell: bash
+    env:
+      GITHUB_CONTEXT: ${{ toJson(github) }}
 
   - name: Checkout
     env:

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -12,16 +12,10 @@ runs:
 
   steps:
     - name: Checkout
-      env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
-        action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
+        repository: "${{ github.action_repository || 'grafana/shared-workflows' }}"
+        ref: ${{ github.action_ref }}
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -11,14 +11,6 @@ runs:
   using: composite
 
   steps:
-    - run: env
-      shell: bash
-
-    - run: echo "$GITHUB_CONTEXT"
-      shell: bash
-      env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-
     - name: Checkout
       env:
         # In a composite action, these two need to be indirected via the

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -15,7 +15,7 @@ runs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: grafana/shared-workflows
-        ref: master
+        ref: main
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -12,10 +12,16 @@ runs:
 
   steps:
     - name: Checkout
+      env:
+        # In a composite action, these two need to be indirected via the
+        # environment, as per the GitHub actions documentation:
+        # https://docs.github.com/en/actions/learn-github-actions/contexts
+        action_repo: ${{ github.action_repository }}
+        action_ref: ${{ github.action_ref }}
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
-        repository: grafana/shared-workflows
-        ref: main
+        repository: ${{ env.action_repo }}
+        ref: ${{ env.action_ref }}
         path: _shared-workflows-argo-lint
 
     - name: Install argo-cli


### PR DESCRIPTION
While attempting to use the `argo-lint` action in an action in another repository, the `github.action_repository` was empty. This smells like a bug that occurs when stacking composite actions from different repositories. I've filed a support issue with GitHub to have a look at this.

This action now falls back onto a hardcoded value.