### PR TITLE
fix(setup-argo): use amd64 as arch

### DIFF
--- a/actions/setup-argo/action.yaml
+++ b/actions/setup-argo/action.yaml
@@ -32,7 +32,7 @@ runs:
     # If it ain't arm64 or x86_64, it'll fall back to runner.arch.
     - if: runner.arch == 'X64'
       shell: sh
-      run: echo "ARCH=x86_64" >> "$GITHUB_ENV"
+      run: echo "ARCH=amd64" >> "$GITHUB_ENV"
 
     - if: runner.arch == 'ARM64'
       shell: sh

--- a/actions/setup-argo/action.yaml
+++ b/actions/setup-argo/action.yaml
@@ -29,7 +29,7 @@ runs:
 
     # runner.arch options: X86, X64, ARM, or ARM64.
     # argo release: arm64, amd64, ppc64le, s390x.
-    # If it ain't arm64 or x86_64, it'll fall back to runner.arch.
+    # If it ain't arm64 or amd64, it'll fall back to runner.arch.
     - if: runner.arch == 'X64'
       shell: sh
       run: echo "ARCH=amd64" >> "$GITHUB_ENV"


### PR DESCRIPTION
Title says it, overlooked that in previous PR.
