### PR TITLE
fix(setup-argo): use bash, fix idempotency, only restore if needed

### DIFF
--- a/.github/workflows/test-setup-argo.yml
+++ b/.github/workflows/test-setup-argo.yml
@@ -1,0 +1,57 @@
+name: Test Setup Argo
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/setup-argo/**
+      - .github/workflows/test-setup-argo.yml
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - actions/setup-argo/**
+      - .github/workflows/test-setup-argo.yml
+  merge_group:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  setup-argo:
+    runs-on: ubuntu-latest
+    env:
+      # generate a unique cache prefix for each test run, so we can test cache behaviour
+      CACHE_PREFIX: argo-${{ github.run_id }}-${{ github.run_attempt }}
+
+    strategy:
+      matrix:
+        cache-hit: [false, true]
+      max-parallel: 1
+
+    name: "Setup Argo (cache hit: ${{ matrix.cache-hit }})"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          sparse-checkout: |
+            actions/setup-argo
+
+      - name: "Setup Argo (cache: ${{ matrix.cache-hit }})"
+        id: setup-argo
+        uses: ./actions/setup-argo
+        with:
+          cache-prefix: ${{ env.CACHE_PREFIX }}
+          version: 3.5.1
+
+      - name: Assert cache
+        if: fromJson(steps.setup-argo.outputs.cache-hit) != matrix.cache-hit
+        run: |
+          echo "Expected cache hit: '${{ matrix.cache-hit }}' but got '${{ fromJson(steps.setup-argo.outputs.cache-hit) }}'"
+          exit 1
+
+      - name: Check Argo CLI works
+        run: argo version

--- a/actions/setup-argo/action.yaml
+++ b/actions/setup-argo/action.yaml
@@ -19,6 +19,7 @@ runs:
         key: argo-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Normalize runner.os to match Argo release
+      if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
       env:
         OS: ${{ runner.os }}
@@ -30,17 +31,17 @@ runs:
     # runner.arch options: X86, X64, ARM, or ARM64.
     # argo release: arm64, amd64, ppc64le, s390x.
     # If it ain't arm64 or amd64, it'll fall back to runner.arch.
-    - if: runner.arch == 'X64'
+    - if: runner.arch == 'X64' && steps.cache.outputs.cache-hit != 'true'
       shell: sh
       run: echo "ARCH=amd64" >> "$GITHUB_ENV"
 
-    - if: runner.arch == 'ARM64'
+    - if: runner.arch == 'ARM64' && steps.cache.outputs.cache-hit != 'true'
       shell: sh
       run: echo "ARCH=arm64" >> "$GITHUB_ENV"
 
     - name: Fetch Github Release Asset
       id: fetch_asset
-      if: steps.restore.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # 1.1.1
       with:
         repo: "argoproj/argo-workflows"
@@ -59,4 +60,10 @@ runs:
     - name: Add binary to path
       shell: sh
       run: |
-        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+        # Check if `argo` is already in the PATH
+        if command -v argo &> /dev/null; then
+          exit 0
+        fi
+
+        echo "Adding '${{ github.workspace }}/bin' to the PATH so the 'argo' binary can be found"
+        echo "${{ github.workspace }}/bin" >> "${GITHUB_PATH}"

--- a/actions/setup-argo/action.yaml
+++ b/actions/setup-argo/action.yaml
@@ -19,7 +19,7 @@ runs:
         key: argo-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Normalize runner.os to match Argo release
-      shell: sh
+      shell: bash
       env:
         OS: ${{ runner.os }}
       run: |

--- a/actions/setup-argo/action.yaml
+++ b/actions/setup-argo/action.yaml
@@ -2,10 +2,19 @@ name: Setup Argo
 description: Setup Argo cli and add it to the PATH, this action will pull the binary from GitHub releases and store it in cache for the next run.
 
 inputs:
+  cache-prefix:
+    description: Prefix for the cache key.
+    default: argo
+
   version:
     description: |
       Version of the Argo CLI to install.
     default: 3.5.1
+
+outputs:
+  cache-hit:
+    description: Whether the cache was hit or not.
+    value: ${{ steps.cache.outputs.cache-hit || 'false' }}
 
 runs:
   using: composite
@@ -16,7 +25,7 @@ runs:
       uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       with:
         path: ${{ github.workspace }}/bin/argo
-        key: argo-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
 
     - name: Normalize runner.os to match Argo release
       if: steps.cache.outputs.cache-hit != 'true'
@@ -54,14 +63,17 @@ runs:
       if: steps.fetch_asset.outcome == 'success'
       shell: sh
       run: |
-        gunzip ${{ github.workspace }}/bin/argo.gz
+        # Overwrite the argo binary if it already exists. We assume it's from a
+        # previous run of this action.
+        gunzip --force ${{ github.workspace }}/bin/argo.gz
         chmod +x ${{ github.workspace }}/bin/argo
 
     - name: Add binary to path
       shell: sh
       run: |
         # Check if `argo` is already in the PATH
-        if command -v argo &> /dev/null; then
+        if command -v argo >/dev/null; then
+          echo "argo is already in the PATH, not re-adding it"
           exit 0
         fi
 


### PR DESCRIPTION
Should fix:

```
# OS=$(echo "$OS" | tr '[:upper:]' '[:lower:]')
/home/runner/work/_temp/69566fd1-c0c9-4966-824c-63cf829358cd.sh: 2: [[: not found
```

and

```
gzip: /home/runner/work/incident/incident/bin/argo already exists;	not overwritten
```

Adds a testsuite to ensure that the cache is used when it should be, and that the `argo` binary is set up properly on the `PATH` and can be run.