### PR TITLE
fix(aws-auth): use ref instead of workflow_ref claim

### DIFF
--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -11,7 +11,7 @@ inputs:
     required: true
     description: "ARN of workload role"
   pass-claims:
-    default: "event_name, repository_owner, repository_name, job_workflow_ref, workflow_ref"
+    default: "event_name, repository_owner, repository_name, job_workflow_ref, ref"
     required: true
     description: "`, `-separated claims from GitHub ID token to make available to `role-arn`"
   set-creds-in-environment:


### PR DESCRIPTION
The `workflow_ref` claim is currently unsupported by the upstream action and there are issues supporting this due to AWS limitations.

See https://github.com/catnekaise/cognito-idpool-auth/pull/9