### PR TITLE
feat(deps): use Renovate to manage Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      # Check for updates to GitHub Actions every week
-      interval: "weekly"
-
   - package-ecosystem: "npm"
     directory: "/actions/lint-pr-title"
     schedule:

--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "branchPrefix": "grafanarenovatebot/",
+  "dependencyDashboard": false,
+  "enabledManagers": ["github-actions"],
+  "forkProcessing": "enabled",
+  "globalExtends": ["config:best-practices"],
+  "onboarding": false,
+  "osvVulnerabilityAlerts": true,
+  "packageRules": [
+    {
+      "labels": ["update-major"],
+      "matchUpdateTypes": ["major"]
+    },
+    {
+      "labels": ["update-minor"],
+      "matchUpdateTypes": ["minor"]
+    },
+    {
+      "labels": ["automerge-patch"],
+      "matchUpdateTypes": ["patch"]
+    },
+    {
+      "labels": ["update-digest"],
+      "matchUpdateTypes": ["digest"]
+    }
+  ],
+  "platformCommit": "enabled",
+  "rebaseWhen": "behind-base-branch",
+  "requireConfig": "optional",
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["automerge-security-update"]
+  }
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,41 @@
+name: Renovate
+on:
+  schedule:
+    # Offset by 12 minutes to avoid busy times on the hour
+    - cron: 12 */4 * * *
+  pull_request:
+    paths:
+      - .github/renovate-app.json
+      - .github/workflows/renovate.yml
+
+jobs:
+  renovate:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          sparse-checkout: .github/renovate-app.json
+
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        with:
+          app-id: ${{ secrets.RENOVATEGRAFANA_ID }}
+          private-key: ${{ secrets.RENOVATEGRAFANA_PEM }}
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@e1db501385ddcccbaae6fb9c06befae04f379f23 # v40.2.10
+        with:
+          configurationFile: .github/renovate-config.json
+          renovate-version: 38.84.1@sha256:053fbfbe217029b410bab7c11e25dbab8518fae75db9b542c423bdbdc97aa206
+          token: ${{ steps.generate-token.outputs.token }}
+        env:
+          LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}
+          RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || null }}
+          RENOVATE_PLATFORM: github
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_USERNAME: GrafanaRenovateBot


### PR DESCRIPTION
Renovate supports updating actions versions in composite actions and Dependabot doesn't. That means in our `actions/*/action.yml` files we have a lot of out of date deps.

This is a test to see if it'll work for that case. We disable Dependabot for Actions and let Renovate manage them.

Check [logs for the run on this PR](https://github.com/grafana/shared-workflows/actions/runs/10903114856/job/30256479619?pr=240). They look good to me. If it works well after we merge this we could consider making this a shared workflow and putting the secrets in Vault rather than GH secrets, & then also whether we should enable for other dep types too.