### PR TITLE
fix(renovate): fix action versions, add more triggers

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9550da953dd3b29aedf76cd635101e48eae5eebd # v3.25.9
+        uses: github/codeql-action/init@9550da953dd3b29aedf76cd635101e48eae5eebd # v2.17.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -50,6 +50,6 @@ jobs:
             paths-ignore: ${{ toJSON(matrix.paths-ignore) }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9550da953dd3b29aedf76cd635101e48eae5eebd # v3.25.9
+        uses: github/codeql-action/analyze@9550da953dd3b29aedf76cd635101e48eae5eebd # v2.17.4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -3,10 +3,26 @@ on:
   schedule:
     # Offset by 12 minutes to avoid busy times on the hour
     - cron: 12 */4 * * *
+
   pull_request:
     paths:
       - .github/renovate-app.json
       - .github/workflows/renovate.yml
+
+  push:
+    branches:
+      - main
+    paths:
+      - .github/renovate-app.json
+      - .github/workflows/renovate.yml
+
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Run Renovate in dry-run mode"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   renovate:
@@ -14,6 +30,7 @@ jobs:
       contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 5
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -35,7 +52,12 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}
-          RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || null }}
+          # For pull requests, this means we'll get the dependencies of the PR's
+          # branch, so you can fix/change things and see the results in the PR's
+          # run. By default, Renovate will clone the main/default branch.
+          RENOVATE_BASE_BRANCHES: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || null }}
+          # Dry run if the event is pull_request, or workflow_dispatch AND the dry-run input is true
+          RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run) && 'full' || null }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: GrafanaRenovateBot

--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -65,7 +65,7 @@ runs:
       # Get the secrets
     - name: Import Secrets
       id: import-secrets
-      uses: hashicorp/vault-action@e3d5714d59e151ca80233142880b9da9d983a48c # v2.8.0
+      uses: hashicorp/vault-action@e3d5714d59e151ca80233142880b9da9d983a48c # v2.7.5
       with:
         url: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net/"
         role: vault-github-actions


### PR DESCRIPTION
When referencing actions, we'll do:

```yaml
uses: foo/bar-action@123456789 # v1.2.3
```

to reference by SHA but still say what the version was. Dependabot supports updating these comments when creating bumps, but Renovate doesn't do this when the comment points to the wrong version.

We had two cases of that in `codeql-action` and `vault-action`. Here we fix both.

Also, it's easier to test if we can kick off runs manually and if Renovate triggers when its config or workflow are changed, so add triggers for that.

[preset]: https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver
