### PR TITLE
fix(lint-shared-workflows): correct tag for `prettier_action`

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Lint with Prettier
-        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3.0
+        uses: creyD/prettier_action@31355f8eef017f8aeba2e0bc09d8502b13dbbad1 # v4.3
         with:
           dry: true
           prettier_options: "--check ."


### PR DESCRIPTION
Noticed this was warning in the Renovate logs. The only thing I can see
is that it should be `v4.3` not `v4.3.0`.
