### PR TITLE
fix(codeql): use proper tagged version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@9550da953dd3b29aedf76cd635101e48eae5eebd # v2.17.4
+        uses: github/codeql-action/init@366cd9811409649a3e1276ce7f1a1c9023832b56 # v2.25.7
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -50,6 +50,6 @@ jobs:
             paths-ignore: ${{ toJSON(matrix.paths-ignore) }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@9550da953dd3b29aedf76cd635101e48eae5eebd # v2.17.4
+        uses: github/codeql-action/analyze@366cd9811409649a3e1276ce7f1a1c9023832b56 # v2.25.7
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
We set this up by using GitHub's wizard in the UI. Looks like it configured it with a random commit (HEAD at the time maybe) and not one that was tagged. Here we update to [the nearest tag][tag] which [contains][contains] the [commit we previously had][commit].

This should hopefully unblock automated updates.

[commit]: https://github.com/github/codeql-action/commit/9550da953dd3b29aedf76cd635101e48eae5eebd
[contains]: https://github.com/github/codeql-action/commits/366cd9811409649a3e1276ce7f1a1c9023832b56/
[tag]: https://github.com/github/codeql-action/releases/tag/v2.25.7
