### PR TITLE
feat(trigger-argo-workflow): support {dev,ops}-aws instances and get repo-specifc paths

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -4,7 +4,7 @@ description: Trigger an Argo workflow in the Grafana Labs Argo Workflows instanc
 inputs:
   instance:
     description: |
-      The instance to use (`dev` or `ops`). Defaults to `ops`.
+      The instance to use (`dev`, `dev-aws`, `ops` or `ops-aws`). Defaults to `ops`.
     default: ops
   namespace:
     description: |
@@ -64,13 +64,44 @@ runs:
           actions/trigger-argo-workflow/go.sum
         go-version-file: "_shared-workflows-trigger-argo-workflow/actions/trigger-argo-workflow/go.mod"
 
+    - name: Map cluster and vault instance from Argo WF instance
+      id: argo-instance
+      shell: sh
+      run: |
+        # Map the instance to the cluster name to get the correct secret
+        case "${{ inputs.instance }}" in
+          dev-aws)
+            cluster="dev-us-east-0"
+            vault_instance="dev"
+            ;;
+          dev)
+            cluster="dev-us-central-0"
+            vault_instance="dev"
+            ;;
+          ops)
+            cluster="ops-us-east-0"
+            vault_instance="ops"
+            ;;
+          ops-aws)
+            cluster="ops-eu-south-0"
+            vault_instance="ops"
+            ;;
+          *)
+            echo "unknown instance '${{ inputs.instance }}'"
+            exit 1
+            ;;
+        esac
+
+        echo "name=${cluster}" | tee -a "${GITHUB_OUTPUT}"
+        echo "vault-instance=${vault_instance}" | tee -a "${GITHUB_OUTPUT}"
+
     - name: Get Argo Token
       id: get-argo-token
       uses: ./_shared-workflows-trigger-argo-workflow/actions/get-vault-secrets
       with:
-        vault_instance: ${{ inputs.instance }}
+        vault_instance: ${{ steps.argo-instance.outputs.vault-instance }}
         repo_secrets: |
-          ARGO_TOKEN=argo-workflows-trigger:token
+          ARGO_TOKEN=${{ steps.argo-instance.outputs.name }}/argo-workflows-trigger:token
 
     - name: Run
       id: run

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -32,12 +32,15 @@ type App struct {
 	retries uint64
 }
 
+var instanceToHost = map[string]string{
+	"dev":     "argo-workflows-dev.grafana.net:443",
+	"dev-aws": "argo-workflows-aws.grafana-dev.net:443",
+	"ops":     "argo-workflows.grafana.net:443",
+	"ops-aws": "argo-workflows-aws.grafana-ops.net:443",
+}
+
 func (a App) server() string {
-	instanceToHost := map[string]string{
-		"dev": "argo-workflows-dev",
-		"ops": "argo-workflows",
-	}
-	return fmt.Sprintf("%s.grafana.net:443", instanceToHost[a.instance])
+	return instanceToHost[a.instance]
 }
 
 func (a App) env() []string {

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/lmittmann/tint"
@@ -113,9 +115,10 @@ func main() {
 			EnvVars: []string{"INSTANCE"},
 			Value:   "ops",
 			Action: func(c *cli.Context, instance string) error {
-				// Validate it is "dev" or "ops"
-				if instance != "dev" && instance != "ops" {
-					return fmt.Errorf("invalid instance: `%s`. choose from: dev, ops", instance)
+				// Validate it is a known instance
+				instances := slices.Collect(maps.Keys(instanceToHost))
+				if !slices.Contains(instances, instance) {
+					return fmt.Errorf("invalid instance: `%s`. choose from: %s", instance, strings.Join(instances, ", "))
 				}
 
 				return nil

--- a/actions/trigger-argo-workflow/go.mod
+++ b/actions/trigger-argo-workflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/shared-workflows/actions/trigger-argo-workflow
 
-go 1.21.5
+go 1.23.1
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
We're migrating our Argo Workflows environment internally, and for that we currently have parallel deployments. We've namespaced the secrets needed to trigger in each cluster. This PR modifies to allow the new `dev-aws` instance and fetch the cluster-scoped secrets.

To save time for the production migration later, we'll also teach everything about `ops-aws` now, even though it doesn't exist yet.
