### PR TITLE
fix(ci): run required checks when undrafting PRs

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -2,7 +2,12 @@ name: Lint PR title
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 jobs:

--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -1,10 +1,18 @@
 on:
   push:
     branches:
-      - "main"
+      - main
 
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
+
+name: Lint shared-workflows
 
 permissions:
   contents: read
@@ -12,6 +20,7 @@ permissions:
 
 jobs:
   lint:
+    name: Lint all shared workflows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +38,8 @@ jobs:
 
   # A separate job so we can run in the `yq` container
   lint-action-yaml:
+    name: Lint action YAMLs
+
     runs-on: ubuntu-latest
 
     container:


### PR DESCRIPTION
We just merged `release-please` support in 023c802ae4fc29d9bc2b3428333a63f47a5dc255. The user this runs as is the default Actions bot user. One thing about this user in particular is that it doesn't trigger workflows to run. We can see that in #427 for example. At the time of writing no checks have run for that PR.

This means that its release PRs aren't actually mergeable, since we have a couple of required checks which come from Actions runs.

Fortunately we don't have to switch to an app. We can use the fact that the PRs are created in draft mode. To make a release, the process will be

1. Make PR ready for review.
2. Add PR to merge queue.

Workflows can be triggered by the `ready_for_review` activity type on the `pull_request` event. So they will be kicked off when a human does step 1.
