### PR TITLE
fix(lint-pr-title): correctly find the `package.json`

### DIFF
--- a/actions/lint-pr-title/action.yml
+++ b/actions/lint-pr-title/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Install bun package manager
       uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5 # v2.0.1
       with:
-        bun-version-file: "./package.json"
+        bun-version-file: "${{ github.action_path }}/package.json"
 
     - name: Install dependencies
       shell: sh


### PR DESCRIPTION
We give the step to set up `bun` a reference to the `package.json` file so that it can install the correct version. Unfortunately, we'd specified that incorrectly when the action is run locally (from this repo), so it [was not finding it][warning]. We need to give an absolute path.

[warning]: https://github.com/grafana/shared-workflows/actions/runs/11073509535/job/30770197846#step:3:14
