### PR TITLE
fix(trigger-argo-workflow): use correct url for ops on AWS

### DIFF
--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -36,7 +36,7 @@ var instanceToHost = map[string]string{
 	"dev":     "argo-workflows-dev.grafana.net:443",
 	"dev-aws": "argo-workflows-aws.grafana-dev.net:443",
 	"ops":     "argo-workflows.grafana.net:443",
-	"ops-aws": "argo-workflows-aws.grafana-ops.net:443",
+	"ops-aws": "argo-workflows-aws.grafana.net:443",
 }
 
 func (a App) server() string {


### PR DESCRIPTION
We decided to have our temp domain on `grafana.net` to remove one variable (certificate) when cutting over.
