### PR TITLE
fix(trigger-argo-workflow): use `argo-workflows-dev-aws.grafana.net` instead for dev-aws

### DIFF
--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -34,7 +34,7 @@ type App struct {
 
 var instanceToHost = map[string]string{
 	"dev":     "argo-workflows-dev.grafana.net:443",
-	"dev-aws": "argo-workflows-aws.grafana-dev.net:443",
+	"dev-aws": "argo-workflows-dev-aws.grafana.net:443",
 	"ops":     "argo-workflows.grafana.net:443",
 	"ops-aws": "argo-workflows-aws.grafana.net:443",
 }


### PR DESCRIPTION
Use the `grafana.net` domain for argo workflows dev instance as part of testing cut-over to aws