### PR TITLE
feat(publish-techdocs)!: switch to AWS for publish techdocs

### DIFF
--- a/.github/workflows/publish-techdocs.md
+++ b/.github/workflows/publish-techdocs.md
@@ -41,8 +41,6 @@ jobs:
 | `rewrite-relative-links-dry-run` | boolean | Execute [rewrite-relative-links][rewrite-action] step but only print the diff without modifying the files                                                              |
 | `publish`                        | boolean | Enable or disable publishing after building the docs                                                                                                                   |
 | `checkout-submodules`            | string  | Checkout submodules in the repository. Options are `true` (checkout submodules), `false` (don't checkout submodules), or `recursive` (recursively checkout submodules) |
-| `bucket`                         | string  | The name of the GCS bucket to which the docs will be published                                                                                                         |
-| `workload-identity-provider`     | string  | The GCP workload identity provider to use for authentication                                                                                                           |
-| `service-account`                | string  | The GCP service account to use for authentication                                                                                                                      |
+| `instance`                       | string  | The name of the instance to which the docs should be published (`ops` (default), `dev`)                                                                                |
 
 [rewrite-action]: ../../actions/techdocs-rewrite-relative-links/README.md

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -40,20 +40,10 @@ on:
         required: false
         type: string
         default: "false"
-      bucket:
-        description: "The name of the GCS bucket to which the docs will be published"
+      instance:
+        description: The instance to use (`dev` or `ops`). Defaults to `ops`.
         required: false
-        type: string
-        default: ops-eu-south-0-backstage
-      aws-region:
-        default: "eu-south-2"
-        required: false
-        description: "AWS region"
-        type: string
-      aws-role-arn:
-        default: "arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher"
-        required: false
-        description: "ARN of workload role"
+        default: "ops"
         type: string
 
 jobs:
@@ -88,12 +78,33 @@ jobs:
           checkout-action-repository: "false"
           checkout-action-repository-path: _shared-workflows-publish-techdocs
 
+      - id: instance-settings
+        shell: sh
+        run: |
+          case "${{inputs.instance}}" in
+            dev)
+              aws_role_arn=arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher
+              aws_region=us-east-2
+              aws_bucket=dev-us-east-0-backstage
+            ops)
+              aws_role_arn=arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher
+              aws_region=eu-south-2
+              aws_bucket=ops-eu-south-0-backstage
+            *)
+              echo "unknown instance"
+              exit 1
+          esac
+
+          echo "aws-role-arn=${aws_role_arn}" | tee -a "${GITHUB_OUTPUT}"
+          echo "aws-region=${aws_region}" | tee -a "${GITHUB_OUTPUT}"
+          echo "aws-bucket=${aws_bucket}" | tee -a "${GITHUB_OUTPUT}"
+
       - id: aws-auth
         if: inputs.publish
         uses: ./_shared-workflows-publish-techdocs/actions/aws-auth
         with:
-          aws-region: ${{ inputs.aws-region }}
-          role-arn: ${{ inputs.aws-role-arn }}
+          aws-region: ${{ steps.instance-settings.output.aws-region }}
+          role-arn: ${{ steps.instance-settings.outputs.aws-role-arn }}
           set-creds-in-environment: true
 
       # Pinning until resolved https://github.com/backstage/backstage/issues/25303
@@ -115,5 +126,5 @@ jobs:
 
       - name: Publish docs site
         if: inputs.publish
-        run: techdocs-cli publish --publisher-type awsS3 --storage-name ${{ inputs.bucket }} --entity ${{ inputs.namespace }}/${{ inputs.kind }}/${{ inputs.name }}
+        run: techdocs-cli publish --publisher-type awsS3 --storage-name ${{ steps.instance-settings.outputs.aws-bucket }} --entity ${{ inputs.namespace }}/${{ inputs.kind }}/${{ inputs.name }}
         working-directory: ${{ inputs.default-working-directory }}

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -83,16 +83,19 @@ jobs:
         run: |
           case "${{inputs.instance}}" in
             dev)
-              aws_role_arn=arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher
+              aws_role_arn=arn:aws:iam::663667355653:role/github-actions/backstage-techdocs-publisher
               aws_region=us-east-2
               aws_bucket=dev-us-east-0-backstage
+              ;;
             ops)
               aws_role_arn=arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher
               aws_region=eu-south-2
               aws_bucket=ops-eu-south-0-backstage
+              ;;
             *)
               echo "unknown instance"
               exit 1
+              ;;
           esac
 
           echo "aws-role-arn=${aws_role_arn}" | tee -a "${GITHUB_OUTPUT}"
@@ -103,7 +106,7 @@ jobs:
         if: inputs.publish
         uses: ./_shared-workflows-publish-techdocs/actions/aws-auth
         with:
-          aws-region: ${{ steps.instance-settings.output.aws-region }}
+          aws-region: ${{ steps.instance-settings.outputs.aws-region }}
           role-arn: ${{ steps.instance-settings.outputs.aws-role-arn }}
           set-creds-in-environment: true
 

--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -44,17 +44,17 @@ on:
         description: "The name of the GCS bucket to which the docs will be published"
         required: false
         type: string
-        default: ops-us-east-0-backstage
-      workload-identity-provider:
-        description: "The GCP workload identity provider to use for authentication"
+        default: ops-eu-south-0-backstage
+      aws-region:
+        default: "eu-south-2"
         required: false
+        description: "AWS region"
         type: string
-        default: projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider
-      service-account:
-        description: "The GCP service account to use for authentication"
+      aws-role-arn:
+        default: "arn:aws:iam::058264369985:role/github-actions/backstage-techdocs-publisher"
         required: false
+        description: "ARN of workload role"
         type: string
-        default: github-backstage-techdocs@grafanalabs-workload-identity.iam.gserviceaccount.com
 
 jobs:
   generate-and-publish-docs:
@@ -88,13 +88,13 @@ jobs:
           checkout-action-repository: "false"
           checkout-action-repository-path: _shared-workflows-publish-techdocs
 
-      - id: auth
-        name: Authenticate with Google Cloud
-        uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+      - id: aws-auth
+        if: inputs.publish
+        uses: ./_shared-workflows-publish-techdocs/actions/aws-auth
         with:
-          create_credentials_file: true
-          workload_identity_provider: ${{ inputs.workload-identity-provider }}
-          service_account: ${{ inputs.service-account }}
+          aws-region: ${{ inputs.aws-region }}
+          role-arn: ${{ inputs.aws-role-arn }}
+          set-creds-in-environment: true
 
       # Pinning until resolved https://github.com/backstage/backstage/issues/25303
       - name: Install techdocs-cli
@@ -115,5 +115,5 @@ jobs:
 
       - name: Publish docs site
         if: inputs.publish
-        run: techdocs-cli publish --publisher-type googleGcs --storage-name ${{ inputs.bucket }} --entity ${{ inputs.namespace }}/${{ inputs.kind }}/${{ inputs.name }}
+        run: techdocs-cli publish --publisher-type awsS3 --storage-name ${{ inputs.bucket }} --entity ${{ inputs.namespace }}/${{ inputs.kind }}/${{ inputs.name }}
         working-directory: ${{ inputs.default-working-directory }}


### PR DESCRIPTION
Part of https://github.com/grafana/enghub/issues/405

Tested with https://github.com/grafana/enghub/actions/runs/11290282786/job/31401811080

Marked as breaking because it renames/changes some of the inputs as we need AWS-specific semantic here.