### PR TITLE
fix(trigger-argo-workflow): treat AWS dev instance as Argo Workflows dev

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -4,7 +4,7 @@ description: Trigger an Argo workflow in the Grafana Labs Argo Workflows instanc
 inputs:
   instance:
     description: |
-      The instance to use (`dev`, `dev-aws`, `ops` or `ops-aws`). Defaults to `ops`.
+      The instance to use (`dev`, `ops` or `ops-aws`). Defaults to `ops`.
     default: ops
   namespace:
     description: |
@@ -70,12 +70,8 @@ runs:
       run: |
         # Map the instance to the cluster name to get the correct secret
         case "${{ inputs.instance }}" in
-          dev-aws)
-            cluster="dev-us-east-0"
-            vault_instance="dev"
-            ;;
           dev)
-            cluster="dev-us-central-0"
+            cluster="dev-us-east-0"
             vault_instance="dev"
             ;;
           ops)

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -34,7 +34,6 @@ type App struct {
 
 var instanceToHost = map[string]string{
 	"dev":     "argo-workflows-dev.grafana.net:443",
-	"dev-aws": "argo-workflows-dev-aws.grafana.net:443",
 	"ops":     "argo-workflows.grafana.net:443",
 	"ops-aws": "argo-workflows-aws.grafana.net:443",
 }


### PR DESCRIPTION
Now that we have migrated to `dev-us-east-0`, remove references to the GCP cluster and allow for fetching the correct cluster-scoped secrets