### PR TITLE
fix(ci): only run get-vault-secrets ci from `grafana` PRs

### DIFF
--- a/.github/workflows/test-get-vault-secrets.yaml
+++ b/.github/workflows/test-get-vault-secrets.yaml
@@ -12,6 +12,7 @@ on:
     paths:
       - "actions/get-vault-secrets/**"
       - ".github/workflows/test-get-vault-secrets.yaml"
+
   merge_group:
 
 permissions:
@@ -27,6 +28,12 @@ jobs:
           - ops
           - invalid
     runs-on: ubuntu-latest
+
+    # The `get-vault-secrets` action only works when run from a `grafana`
+    # repository, so skip this test if the PR is from a different repository. We
+    # will still get a run of this workflow for the change before merging, as we
+    # use merge queues.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == 'grafana'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The `get-vault-secrets` action only works when run from a `grafana` repository, so skip this test if the PR is from a different repository. We will still get a run of this workflow for the change before merging, as we use merge queues. We can see an example of this failing in https://github.com/grafana/shared-workflows/pull/147.

I've created this PR itself from a fork, to test that this works. I pushed the same change to https://github.com/grafana/shared-workflows/pull/473 to see that we still ran the test from a non-fork. 👍 