### PR TITLE
fix(get-vault-secrets): correct path to `translate-secrets`

### DIFF
--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -56,7 +56,7 @@ runs:
     # Translate the secrets into a format that the Vault action can understand
     - id: translate-secrets
       shell: bash
-      run: "${GITHUB_ACTION_PATH}/translate-secrets.sh"
+      run: "${GITHUB_ACTION_PATH}/translate-secrets.bash"
       env:
         REPO_SECRETS: ${{ inputs.repo_secrets }}
         COMMON_SECRETS: ${{ inputs.common_secrets }}


### PR DESCRIPTION
In 570898eda6d4fb6c0e4d45a24bf9681c89a12aa6 we renamed this but forgot to update a reference. `get-vault-secrets` is now failing.
