### PR TITLE
chore(ci): run `pull_request` workflows when undrafting

### DIFF
--- a/.github/workflows/build-trigger-argo-workflow.yaml
+++ b/.github/workflows/build-trigger-argo-workflow.yaml
@@ -9,6 +9,11 @@ on:
   pull_request:
     paths:
       - "actions/trigger-argo-workflow/**"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
   merge_group:
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   pull_request:
     branches:
       - "main"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
 
   schedule:
     - cron: "21 5 * * 3"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,11 @@ on:
     paths:
       - .github/renovate-config.json
       - .github/workflows/renovate.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
 
   push:
     branches:

--- a/.github/workflows/test-find-pr-for-commit.yml
+++ b/.github/workflows/test-find-pr-for-commit.yml
@@ -11,6 +11,11 @@ on:
     paths:
       - actions/find-pr-for-commit/**
       - .github/workflows/test-find-pr-for-commit.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
 
 permissions:
   contents: read

--- a/.github/workflows/test-get-vault-secrets.yaml
+++ b/.github/workflows/test-get-vault-secrets.yaml
@@ -12,6 +12,11 @@ on:
     paths:
       - "actions/get-vault-secrets/**"
       - ".github/workflows/test-get-vault-secrets.yaml"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
 
   merge_group:
 

--- a/.github/workflows/test-lint-pr-title.yml
+++ b/.github/workflows/test-lint-pr-title.yml
@@ -6,10 +6,17 @@ on:
     paths:
       - .github/workflows/test-lint-pr-title.yml
       - actions/lint-pr-title/**
+
   pull_request:
     paths:
       - .github/workflows/test-lint-pr-title.yml
       - actions/lint-pr-title/**
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 jobs:

--- a/.github/workflows/test-login-to-gar.yaml
+++ b/.github/workflows/test-login-to-gar.yaml
@@ -12,6 +12,12 @@ on:
     paths:
       - "actions/login-to-gar/**"
       - ".github/workflows/test-login-to-gar.yaml"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 permissions:

--- a/.github/workflows/test-publish-techdocs.yml
+++ b/.github/workflows/test-publish-techdocs.yml
@@ -19,6 +19,12 @@ on:
       - .github/workflows/test-publish-techdocs.yml
       - .github/workflows/test-techdocs-rewrite-relative-links.yml
       - techdocs-rewrite-relative-links/**
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 concurrency:

--- a/.github/workflows/test-setup-argo.yml
+++ b/.github/workflows/test-setup-argo.yml
@@ -13,6 +13,12 @@ on:
     paths:
       - actions/setup-argo/**
       - .github/workflows/test-setup-argo.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 concurrency:

--- a/.github/workflows/test-techdocs-rewrite-relative-links.yaml
+++ b/.github/workflows/test-techdocs-rewrite-relative-links.yaml
@@ -12,6 +12,12 @@ on:
     paths:
       - "actions/techdocs-rewrite-relative-links/**"
       - ".github/workflows/test-techdocs-rewrite-relative-links.yaml"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
   merge_group:
 
 jobs:


### PR DESCRIPTION
We have the GitHub Actions bot user create release PRs, and this user doesn't trigger workflows. Fortunately, since we create the PRs in draft mode and a human undrafts to make a release, we can use this as a trigger to run workflows. This only works if the workflows trigger when undrafted. Add that here. This is the same approach we're taking in `wait-for-github` and it works fine there.
