### PR TITLE
fix(aws-auth): support checked out action mode

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -62,7 +62,6 @@ jobs:
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           repository: grafana/shared-workflows
-          # TODO: Replace after merge
           ref: main
           path: _shared-workflows-publish-techdocs
           submodules: "${{ inputs.checkout-submodules }}"
@@ -106,6 +105,7 @@ jobs:
         if: inputs.publish
         uses: ./_shared-workflows-publish-techdocs/actions/aws-auth
         with:
+          checkout-actions-repository-path: ./_shared-workflows-publish-techdocs
           aws-region: ${{ steps.instance-settings.outputs.aws-region }}
           role-arn: ${{ steps.instance-settings.outputs.aws-role-arn }}
           set-creds-in-environment: true

--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -22,6 +22,8 @@ inputs:
     default: "3600"
     required: false
     description: "Role duration in seconds"
+  checkout-actions-repository-path:
+    description: "The path in the filesystem where this repository has been checked out. This is mandatory for setups where executing this action inside a local clone of the repository."
 
 outputs:
   aws_access_key_id:
@@ -62,4 +64,9 @@ runs:
       env:
         AWS_REGION: "${{ inputs.aws-region }}"
         AWS_DEFAULT_REGION: "${{ inputs.aws-region }}"
-      run: ./resolve-aws-region.sh
+        REPOSITORY_PATH: "${{ inputs.checkout-actions-repository-path }}"
+      run: |
+        if [[ ! -z "${REPOSITORY_PATH}" ]]; then
+          cd ${REPOSITORY_PATH}/actions/aws-auth
+        fi
+        ./resolve-aws-region.sh


### PR DESCRIPTION
Resolves https://github.com/grafana/shared-workflows/issues/483

This follows the same naming for local checkouts as the [techdocs-rewrite-relative-links](https://github.com/grafana/shared-workflows/tree/main/actions/techdocs-rewrite-relative-links) action. Follow-up to https://github.com/grafana/shared-workflows/commit/570898eda6d4fb6c0e4d45a24bf9681c89a12aa6