### PR TITLE
fix(aws-auth): no such file for resolve-aws-region.sh

### DIFF
--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -68,5 +68,7 @@ runs:
       run: |
         if [[ ! -z "${REPOSITORY_PATH}" ]]; then
           cd ${REPOSITORY_PATH}/actions/aws-auth
+        else
+          cd "${{ github.action_path }}"
         fi
         ./resolve-aws-region.sh


### PR DESCRIPTION
Currently when REPOSITORY_PATH is not provided I'm getting error: `./resolve-aws-region.sh: No such file or directory`.

Check: https://github.com/grafana/runner-images/actions/runs/11441826500/job/31838893119

This will cd into the action path from [context](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) in case `checkout-actions-repository-path` is not provided.

Related: #484