### PR TITLE
fix(trigger-argo-workflow): treat AWS ops instance as Argo Workflows ops

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -75,7 +75,7 @@ runs:
             vault_instance="dev"
             ;;
           ops)
-            cluster="ops-us-east-0"
+            cluster="ops-eu-south-0"
             vault_instance="ops"
             ;;
           ops-aws)

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -4,7 +4,7 @@ description: Trigger an Argo workflow in the Grafana Labs Argo Workflows instanc
 inputs:
   instance:
     description: |
-      The instance to use (`dev`, `ops` or `ops-aws`). Defaults to `ops`.
+      The instance to use (`dev` or `ops`). Defaults to `ops`.
     default: ops
   namespace:
     description: |
@@ -75,10 +75,6 @@ runs:
             vault_instance="dev"
             ;;
           ops)
-            cluster="ops-eu-south-0"
-            vault_instance="ops"
-            ;;
-          ops-aws)
             cluster="ops-eu-south-0"
             vault_instance="ops"
             ;;

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -35,7 +35,6 @@ type App struct {
 var instanceToHost = map[string]string{
 	"dev":     "argo-workflows-dev.grafana.net:443",
 	"ops":     "argo-workflows.grafana.net:443",
-	"ops-aws": "argo-workflows-aws.grafana.net:443",
 }
 
 func (a App) server() string {


### PR DESCRIPTION
Now that we have migrated to `ops-eu-south-0`, remove references to the GCP cluster and allow for fetching the correct cluster-scoped secrets