### PR TITLE
feat: allow skipping QEMU in Docker build&push action

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -17,6 +17,10 @@ inputs:
     description: |
       List of platforms to build the image for
     required: false
+  skip-qemu:
+    description: |
+      Skips the installation of QEMU. Might be useful for faster multiarch builds of Go applications.
+    default: "false"
   push:
     description: |
       Also push the generated images to DockerHub
@@ -82,7 +86,7 @@ runs:
 
     # If platforms is specified then also initialize buildx and qemu:
     - name: Set up QEMU
-      if: inputs.platforms
+      if: ${{ inputs.skip-qemu != 'true' && inputs.platforms }}
       uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3.2.0
 
     - name: Set up Docker Buildx


### PR DESCRIPTION
Qemu slowdowns compilation by orders or magnitude.

At least in Go applications, buildx should work well without QEMU for multiarch builds.

This PR adds a configuration option to disable Qemu installation.