### PR TITLE
chore(renovate): update Renovate itself less frequently (weekly)

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -36,6 +36,11 @@
       labels: ["update-digest"],
       matchUpdateTypes: ["digest"],
     },
+    {
+      // Run the custom matcher on early Monday mornings (UTC)
+      schedule: "* 0-4 * * 1",
+      matchPackageNames: ["ghcr.io/renovatebot/renovate"],
+    },
   ],
   platformCommit: "enabled",
   rebaseWhen: "behind-base-branch",


### PR DESCRIPTION
Renovate pushes out new images most days, sometimes multiple times a day. We don't need to track these so closely, so let's look for these particular updates only once a week - early on Monday mornings.
