### PR TITLE
chore(get-vault-secrets): remove the iap-auth step from get-vault-secrets

### DIFF
--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -36,22 +36,6 @@ runs:
       run: |
         echo "Invalid value for vault_instance input: ${{ inputs.vault_instance }}. Must be 'dev' or 'ops'."
         exit 1
-    - id: vault-iap-auth
-      uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
-      with:
-        # Note that these aren't secrets, login is secured through Github's OIDC integrations with GCP and Vault.
-        # Get with:
-        #   gcloud iam workload-identity-pools list --project=grafanalabs-workload-identity --location="global"
-        #   gcloud iam workload-identity-pools providers list --workload-identity-pool=<POOL>
-        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: "github-vault-actions-${{ inputs.vault_instance }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
-        token_format: id_token
-        # Get with:
-        #   gcloud alpha iap oauth-brands list --project=ops-tools-1203 (or grafanalabs-dev for dev)
-        #   gcloud alpha iap oauth-clients list <BRAND_NAME>
-        id_token_audience: ${{ inputs.vault_instance == 'ops' && '398738203898-b4pffihghfj5aec08rg9n87hnnqn513k.apps.googleusercontent.com' || '1040409107725-0epub52fk3fmqtsst39dqi8na02rco6a.apps.googleusercontent.com' }}
-        id_token_include_email: true
-        create_credentials_file: false
 
     # Translate the secrets into a format that the Vault action can understand
     - id: translate-secrets
@@ -81,7 +65,6 @@ runs:
         method: jwt
         jwtGithubAudience: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net"
         extraHeaders: |
-          Proxy-Authorization: Bearer ${{ steps.vault-iap-auth.outputs.id_token }}
           Proxy-Authorization-Token: Bearer ${{ steps.get-github-jwt-token.outputs.github-jwt }}
         secrets: |
           ${{ steps.translate-secrets.outputs.secrets }}


### PR DESCRIPTION
 Remove the iap-auth step from get-vault-secrets because with the new Vault deployment it's not necessary any more