### PR TITLE
feat: add action to log into Docker Hub pull-through cache

### DIFF
--- a/actions/dockerhub-pull-through-cache-login/README.md
+++ b/actions/dockerhub-pull-through-cache-login/README.md
@@ -1,0 +1,29 @@
+# dockerhub-pull-through-cache-login
+
+This is a composite GitHub Action, used to login to Grafana's Docker Hub pull
+through cache.
+
+It uses [OIDC
+authentication](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
+which means that only workflows which run in the `grafana` GitHub organization
+can use this action.
+
+```yaml
+name: CI
+on:
+  pull_request:
+
+# These permissions are needed to assume roles from Github's OIDC.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  login:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-pull-through-cache-login@main
+      # Prefix your image with `us-docker.pkg.dev/ops-tools-1203/dockerhub-proxy`
+      - run: docker pull us-docker.pkg.dev/ops-tools-1203/dockerhub-proxy/grafana/grafana:latest
+```

--- a/actions/dockerhub-pull-through-cache-login/action.yaml
+++ b/actions/dockerhub-pull-through-cache-login/action.yaml
@@ -1,0 +1,20 @@
+name: Login to Docker Hub pull-through cache
+description: Composite action to log in to Docker Hub pull-through cache
+
+runs:
+  using: composite
+  steps:
+    - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
+      id: gcloud-auth
+      with:
+        token_format: access_token
+        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        service_account: dockerhub-proxy-reader@grafanalabs-workload-identity.iam.gserviceaccount.com
+        create_credentials_file: false
+
+    - name: Login to GAR
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+      with:
+        registry: us-docker.pkg.dev/ops-tools-1203/dockerhub-proxy
+        username: oauth2accesstoken
+        password: ${{ steps.gcloud-auth.outputs.access_token }}


### PR DESCRIPTION
Grafana Labs has a pull-through cache hosted in GAR to avoid hititng Docker Hub for every image request, which is something that is quite subject to rate limiting.

This adds a new composite action to make logging into this registry easier.
