### PR TITLE
chore: update readme when a new release is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,4 +153,4 @@ jobs:
 
 ````
 
-Every semver-like string nested in the above release-please block, will be updated with the new semver once it's released.
+Every semver-like string between the `x-release-please-start-version` and `x-release-please-end-version` comments will be updated with the new version whenever the component is released.

--- a/README.md
+++ b/README.md
@@ -108,3 +108,50 @@ More about how the upstream action works can be found [here](https://github.com/
 ### Add new components to Release Please config file
 
 In order for components to be released, they must be in the [release-please-config.json](./release-please-config.json) file. Always ensure new components are added to this file.
+
+#### Automatically update README files with the latest version
+
+As part of using the latest version of an action, it's a good practice to update the README file of each shared workflow every time there is a new release.
+
+To do so, after adding the name of the new action which needs to be released in the [release-please-config.json](./release-please-config.json) file, the `"extra-files"` field should also be added and include the `README.md` like:
+
+```json
+  ...
+  "packages": {
+    "actions/my-new-action": {
+      "package-name": "my-new-action",
+      "extra-files": ["README.md"]
+    },
+  }
+```
+
+Also, the following block should be added in the README file which will be responsible for updating the version with a new one:
+
+`README.md`:
+````
+# my-new-action
+
+This is my new action which does awesome stuff!
+
+<!-- x-release-please-start-version --> # beginning of the release please block
+
+```yaml
+name: My new action
+on:
+  pull_request:
+
+jobs:
+  my-new-action:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: do-stuff
+        uses: grafana/shared-workflows/actions/my-new-action@my-new-action-v1.0.0
+
+```
+
+<!-- x-release-please-end-version --> # end of the release please block
+
+````
+
+Every semver-like string nested in the above release-please block, will be updated with the new semver once it's released.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ Once the component is added, as part of using the latest version of an action, i
 To do so, after adding the name of the new action which needs to be released in the [release-please-config.json](./release-please-config.json) file, the `"extra-files"` field should also be added and include the `README.md` like:
 
 ```json
-  ...
   "packages": {
     "actions/my-new-action": {
       "package-name": "my-new-action",

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ To do so, after adding the name of the new action which needs to be released in 
 Also, the following block should be added in the README file which will be responsible for updating the version with a new one:
 
 `README.md`:
+
 ````
 # my-new-action
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ More about how the upstream action works can be found [here](https://github.com/
 
 In order for components to be released, they must be in the [release-please-config.json](./release-please-config.json) file. Always ensure new components are added to this file.
 
-
 `README` files for each component should have embedded versions updated every time there is a new release.
 
 Add a new entry which looks like this:
@@ -146,11 +145,9 @@ jobs:
     steps:
       - id: do-stuff
         uses: grafana/shared-workflows/actions/my-new-action@my-new-action-v1.0.0
-
 ```
 
 <!-- x-release-please-end-version -->
-
 ````
 
 Every semver-like string between the `x-release-please-start-version` and `x-release-please-end-version` comments will be updated with the new version whenever the component is released.

--- a/README.md
+++ b/README.md
@@ -109,9 +109,7 @@ More about how the upstream action works can be found [here](https://github.com/
 
 In order for components to be released, they must be in the [release-please-config.json](./release-please-config.json) file. Always ensure new components are added to this file.
 
-#### Automatically update README files with the latest version
-
-As part of using the latest version of an action, it's a good practice to update the README file of each shared workflow every time there is a new release.
+Once the component is added, as part of using the latest version of an action, it's a good practice to update the README file of each shared workflow every time there is a new release.
 
 To do so, after adding the name of the new action which needs to be released in the [release-please-config.json](./release-please-config.json) file, the `"extra-files"` field should also be added and include the `README.md` like:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ More about how the upstream action works can be found [here](https://github.com/
 
 In order for components to be released, they must be in the [release-please-config.json](./release-please-config.json) file. Always ensure new components are added to this file.
 
-Once the component is added, as part of using the latest version of an action, it's a good practice to update the README file of each shared workflow every time there is a new release.
+
+`README` files for each component should have embedded versions updated every time there is a new release.
 
 To do so, after adding the name of the new action which needs to be released in the [release-please-config.json](./release-please-config.json) file, the `"extra-files"` field should also be added and include the `README.md` like:
 

--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ Also, the following block should be added in the README file which will be respo
 
 `README.md`:
 
-````
+````markdown
 # my-new-action
 
 This is my new action which does awesome stuff!
 
-<!-- x-release-please-start-version --> # beginning of the release please block
+<!-- x-release-please-start-version -->
 
 ```yaml
 name: My new action
@@ -149,7 +149,7 @@ jobs:
 
 ```
 
-<!-- x-release-please-end-version --> # end of the release please block
+<!-- x-release-please-end-version -->
 
 ````
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ In order for components to be released, they must be in the [release-please-conf
 
 `README` files for each component should have embedded versions updated every time there is a new release.
 
-To do so, after adding the name of the new action which needs to be released in the [release-please-config.json](./release-please-config.json) file, the `"extra-files"` field should also be added and include the `README.md` like:
+Add a new entry which looks like this:
 
 ```json
   "packages": {

--- a/actions/argo-lint/README.md
+++ b/actions/argo-lint/README.md
@@ -1,0 +1,16 @@
+# Lint Argo
+
+Shared workflow to lint Argo workflow files.
+
+## Example
+
+<!-- x-release-please-start-version -->
+
+```
+uses: grafana/shared-workflows/actions/argo-lint@argo-lint-v1.0.0
+with:
+  path: /path/to/files # Paths to files for linting
+
+```
+
+<!-- x-release-please-end-version -->

--- a/actions/aws-auth/README.md
+++ b/actions/aws-auth/README.md
@@ -4,6 +4,8 @@ This is a composite GitHub Action used to authenticate and access resources in A
 
 Example usage in a repository:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Authenticate to AWS
 on:
@@ -18,7 +20,7 @@ jobs:
 
     steps:
       - id: aws-auth
-        uses: grafana/shared-workflows/actions/aws-auth@main
+        uses: grafana/shared-workflows/actions/aws-auth@argo-lint-v1.0.0
         with:
           aws-region: "us-west-1"
           role-arn: "arn:aws:iam::366620023056:role/github-actions/s3-test-access"
@@ -30,6 +32,8 @@ jobs:
           aws s3 cp 's3://grafanalabs-github-actions-test-repo/test.txt' 'test.txt'
           cat 'test.txt'
 ```
+
+<!-- x-release-please-end-version -->
 
 ## Inputs
 

--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -5,6 +5,8 @@ It uses `get-vault-secrets` action to get the DockerHub username and password fr
 
 Example of how to use this action in a repository:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Push to DockerHub
 on:
@@ -23,7 +25,7 @@ jobs:
         uses: actions/checkout@v4
 
       - id: push-to-dockerhub
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@main
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@build-push-to-dockerhub-v0.1.0
         with:
           repository: ${{ github.repository }} # or any other dockerhub repository
           context: .
@@ -31,6 +33,8 @@ jobs:
             "2024-04-01-abcd1234"
             "latest"
 ```
+
+<!-- x-release-please-end-version -->
 
 ## Inputs
 

--- a/actions/dockerhub-login/README.md
+++ b/actions/dockerhub-login/README.md
@@ -5,6 +5,8 @@ It uses `get-vault-secrets` action to get the DockerHub username and password fr
 
 Example of how to use this action in a repository:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Push to DockerHub
 on:
@@ -20,7 +22,9 @@ jobs:
 
     steps:
       - name: Login to DockerHub
-        uses: grafana/shared-workflows/actions/dockerhub-login@main
+        uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.0
       - name: Build and push
         run: make build && make push
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/generate-openapi-clients/README.md
+++ b/actions/generate-openapi-clients/README.md
@@ -18,6 +18,8 @@ _Note: For now, it only generates Go code. But it's structured in a way that any
 
 ## Example workflow
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Generate Clients
 
@@ -38,12 +40,14 @@ jobs:
         with:
           go-version: 1.18
       - name: Generate clients
-        uses: grafana/shared-workflows/actions/generate-openapi-clients@main
+        uses: grafana/shared-workflows/actions/generate-openapi-clients@generate-openapi-clients-v1.0.0
         with:
           package-name: slo
           spec-path: openapi.yaml
           modify-spec-script: .github/workflows/modify-spec.sh # Optional, see "Spec Modifications" section
 ```
+
+<!-- x-release-please-end-version -->
 
 ### Spec Modifications at Runtime
 

--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -5,6 +5,8 @@ The secret format is defined here: <https://github.com/hashicorp/vault-action>
 
 Example workflow:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: CI
 on:
@@ -21,7 +23,7 @@ jobs:
 
     steps:
       - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1
         with:
           # Secrets placed in the ci/common/<path> path in Vault
           common_secrets: |
@@ -37,3 +39,5 @@ jobs:
           echo "$ENVVAR1"
           echo "${{ env.ENVVAR2 }}"
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/login-to-gar/README.md
+++ b/actions/login-to-gar/README.md
@@ -4,6 +4,8 @@ This is a composite GitHub Action, used to login to Google Artifact Registry (GA
 It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
 which means that only workflows which get triggered based on certain rules can trigger these composite workflows.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: CI
 on:
@@ -19,9 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: grafana/shared-workflows/actions/login-to-gar@main
+      - uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.1.0
         id: login-to-gar
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev
           environment: "prod" # can be either dev/prod
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/login-to-gcs/README.md
+++ b/actions/login-to-gcs/README.md
@@ -5,6 +5,8 @@ It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/secu
 which means that only workflows which get triggered based on certain rules can
 trigger these composite workflows.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Login-to-gcs
 
@@ -21,9 +23,11 @@ jobs:
   login-to-gcs:
     name: login-to-gcs
     steps:
-      - uses: grafana/shared-workflows/actions/login-to-gcs@main
+      - uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.1.0
         id: login-to-gcs
 ```
+
+<!-- x-release-please-end-version -->
 
 You can now use the shared-workflow `push-to-gcs` or gcloud to push objects from your CI pipeline.
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -5,6 +5,8 @@ It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/secu
 which means that only workflows which get triggered based on certain rules can
 trigger these composite workflows.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: CI
 on:
@@ -24,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - id: push-to-gar
-        uses: grafana/shared-workflows/actions/push-to-gar-docker@main
+        uses: grafana/shared-workflows/actions/push-to-gar-docker@push-to-gar-docker-v0.1.0
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
           tags: |-
@@ -34,6 +36,8 @@ jobs:
           image_name: "backstage" # name of the image to be published, required
           environment: "dev" # can be either dev/prod
 ```
+
+<!-- x-release-please-end-version -->
 
 [Artifact Registry repositories can't contain underscores][underscore-issue].
 As a convention, this action will replace any underscores in the repository name

--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -5,6 +5,8 @@ It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/secu
 which means that only workflows which get triggered based on certain rules can
 trigger these composite workflows.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Upload Files to GCS
 
@@ -27,14 +29,14 @@ jobs:
         id: login-to-gcs
 
         # Upload a single file to the bucket root
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: file.txt
           environment: "dev" # Can be dev/prod (defaults to dev)
 
         # Upload a single file and apply a predefined ACL. See `predefinedAcl` for options.
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: file.txt
@@ -42,28 +44,28 @@ jobs:
           environment: "dev"
 
         # Here are 3 equivalent statements to upload a single file and its parent directory to the bucket root
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder/file.txt
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: .
           glob: "folder/file.txt"
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder
           glob: "file.txt"
 
         # Here are 2 equivalent statements to upload a single file WITHOUT its parent directory to the bucket root
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder/file.txt
           parent: false
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder
@@ -71,18 +73,18 @@ jobs:
           parent: false
 
         # Here are 2 equivalent statements to upload a directory with all subdirectories
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder/
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: .
           glob: "folder/**/*"
 
         # Specify a bucket prefix with `bucket_path`
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         name: upload-yaml-to-some-path
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
@@ -90,19 +92,21 @@ jobs:
           bucket_path: some-path/
 
         # Upload all files of a type
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder/
           glob: "*.txt"
 
         # upload all files of a type recursively
-      - uses: grafana/shared-workflows/actions/push-to-gcs@main
+      - uses: grafana/shared-workflows/actions/push-to-gcs@push-to-gcs-v0.1.0
         with:
           bucket: ${{ steps.login-to-gcs.outputs.bucket }}
           path: folder/
           glob: "**/*.txt"
 ```
+
+<!-- x-release-please-end-version -->
 
 ## Inputs
 

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -5,6 +5,8 @@ You do not need to set up Slack webhooks in order to use this action.
 
 See the docs for the [slackapi/slack-github-action workflow](https://github.com/slackapi/slack-github-action/blob/main/README.md#technique-2-slack-app) for more info. Our installation is via Slack App.
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: Send And Update a Slack plain text message
 jobs:
@@ -13,13 +15,13 @@ jobs:
     steps:
       - name: Send Slack Message
         id: slack
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: "Channel Name or ID"
           slack-message: "We are testing, testing, testing all day long"
 
       - name: Update Slack Message
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: ${{ steps.slack.outputs.channel_id }} # Channel ID is required when updating a message
           slack-message: "This is the updated message"
@@ -34,7 +36,7 @@ jobs:
     steps:
       - name: Send Slack Message via Payload
         id: slack
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: "Channel Name or ID"
           payload: |
@@ -56,7 +58,7 @@ jobs:
             }
 
       - name: Update Slack Message via Payload
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: ${{ steps.slack.outputs.channel_id }}
           payload: |
@@ -88,7 +90,7 @@ jobs:
     steps:
       - name: Post to a Slack channel
         id: slack
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: "Channel Name or ID"
           payload: |
@@ -96,7 +98,7 @@ jobs:
               "text": "Deployment started (In Progress)"
             }
       - name: Respond to Slack Message
-        uses: grafana/shared-workflows/actions/send-slack-message@main
+        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v1.0.0
         with:
           channel-id: ${{ steps.slack.outputs.channel_id }}
           payload: |
@@ -105,6 +107,8 @@ jobs:
               "text": "Deployment finished (Completed)"
             }
 ```
+
+<!-- x-release-please-end-version -->
 
 ## Inputs
 

--- a/actions/setup-argo/README.md
+++ b/actions/setup-argo/README.md
@@ -4,9 +4,13 @@ Setup Argo cli and add it to the PATH, this action will pull the binary from Git
 
 ## Example
 
+<!-- x-release-please-start-version -->
+
 ```
-uses: grafana/shared-workflows/actions/setup-argo@main
+uses: grafana/shared-workflows/actions/setup-argo@setup-argo-v1.0.0
 with:
   version: 3.5.1 # Version of the Argo CLI to install.
 
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/setup-conftest/README.md
+++ b/actions/setup-conftest/README.md
@@ -4,9 +4,13 @@ Setup conftest and add it to the PATH, this action will pull the binary from Git
 
 ## Example
 
+<!-- x-release-please-start-version -->
+
 ```
-uses: grafana/shared-workflows/actions/setup-conftest@main
+uses: grafana/shared-workflows/actions/setup-conftest@setup-conftest-v1.0.0
 with:
   version: 0.55.0 # Version of conftest to install.
 
 ```
+
+<!-- x-release-please-end-version -->

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -54,49 +54,40 @@
   "include-v-in-tag": true,
   "packages": {
     "actions/argo-lint": {
-      "package-name": "argo-lint"
+      "package-name": "argo-lint",
+      "extra-files": ["README.md"]
     },
     "actions/aws-auth": {
-      "package-name": "aws-auth"
+      "package-name": "aws-auth",
+      "extra-files": ["README.md"]
     },
     "actions/build-push-to-dockerhub": {
-      "package-name": "build-push-to-dockerhub"
+      "package-name": "build-push-to-dockerhub",
+      "extra-files": ["README.md"]
     },
     "actions/dockerhub-login": {
-      "package-name": "dockerhub-login"
+      "package-name": "dockerhub-login",
+      "extra-files": ["README.md"]
     },
     "actions/find-pr-for-commit": {
-      "package-name": "find-pr-for-commit"
+      "package-name": "find-pr-for-commit",
+      "extra-files": ["README.md"]
     },
     "actions/generate-openapi-clients": {
-      "package-name": "generate-openapi-clients"
+      "package-name": "generate-openapi-clients",
+      "extra-files": ["README.md"]
     },
     "actions/get-vault-secrets": {
-      "package-name": "get-vault-secrets"
+      "package-name": "get-vault-secrets",
+      "extra-files": ["README.md"]
     },
     "actions/lint-pr-title": {
-      "package-name": "lint-pr-title"
+      "package-name": "lint-pr-title",
+      "extra-files": ["README.md"]
     },
     "actions/login-to-gar": {
-      "package-name": "login-to-gar"
-    },
-    "actions/login-to-gcs": {
-      "package-name": "login-to-gcs"
-    },
-    "actions/push-to-gar-docker": {
-      "package-name": "push-to-gar-docker"
-    },
-    "actions/push-to-gcs": {
-      "package-name": "push-to-gcs"
-    },
-    "actions/send-slack-message": {
-      "package-name": "send-slack-message"
-    },
-    "actions/setup-argo": {
-      "package-name": "setup-argo"
-    },
-    "actions/setup-conftest": {
-      "package-name": "setup-conftest"
+      "package-name": "login-to-gar",
+      "extra-files": ["README.md"]
     }
   },
   "release-type": "simple",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -88,6 +88,30 @@
     "actions/login-to-gar": {
       "package-name": "login-to-gar",
       "extra-files": ["README.md"]
+    },
+    "actions/login-to-gcs": {
+      "package-name": "login-to-gcs",
+      "extra-files": ["README.md"]
+    },
+    "actions/push-to-gar-docker": {
+      "package-name": "push-to-gar-docker",
+      "extra-files": ["README.md"]
+    },
+    "actions/push-to-gcs": {
+      "package-name": "push-to-gcs",
+      "extra-files": ["README.md"]
+    },
+    "actions/send-slack-message": {
+      "package-name": "send-slack-message",
+      "extra-files": ["README.md"]
+    },
+    "actions/setup-argo": {
+      "package-name": "setup-argo",
+      "extra-files": ["README.md"]
+    },
+    "actions/setup-conftest": {
+      "package-name": "setup-conftest",
+      "extra-files": ["README.md"]
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
We need this feature so the README.md guide always contains the latest version of the action.

Currently our workflow READMEs are a bit misleading since we tell people to use `main`, which will cause backwards compatibility issues.

[Working example](https://github.com/grafana/shared-workflows/pull/571/files).