### PR TITLE
fix(lint-shared-workflows): correct tag for shellcheck action

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: raven-actions/actionlint@01fce4f43a270a612932cb1c64d40505a029f821 # v2.0.0
 
       - name: Run ShellCheck on scripts
-        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0
 
   # A separate job so we can run in the `yq` container
   lint-action-yaml:


### PR DESCRIPTION
I noticed

> Could not determine new digest for update (github-tags package ludeeus/action-shellcheck)

in [a recent log][log]. This is because the tag is [`2.0.0`] and not `v2.0.0`.

[`2.0.0`]: https://github.com/ludeeus/action-shellcheck/releases/tag/2.0.0
[log]: https://github.com/grafana/shared-workflows/actions/runs/12050129862/job/33598355724#step:5:123
