### PR TITLE
chore(ci): pin dependencies too

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -16,7 +16,7 @@
   dependencyDashboard: false,
   enabledManagers: ["bun", "custom.regex", "github-actions", "npm"],
   forkProcessing: "enabled",
-  globalExtends: ["config:best-practices"],
+  globalExtends: [":pinDependencies", "config:best-practices"],
   onboarding: false,
   osvVulnerabilityAlerts: true,
   packageRules: [


### PR DESCRIPTION
We're using the default behaviour of pinning only dev dependencies. The effect of this can be seen in 49a4348fb372ec3a866f275ce7a98fb21c2788c5.

Renovate has [an essay][dependency-pinning] discussing this whole area. The [summary] is that for our case, developing an application not a library, it would be more robust to [pin runtime dependencies][pinDependencies] too.

[dependency-pinning]: https://docs.renovatebot.com/dependency-pinning/
[pinDependencies]: https://docs.renovatebot.com/presets-default/#pindependencies
[summary]: https://docs.renovatebot.com/dependency-pinning/#so-whats-best
