### PR TITLE
feat(dependabot-gar-login): create composite action

### DIFF
--- a/actions/dependabot-gar-login/README.md
+++ b/actions/dependabot-gar-login/README.md
@@ -1,0 +1,39 @@
+# Dependabot GAR Login
+
+Updates the token for Google Artifact Registry and sets it as a secret for Dependabot at the repository level.
+
+The token can be refreshed and set to the `DEPENDABOT_GAR_TOKEN` secret every 50 minutes to ensure Dependabot can access Google Artifact Registry without interruptions.
+
+## Example
+
+```yaml
+name: Update Google Artifact Registry Token
+
+on:
+  schedule:
+    # Update every 50 minutes
+    - cron: "*/50 * * * *"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Update Artifact Registry Token
+        uses: ./.github/actions/update-artifact-registry-token
+```
+
+## Configuring Dependabot
+
+To use the secret in your dependabot.yml, add the following configuration:
+
+```yaml
+registries:
+  google-artifact-registry:
+    type: "docker-registry" # Replace with your registry type
+    url: "us-docker.pkg.dev"
+    token: "${{ secrets.DEPENDABOT_GAR_TOKEN }}"
+```

--- a/actions/dependabot-gar-login/action.yaml
+++ b/actions/dependabot-gar-login/action.yaml
@@ -1,0 +1,44 @@
+name: "Update Google Artifact Registry Token"
+description: "Updates the token for Google Artifact Registry and sets it as a secret for Dependabot at the repository level."
+
+runs:
+  using: "composite"
+  steps:
+    - id: get-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@main
+      with:
+        common_secrets: |
+          APP_ID=dependabot-gar-app:app-id
+          PRIVATE_KEY=dependabot-gar-app:private-key
+
+    - name: Construct service account
+      id: construct-service-account
+      shell: sh
+      run: |
+        SERVICE_ACCOUNT="github-${{ github.repository_id }}-prod@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
+
+    - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
+      id: gcloud-auth
+      with:
+        token_format: access_token
+        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        service_account: ${{ steps.construct-service-account.outputs.service_account }}
+        create_credentials_file: false
+
+    - uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+      id: app-token
+      with:
+        app_id: ${{ steps.get-secrets.outputs.APP_ID }}
+        private_key: ${{ steps.get-secrets.outputs.PRIVATE_KEY }}
+
+    - name: Update Repository Secret
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      shell: sh
+      run: |
+        gh secret set DEPENDABOT_GAR_TOKEN \
+          --repo ${{ github.repository }} \
+          --visibility all \
+          --app dependabot \
+          --body "${{ steps.gcloud-auth.outputs.access_token }}"


### PR DESCRIPTION
The dependabot job for updating Docker images in our private registries has been failing.

From the job logs we can see dependabot fails on authenticating to two different repositories that we use as sources.

These failures also seem to make the successfully-queried images not create PRs even though the logs indicate they do.

ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot#storing-credentials-for-dependabot-to-use

This PR suggests creating a shared action that would allow multiple repositories to solve this issue easily by creating a workflow that updates a token for Dependabot safely using OIDC.