### PR TITLE
feat: add workflow to check for non-releasable actions

### DIFF
--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -42,7 +42,6 @@ jobs:
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
       - name: Compare config JSON with directories
-        id: compare-package-lists
         run: |
           package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
           folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -60,7 +60,7 @@ jobs:
           done
 
           if [ -n "$missing_paths" ]; then
-              echo "\nThe following actions are missing from the file paths and thus won't be automatically released:"
+              echo "The following actions are missing from the file paths and thus won't be automatically released:"
               echo -e "$missing_paths"
               echo "Please add them in release-please-config.json!"
               exit 1

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Compare config JSON with directories
         run: |
+          # shellcheck disable=SC2207,SC2028
           package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
           folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
 

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - actions/
       - .github/workflows/check-for-non-releasable-actions.yaml
+      - release-please-config.json
     types:
       - edited
       - opened
@@ -16,6 +17,7 @@ on:
     paths:
       - actions/
       - .github/workflows/check-for-non-releasable-actions.yaml
+      - release-please-config.json
 
 jobs:
   check-for-non-releasable-actions:

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -38,7 +38,14 @@ jobs:
           paths: |
             ./actions
 
+      - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        id: jsonnet-cache
+        with:
+          path: ~/go/bin/jsonnet
+          key: jsonnet
+
       - name: Install jsonnet
+        if: ${{ steps.jsonnet-cache.outputs.cache-hit != 'true' }}
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
       - name: Compare config JSON with directories

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -35,38 +35,28 @@ jobs:
             ./actions
             ./release-please-config.json
 
-      - name: List folders
-        id: list-folders
-        uses: Drafteame/list-folders-action@2138be65c1ec39ea5357a0d47263f330d28b4b02 # v1.0.0
+      - uses: actions/github-script@v7
         with:
-          paths: |
-            ./actions
+          script: |
+            const fs = require('fs/promises');
+            const releasePleaseConfig = JSON.parse(await fs.readFile('release-please-config.json', 'utf-8'));
 
-      - name: Compare config JSON with directories
-        run: |
-          package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
-          folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
+            const configuredPackageNames = new Set(Object.keys(releasePleaseConfig.packages));
+            const packageNames = new Set();
 
-          # shellcheck disable=SC2207
-          # SC2007=prefer mapfile or read -a to split command output (or quote to avoid splitting)
-          folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
+            const folders = await fs.readdir('actions', { withFileTypes: true });
+            for (const folder of folders) {
+              if (folder.isDirectory()) {
+                packageNames.add('actions/' + folder.name);
+              }
+            }
 
-          # initialize a variable to store missing actions
-          missing_paths=""
+            const missingConfigurations = [...packageNames].filter(pkg => !configuredPackageNames.has(pkg));
 
-          for folder in "${folder_paths_array[@]}"; do
-              folder_name=$(echo "$folder" | sed 's/^.\///')
-
-              if ! echo "$folder_name" | grep -qwF "$package_names_from_json"; then
-                  missing_paths+="$folder_name"$'\n'
-              fi
-          done
-
-          if [ -n "$missing_paths" ]; then
-              echo "The following actions are missing from the release-please-config.json file and thus won't be automatically released:"
-              echo -e "$missing_paths"
-              echo "Please add them in release-please-config.json!"
-              exit 1
-          else
-              echo "All actions are releasable!"
-          fi
+            if (missingConfigurations.length > 0) {
+              console.log('The following actions are missing from the release-please-config.json file and thus won\'t be automatically released:');
+              console.log(missingConfigurations.join('\n'));
+              console.log('Please add them in release-please-config.json!');
+            } else {
+              console.log('All actions are releasable!');
+            }

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -62,7 +62,7 @@ jobs:
           done
 
           if [ -n "$missing_paths" ]; then
-              echo "The following actions are missing from the file paths and thus won't be automatically released:"
+              echo "The following actions are missing from the release-please-config.json file and thus won't be automatically released:"
               echo -e "$missing_paths"
               echo "Please add them in release-please-config.json!"
               exit 1

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -47,7 +47,9 @@ jobs:
       - id: compare-package-lists
         run: |
             package_names=$(jq -r '.packages | keys[]' ./release-please-config.json)
-            folder_paths="${{ steps.list-folders.outputs.folders }}"
+            folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
+
+            echo "$folder_paths"
 
             folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
 

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - actions/
+      - .github/workflows/check-for-non-releasable-actions.yaml
     types:
       - edited
       - opened
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - actions/
+      - .github/workflows/check-for-non-releasable-actions.yaml
 
 jobs:
   check-for-non-releasable-actions:

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -43,10 +43,10 @@ jobs:
 
       - name: Compare config JSON with directories
         run: |
-          # shellcheck disable=SC2207,SC2028
           package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
           folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
 
+          # shellcheck disable=SC2207
           folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
 
           # initialize a variable to store missing actions

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -46,10 +46,8 @@ jobs:
 
       - id: compare-package-lists
         run: |
-            package_names=$(jq -r '.packages | keys[]' ./release-please-config.json)
+            package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
             folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
-
-            echo "$folder_paths"
 
             folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
 
@@ -59,17 +57,15 @@ jobs:
             for folder in "${folder_paths_array[@]}"; do
                 folder_name=$(echo "$folder" | sed 's/^.\///')
 
-                echo "checking folder: $folder"
-
-                if ! echo "$folder_name" | grep -qwF "$package_names"; then
+                if ! echo "$folder_name" | grep -qwF "$package_names_from_json"; then
                     missing_paths+="$folder_name"$'\n'
                 fi
             done
 
             if [ -n "$missing_paths" ]; then
-                echo "The following actions are missing from the file paths and thus won't be automatically released:"
+                echo "\nThe following actions are missing from the file paths and thus won't be automatically released:"
                 echo -e "$missing_paths"
-                echo "Please add them in release-please-config.json."
+                echo "Please add them in release-please-config.json!"
                 exit 1
             else
                 echo "All actions are present in the file paths."

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -35,7 +35,8 @@ jobs:
             ./actions
             ./release-please-config.json
 
-      - uses: actions/github-script@v7
+      - name: Check for non-releasable actions
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs/promises');

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -1,0 +1,77 @@
+name: Check for non-releasable actions
+on:
+  pull_request:
+    paths:
+      - actions/
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  push:
+    branches:
+      - main
+    paths:
+      - actions/
+
+jobs:
+  check-for-non-releasable-actions:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+            sparse-checkout: |
+                ./actions
+                ./release-please-config.json
+
+      - id: list-folders
+        uses: Drafteame/list-folders-action@2138be65c1ec39ea5357a0d47263f330d28b4b02 # v1.0.0
+        with:
+          paths: |
+            ./actions
+    
+      - name: Install jsonnet
+        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
+
+      - id: print-folders
+        run: |
+            echo ${{ steps.list-folders.outputs.folders }}
+
+      - id: compare-package-lists
+        run: |
+            package_names=$(jq -r '.packages | keys[]' ./release-please-config.json)
+            folder_paths="${{ steps.list-folders.outputs.folders }}"
+
+            folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
+
+            # initialize a variable to store missing actions
+            missing_paths=""
+
+            for folder in "${folder_paths_array[@]}"; do
+                folder_name=$(echo "$folder" | sed 's/^.\///')
+
+                echo "checking folder: $folder"
+
+                if ! echo "$folder_name" | grep -qwF "$package_names"; then
+                    missing_paths+="$folder_name"$'\n'
+                fi
+            done
+
+            if [ -n "$missing_paths" ]; then
+                echo "The following actions are missing from the file paths and thus won't be automatically released:"
+                echo -e "$missing_paths"
+                echo "Please add them in release-please-config.json."
+                exit 1
+            else
+                echo "All actions are present in the file paths."
+            fi
+
+
+     

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -38,16 +38,6 @@ jobs:
           paths: |
             ./actions
 
-      - uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        id: jsonnet-cache
-        with:
-          path: ~/go/bin/jsonnet
-          key: jsonnet
-
-      - name: Install jsonnet
-        if: ${{ steps.jsonnet-cache.outputs.cache-hit != 'true' }}
-        run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
-
       - name: Compare config JSON with directories
         run: |
           package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -31,7 +31,8 @@ jobs:
                 ./actions
                 ./release-please-config.json
 
-      - id: list-folders
+      - name: List folders
+        id: list-folders
         uses: Drafteame/list-folders-action@2138be65c1ec39ea5357a0d47263f330d28b4b02 # v1.0.0
         with:
           paths: |
@@ -40,11 +41,8 @@ jobs:
       - name: Install jsonnet
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
-      - id: print-folders
-        run: |
-            echo ${{ steps.list-folders.outputs.folders }}
-
-      - id: compare-package-lists
+      - name: Compare config JSON with directories
+        id: compare-package-lists
         run: |
             package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
             folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
@@ -68,7 +66,7 @@ jobs:
                 echo "Please add them in release-please-config.json!"
                 exit 1
             else
-                echo "All actions are present in the file paths."
+                echo "All actions are releasable!"
             fi
 
 

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -47,6 +47,7 @@ jobs:
           folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
 
           # shellcheck disable=SC2207
+          # SC2007=prefer mapfile or read -a to split command output (or quote to avoid splitting)
           folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
 
           # initialize a variable to store missing actions

--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -27,9 +27,9 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-            sparse-checkout: |
-                ./actions
-                ./release-please-config.json
+          sparse-checkout: |
+            ./actions
+            ./release-please-config.json
 
       - name: List folders
         id: list-folders
@@ -37,37 +37,34 @@ jobs:
         with:
           paths: |
             ./actions
-    
+
       - name: Install jsonnet
         run: go install github.com/google/go-jsonnet/cmd/jsonnet@latest
 
       - name: Compare config JSON with directories
         id: compare-package-lists
         run: |
-            package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
-            folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
+          package_names_from_json=$(jq -r '.packages | keys[]' ./release-please-config.json)
+          folder_paths="${{ toJSON(steps.list-folders.outputs.folders) }}"
 
-            folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
+          folder_paths_array=($(echo "$folder_paths" | jq -r '.[]'))
 
-            # initialize a variable to store missing actions
-            missing_paths=""
+          # initialize a variable to store missing actions
+          missing_paths=""
 
-            for folder in "${folder_paths_array[@]}"; do
-                folder_name=$(echo "$folder" | sed 's/^.\///')
+          for folder in "${folder_paths_array[@]}"; do
+              folder_name=$(echo "$folder" | sed 's/^.\///')
 
-                if ! echo "$folder_name" | grep -qwF "$package_names_from_json"; then
-                    missing_paths+="$folder_name"$'\n'
-                fi
-            done
+              if ! echo "$folder_name" | grep -qwF "$package_names_from_json"; then
+                  missing_paths+="$folder_name"$'\n'
+              fi
+          done
 
-            if [ -n "$missing_paths" ]; then
-                echo "\nThe following actions are missing from the file paths and thus won't be automatically released:"
-                echo -e "$missing_paths"
-                echo "Please add them in release-please-config.json!"
-                exit 1
-            else
-                echo "All actions are releasable!"
-            fi
-
-
-     
+          if [ -n "$missing_paths" ]; then
+              echo "\nThe following actions are missing from the file paths and thus won't be automatically released:"
+              echo -e "$missing_paths"
+              echo "Please add them in release-please-config.json!"
+              exit 1
+          else
+              echo "All actions are releasable!"
+          fi

--- a/actions/syft-sbom-report/README.md
+++ b/actions/syft-sbom-report/README.md
@@ -4,6 +4,8 @@ Generate an SPDX SBOM Report and attached to Release Artifcats on Release Publis
 
 Example workflow:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: syft-sbom-ci
 on:
@@ -17,7 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Anchore SBOM Action
-        uses: anchore/sbom-action@v0.15.10
+        uses: grafana/shared-workflows/actions@syft-sbom-v0.0.1
         with:
           artifact-name: ${{ github.event.repository.name }}-spdx.json
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/techdocs-rewrite-relative-links/README.md
+++ b/actions/techdocs-rewrite-relative-links/README.md
@@ -23,13 +23,15 @@ Then this link inside the file will be changed to ...
 [outside link](https://github.com/grafana/reponame/blob/main/README.md)
 ```
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 - id: checkout-shared-workflows
   name: Checkout shared workflows
   uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
   with:
     repository: grafana/shared-workflows
-    ref: main
+    ref: techdocs-rewrite-relative-links-v0.0.1
     path: _shared-workflows
 
 - name: Rewrite relative links
@@ -44,6 +46,8 @@ Then this link inside the file will be changed to ...
     checkout-action-repository: true
     checkout-action-repository-path: _shared-workflows
 ```
+
+<!-- x-release-please-end-version -->
 
 Follow that up with the actions that should publish the docs to EngHub. See [the `publish-techdocs.yaml` workflow](https://github.com/grafana/shared-workflows/blob/main/.github/workflows/publish-techdocs.yaml) for details.
 

--- a/actions/trigger-argo-workflow/README.md
+++ b/actions/trigger-argo-workflow/README.md
@@ -37,10 +37,12 @@ parameters: |
 
 Here is an example of how to use this action:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 steps:
   - name: Trigger Argo Workflow
-uses: actions/trigger-argo-workflow@main
+uses: grafana/shared-workflows/actions/trigger-argo-workflow@trigger-argo-workflow-v0.0.1
 with:
   instance: "ops"
   namespace: "mynamespace"
@@ -50,3 +52,5 @@ with:
   extra_args: "--generate-name hello-world-"
   log_level: "debug"
 ```
+
+<!-- x-release-please-end-version -->

--- a/actions/validate-policy-bot-config/README.md
+++ b/actions/validate-policy-bot-config/README.md
@@ -9,6 +9,8 @@ See [https://github.com/palantir/policy-bot?tab=readme-ov-file#configuration](Po
 
 Example workflow:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: validate-policy-bot
 on:
@@ -25,5 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Validate Policy Bot configuration
-        uses: grafana/shared-workflows/actions/validate-policy-bot-config@main
+        uses: grafana/shared-workflows/actions/validate-policy-bot-config@validate-policy-bot-config-v0.0.1
 ```
+
+<!-- x-release-please-end-version -->

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -112,6 +112,22 @@
     "actions/setup-conftest": {
       "package-name": "setup-conftest",
       "extra-files": ["README.md"]
+    },
+    "actions/syft-sbom-report": {
+      "package-name": "syft-sbom-report",
+      "extra-files": ["README.md"]
+    },
+    "actions/techdocs-rewrite-relative-links": {
+      "package-name": "techdocs-rewrite-relative-links",
+      "extra-files": ["README.md"]
+    },
+    "actions/trigger-argo-workflow": {
+      "package-name": "trigger-argo-workflow",
+      "extra-files": ["README.md"]
+    },
+    "actions/validate-policy-bot-config": {
+      "package-name": "validate-policy-bot-config",
+      "extra-files": ["README.md"]
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
We need to ensure that all of our actions in this repositories are releasable. We are adding this check so when we create a new action it will fail if it cannot be released. 

Part of: https://github.com/grafana/shared-workflows/issues/574

Example of missing actions here: https://github.com/grafana/shared-workflows/actions/runs/12073279306/job/33669061564#step:6:29

Example of successful workflow after the missing actions have been added: https://github.com/grafana/shared-workflows/actions/runs/12073454603/job/33669584061#step:6:30

Example of successful workflow with cache enabled: https://github.com/grafana/shared-workflows/actions/runs/12082633004/job/33694117294