### PR TITLE
fix: make check-for-non-releasable-actions action run on any actions/ change

### DIFF
--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -2,7 +2,7 @@ name: Check for non-releasable actions
 on:
   pull_request:
     paths:
-      - actions/
+      - actions/**
       - .github/workflows/check-for-non-releasable-actions.yaml
       - release-please-config.json
     types:
@@ -15,7 +15,7 @@ on:
     branches:
       - main
     paths:
-      - actions/
+      - actions/**
       - .github/workflows/check-for-non-releasable-actions.yaml
       - release-please-config.json
 


### PR DESCRIPTION
After https://github.com/grafana/shared-workflows/pull/588 got merged, I realized that the action wasn't triggered in the automated release-please PRs, even if the CHANGELOG changes, which lives in `actions/` directory.

This PR should fix the issue, by adding the double-start glob pattern.