### PR TITLE
fix: remove path triggers

### DIFF
--- a/.github/workflows/check-for-non-releasable-actions.yaml
+++ b/.github/workflows/check-for-non-releasable-actions.yaml
@@ -1,10 +1,6 @@
 name: Check for non-releasable actions
 on:
   pull_request:
-    paths:
-      - actions/
-      - .github/workflows/check-for-non-releasable-actions.yaml
-      - release-please-config.json
     types:
       - edited
       - opened
@@ -14,10 +10,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - actions/
-      - .github/workflows/check-for-non-releasable-actions.yaml
-      - release-please-config.json
 
 jobs:
   check-for-non-releasable-actions:


### PR DESCRIPTION
As per [this comment](https://github.com/grafana/shared-workflows/pull/593#issuecomment-2508195262), it'd be better to just remove the paths and let the `check-for-non-releasable-actions.yaml` action run on every event.