### PR TITLE
feat: introduce setup-crossplane action

### DIFF
--- a/.github/workflows/test-setup-crossplane.yml
+++ b/.github/workflows/test-setup-crossplane.yml
@@ -60,4 +60,4 @@ jobs:
           exit 1
 
       - name: Check Crossplane CLI works
-        run: crossplane version
+        run: crossplane -h

--- a/.github/workflows/test-setup-crossplane.yml
+++ b/.github/workflows/test-setup-crossplane.yml
@@ -1,0 +1,63 @@
+name: Test Setup Crossplane
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/setup-crossplane/**
+      - .github/workflows/test-setup-crossplane.yml
+
+  pull_request:
+    branches:
+      - main
+    paths:
+      - actions/setup-crossplane/**
+      - .github/workflows/test-setup-crossplane.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  merge_group:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  setup-crossplane:
+    runs-on: ubuntu-latest
+    env:
+      # generate a unique cache prefix for each test run, so we can test cache behaviour
+      CACHE_PREFIX: crossplane-${{ github.run_id }}-${{ github.run_attempt }}
+
+    strategy:
+      matrix:
+        cache-hit: [false, true]
+      max-parallel: 1
+
+    name: "Setup Crossplane (cache hit: ${{ matrix.cache-hit }})"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            actions/setup-crossplane
+
+      - name: "Setup Crossplane (cache: ${{ matrix.cache-hit }})"
+        id: setup-crossplane
+        uses: ./actions/setup-crossplane
+        with:
+          cache-prefix: ${{ env.CACHE_PREFIX }}
+          version: v1.18.1
+
+      - name: Assert cache
+        if: fromJson(steps.setup-crossplane.outputs.cache-hit) != matrix.cache-hit
+        run: |
+          echo "Expected cache hit: '${{ matrix.cache-hit }}' but got '${{ fromJson(steps.setup-crossplane.outputs.cache-hit) }}'"
+          exit 1
+
+      - name: Check Crossplane CLI works
+        run: crossplane version

--- a/actions/setup-crossplane/README.md
+++ b/actions/setup-crossplane/README.md
@@ -1,0 +1,16 @@
+# Setup Crossplane
+
+Setup Crossplane cli and add it to the PATH, this action will run the install bash script and store the binary in cache for the next run.
+
+## Example
+
+<!-- x-release-please-start-version -->
+
+```
+uses: grafana/shared-workflows/actions/setup-crossplane@setup-crossplane-v1.0.0
+with:
+  version: v1.18.1 # Version of the Crossplane CLI to install.
+
+```
+
+<!-- x-release-please-end-version -->

--- a/actions/setup-crossplane/action.yaml
+++ b/actions/setup-crossplane/action.yaml
@@ -1,0 +1,60 @@
+name: Setup Crossplane
+description: Setup Crossplane cli and add it to the PATH, this action will run the install bash script and store the binary in cache for the next run.
+
+inputs:
+  cache-prefix:
+    description: Prefix for the cache key.
+    default: crossplane
+
+  version:
+    description: |
+      Version of the Crossplane CLI to install.
+    default: v1.18.1
+
+  channel:
+    description: |
+      Channel of the Crossplane CLI to install.
+    default: stable
+
+outputs:
+  cache-hit:
+    description: Whether the cache was hit or not.
+    value: ${{ steps.cache.outputs.cache-hit || 'false' }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup cache
+      id: cache
+      uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+      with:
+        path: ${{ github.workspace }}/bin/crossplane
+        key: ${{ inputs.cache-prefix }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}
+
+    - run: "curl -sL https://raw.githubusercontent.com/crossplane/crossplane/master/install.sh | sh"
+      id: install
+      shell: bash
+      env:
+        XP_VERSION: ${{ inputs.version }}
+        XP_CHANNEL: ${{ inputs.channel }}
+
+    - name: move binary
+      id: move
+      if: steps.install.outcome == 'success'
+      shell: sh
+      run: |
+        mkdir -p ${{ github.workspace }}/bin
+        mv ./crossplane ${{ github.workspace }}/bin/crossplane
+
+    - name: Add binary to path
+      shell: sh
+      run: |
+        # Check if `crossplane` is already in the PATH
+        if command -v crossplane >/dev/null; then
+          echo "crossplane is already in the PATH, not re-adding it"
+          exit 0
+        fi
+
+        echo "Adding '${{ github.workspace }}/bin' to the PATH so the 'crossplane' binary can be found"
+        echo "${{ github.workspace }}/bin" >> "${GITHUB_PATH}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -113,6 +113,10 @@
       "package-name": "setup-conftest",
       "extra-files": ["README.md"]
     },
+    "actions/setup-crossplane": {
+      "package-name": "setup-crossplane",
+      "extra-files": ["README.md"]
+    },
     "actions/syft-sbom-report": {
       "package-name": "syft-sbom-report",
       "extra-files": ["README.md"]


### PR DESCRIPTION
Based on https://github.com/crossplane-contrib/xpkg-action which looks poorly maintained.

I'm using this action in https://github.com/grafana/grafana-crossplane-libsonnet to push Configuration packages to OCI repos (GHCR, Upbound Marketplace).
