### PR TITLE
chore(renovate): use upstream `customManagers:githubActionsVersions` instead of our own

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -1,22 +1,14 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   branchPrefix: "grafanarenovatebot/",
-  customManagers: [
-    {
-      customType: "regex",
-      fileMatch: [
-        "(?:^|/)\\.github/(?:workflows|actions)/.+\\.ya?ml$",
-        "(?:^|/)action\\.ya?ml$",
-      ],
-      matchStrings: [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_-]+?[_-](?:VERSION|version)\\s*:\\s*[\"']?(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
-      ],
-    },
-  ],
   dependencyDashboard: false,
   enabledManagers: ["bun", "custom.regex", "github-actions", "npm"],
   forkProcessing: "enabled",
-  globalExtends: [":pinDependencies", "config:best-practices"],
+  globalExtends: [
+    ":pinDependencies",
+    "config:best-practices",
+    "customManagers:githubActionsVersions",
+  ],
   onboarding: false,
   osvVulnerabilityAlerts: true,
   packageRules: [
@@ -38,7 +30,9 @@
       matchUpdateTypes: ["digest"],
     },
     {
-      // Run the custom matcher on early Monday mornings (UTC)
+      // Update the Renovate version being used early Monday mornings (UTC). We
+      // have a special case for this as Renovate uses CD and otherwise there
+      // are too many updates.
       schedule: "* 0-4 * * 1",
       matchPackageNames: ["ghcr.io/renovatebot/renovate"],
     },

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -62,11 +62,6 @@ jobs:
 
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@e3a862510f27d57a380efb11f0b52ad7e8dbf213 # v41.0.6
-        with:
-          configurationFile: .github/renovate-config.json5
-          # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
-          renovate-version: 39.57.4@sha256:a1f28f4eba3589d4cf7228f82ba1bdcec42947407f9379d719c0f8a581c564f9
-          token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}
           # For pull requests, this means we'll get the dependencies of the PR's
@@ -78,3 +73,9 @@ jobs:
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: GrafanaRenovateBot
+          # renovate: datasource=docker depName=ghcr.io/renovatebot/renovate
+          RENOVATE_VERSION: 39.57.4@sha256:a1f28f4eba3589d4cf7228f82ba1bdcec42947407f9379d719c0f8a581c564f9
+        with:
+          configurationFile: .github/renovate-config.json5
+          renovate-version: ${{ env.RENOVATE_VERSION }}
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
I just discovered that Renovate has [a built-in `githubActionsVersions` manager][manager] which is almost the same as the one we've been maintaining. Let's switch to that and remove our own. The main difference is that we supported `_VERSION` and `-version`-style variables and theirs only supports the former. But it's not hard for us to switch in the only case we use the matcher.

[manager]: https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
