### PR TITLE
fix(techdocs-rewrite-relative-links): run `go mod tidy`

### DIFF
--- a/actions/techdocs-rewrite-relative-links/go.mod
+++ b/actions/techdocs-rewrite-relative-links/go.mod
@@ -1,7 +1,6 @@
 module github.com/grafana/shared-workflows/actions/techdocs-rewrite-relative-links
 
-go 1.22.2
-toolchain go1.23.4
+go 1.23.4
 
 require (
 	github.com/aymanbagabas/go-udiff v0.2.0


### PR DESCRIPTION
The last commit broke `techdocs-rewrite-relative-links`, leaving it in a state where it needs `go mod tidy`ing. Here we do that.

```
go: updates to go.mod needed; to update it:
	go mod tidy

```
