### PR TITLE
feat(publish-techdocs): add github-admonitions plugin

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -121,11 +121,19 @@ jobs:
 
       # Pinning until resolved https://github.com/backstage/backstage/issues/25303
       - name: Install mkdocs and mkdocs plugins
-        run: python -m pip install mkdocs-techdocs-core==1.3.5
+        run: python -m pip install mkdocs-techdocs-core==1.3.5 mkdocs-github-admonitions-plugin==0.0.3
 
       - name: Generate docs site
         run: techdocs-cli generate --no-docker --verbose
         working-directory: ${{ inputs.default-working-directory }}
+
+      # Create an artifact out of the generated documentation so that it can be
+      # debugged if necessary:
+      - name: Create docs artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: site
+          path: site
 
       - name: Publish docs site
         if: inputs.publish


### PR DESCRIPTION
This also saves the generated HTML as an artifact so that it can be more easily debugged.