### PR TITLE
docs: update instructions after slack action v2 update

### DIFF
--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -46,6 +46,7 @@ jobs:
             {
               "channel": ${{ steps.slack.outputs.channel_id }},
               "text": "Deployment finished (Completed)",
+              "ts": ${{ steps.slack.outputs.ts }},
               "attachments": [
                 {
                   "pretext": "Deployment finished",
@@ -60,7 +61,6 @@ jobs:
                 }
               ]
             }
-          update-ts: ${{ steps.slack.outputs.ts }}
 ```
 
 ```yaml

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -73,7 +73,7 @@ jobs:
         id: slack
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          method: chat.postMessage 
+          method: chat.postMessage
           payload: |
             {
               "channel": "Channel ID",
@@ -82,7 +82,7 @@ jobs:
       - name: Respond to Slack Message
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          method: chat.postMessage 
+          method: chat.postMessage
           payload-templated: true
           payload: |
             {
@@ -96,12 +96,12 @@ jobs:
 
 ## Inputs
 
-| Name            | Type   | Description                                                                               |
-| --------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `payload`       | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                     |             |
-| `method`     | String | The Slack API method to call. |
-| `payload-templated`     | String | The Slack API method to call. |
-| `update-ts`     | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
+| Name                | Type   | Description                                                                                                                                        |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                                                                              |     |
+| `method`            | String | The Slack API method to call.                                                                                                                      |
+| `payload-templated` | String | The Slack API method to call.                                                                                                                      |
+| `update-ts`         | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
 
 ## Outputs
 

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -8,27 +8,6 @@ See the docs for the [slackapi/slack-github-action workflow](https://github.com/
 <!-- x-release-please-start-version -->
 
 ```yaml
-name: Send And Update a Slack plain text message
-jobs:
-  send-and-update-slack-message:
-    name: Send and update Slack message
-    steps:
-      - name: Send Slack Message
-        id: slack
-        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
-        with:
-          channel-id: "Channel Name or ID"
-          slack-message: "We are testing, testing, testing all day long"
-
-      - name: Update Slack Message
-        uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
-        with:
-          channel-id: ${{ steps.slack.outputs.channel_id }} # Channel ID is required when updating a message
-          slack-message: "This is the updated message"
-          update-ts: ${{ steps.slack.outputs.ts }}
-```
-
-```yaml
 name: Send And Update a Slack message using JSON payload
 jobs:
   send-and-update-slack-message:
@@ -38,9 +17,10 @@ jobs:
         id: slack
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          channel-id: "Channel Name or ID"
+          method: chat.postMessage
           payload: |
             {
+              "channel": "Channel ID",
               "text": "Deployment started (In Progress)",
               "attachments": [
                 {
@@ -60,9 +40,11 @@ jobs:
       - name: Update Slack Message via Payload
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          channel-id: ${{ steps.slack.outputs.channel_id }}
+          method: post.update
+          payload-templated: true
           payload: |
             {
+              "channel": ${{ steps.slack.outputs.channel_id }},
               "text": "Deployment finished (Completed)",
               "attachments": [
                 {
@@ -78,7 +60,6 @@ jobs:
                 }
               ]
             }
-
           update-ts: ${{ steps.slack.outputs.ts }}
 ```
 
@@ -92,17 +73,20 @@ jobs:
         id: slack
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          channel-id: "Channel Name or ID"
+          method: chat.postMessage 
           payload: |
             {
+              "channel": "Channel ID",
               "text": "Deployment started (In Progress)"
             }
       - name: Respond to Slack Message
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          channel-id: ${{ steps.slack.outputs.channel_id }}
+          method: chat.postMessage 
+          payload-templated: true
           payload: |
             {
+              "channel": "Channel ID",
               "thread_ts": "${{ steps.slack.outputs.ts }}",
               "text": "Deployment finished (Completed)"
             }
@@ -114,10 +98,10 @@ jobs:
 
 | Name            | Type   | Description                                                                               |
 | --------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `channel-id`    | String | Name or ID of the channel to send to.                                                     |
-| `payload`       | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                     |
-| `slack-message` | String | Plain text message to send. Use `payload` or `slack-message`, but not both.               |
-| `update-ts`     | String | The timestamp of a previous message posted. Used to update or reply to previous messages. |
+| `payload`       | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                     |             |
+| `method`     | String | The Slack API method to call. |
+| `payload-templated`     | String | The Slack API method to call. |
+| `update-ts`     | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
 
 ## Outputs
 

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -96,12 +96,12 @@ jobs:
 
 ## Inputs
 
-| Name                | Type   | Description                                                                 |
-| ------------------- | ------ | --------------------------------------------------------------------------- |
-| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.       |
-| `method`            | String | The Slack API method to call.                                               |
+| Name                | Type   | Description                                                                                                                                        |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                                                                              |
+| `method`            | String | The Slack API method to call.                                                                                                                      |
 | `payload-templated` | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
-| `update-ts`         | String | The timestamp of the message to update.                                      |
+| `update-ts`         | String | The timestamp of the message to update.                                                                                                            |
 
 ## Outputs
 

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -101,7 +101,6 @@ jobs:
 | `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                                                                              |
 | `method`            | String | The Slack API method to call.                                                                                                                      |
 | `payload-templated` | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
-| `update-ts`         | String | The timestamp of the message to update.                                                                                                            |
 
 ## Outputs
 

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -40,7 +40,7 @@ jobs:
       - name: Update Slack Message via Payload
         uses: grafana/shared-workflows/actions/send-slack-message@send-slack-message-v2.0.0
         with:
-          method: post.update
+          method: chat.update
           payload-templated: true
           payload: |
             {

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -96,12 +96,12 @@ jobs:
 
 ## Inputs
 
-| Name                | Type   | Description                                                                                                                                        |
-| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
-| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                                                                              |     |
-| `method`            | String | The Slack API method to call.                                                                                                                      |
-| `payload-templated` | String | The Slack API method to call.                                                                                                                      |
-| `update-ts`         | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
+| Name                | Type   | Description                                                                 |
+| ------------------- | ------ | --------------------------------------------------------------------------- |
+| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.       |
+| `method`            | String | The Slack API method to call.                                               |
+| `payload-templated` | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
+| `update-ts`         | String | The timestamp of the message to update.                                      |
 
 ## Outputs
 

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -41,7 +41,7 @@ runs:
       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
         payload-templated: ${{ inputs.payload-templated }}
-        method: chat.postMessage
+        method: ${{ inputs.method }}
         payload: ${{ inputs.payload }}
         update-ts: ${{ inputs.update-ts }}
         token: ${{ env.SLACK_BOT_TOKEN }}

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -2,17 +2,17 @@ name: Send Slack Message
 description: Composite action to send a Slack message
 
 inputs:
-  channel-id:
-    description: "Name or ID of the channel to send to"
-    required: true
   payload:
     description: "JSON payload to send. Use `payload` or `slack-message`, but not both"
     required: false
-  slack-message:
-    description: "Plain text message to send. Use `payload` or `slack-message`, but not both"
-    required: false
   update-ts:
     description: "The timestamp of a previous message posted. Used to update or reply to existing messages"
+    required: false
+  method:
+    description: "The Slack API method to call"
+    required: true
+  payload-templated:
+    description: "To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true"
     required: false
 outputs:
   time:
@@ -40,9 +40,8 @@ runs:
       id: send-slack-message
       uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
       with:
+        payload-templated: ${{ inputs.payload-templated }}
         method: chat.postMessage
-        channel: ${{ inputs.channel-id }}
         payload: ${{ inputs.payload }}
-        slack-message: ${{ inputs.slack-message }}
         update-ts: ${{ inputs.update-ts }}
         token: ${{ env.SLACK_BOT_TOKEN }}

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -5,9 +5,6 @@ inputs:
   payload:
     description: "JSON payload to send. Use `payload` or `slack-message`, but not both"
     required: false
-  update-ts:
-    description: "The timestamp of a previous message posted. Used to update or reply to existing messages"
-    required: false
   method:
     description: "The Slack API method to call"
     required: true
@@ -43,5 +40,4 @@ runs:
         payload-templated: ${{ inputs.payload-templated }}
         method: ${{ inputs.method }}
         payload: ${{ inputs.payload }}
-        update-ts: ${{ inputs.update-ts }}
         token: ${{ env.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Update instructions based on: https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0