### PR TITLE
fix: login to GAR only on push events

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -132,6 +132,7 @@ runs:
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
 
     - name: Login to GAR
+      if: ${{ inputs.push == 'true' }}
       uses: ./shared-workflows/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}


### PR DESCRIPTION
Uses login-to-gar action only on push events, to allow PRs that come from forks to at least be able to build docker images on PRs.