### PR TITLE
feat(drone-sig): add check for fork

### DIFF
--- a/.github/workflows/check-drone-signature.yaml
+++ b/.github/workflows/check-drone-signature.yaml
@@ -13,11 +13,47 @@ on:
         default: "https://drone.grafana.net"
 
 jobs:
+  # This job checks if we should run the drone signature check.
+  # If the repository is under the "grafana" org, we will run the signature check.
+  # If the repository is a fork, we will skip the signature check, as secrets
+  # needed for the validation are not available in forked repos.
+  check-fork:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    outputs:
+      isFork: ${{ steps.check-if-fork.outputs.isFork }}
+    steps:
+      - name: Check if forked repository
+        id: check-if-fork
+        run: |
+          REPO_FULLNAME="${{ github.repository }}"
+          REPO_OWNER="${REPO_FULLNAME%/*}"
+
+          if [ "$REPO_OWNER" = "${{ github.repository_owner }}" ]; then
+            echo "isFork=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "isFork=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Post PR message about fork
+        if: steps.check-if-fork.outputs.isFork == true && github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Skipping Drone CI config signature check, as this is a forked repository. A user with the proper repo permissions will need to sign the Drone CI configuration file.'
+            })
+
   check-drone-signature:
     permissions:
       contents: read
       id-token: write
     runs-on: ubuntu-latest
+    needs: check-fork
+    if: needs.check-fork.outputs.isFork == 'false'
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Since this reusable workflow is used by OSS projects, we need to be aware if we're dealing with a fork or not, especially when it comes to PRs. If we're on a fork, we don't have access to the secret needed to run the drone ci config signature validation. In this case, we post a comment to the PR saying we're skipping the check and someone with proper repo persmissions needs to check/sign the drone ci config changes.