### PR TITLE
feat: add `custom-service-account` input to `*-to-gcs` actions

### DIFF
--- a/actions/login-to-gcs/README.md
+++ b/actions/login-to-gcs/README.md
@@ -39,10 +39,11 @@ $ gcloud storage cp OBJECT_LOCATION gs://DESTINATION_BUCKET_NAME
 
 ## Inputs
 
-| Name          | Type   | Description                                                                                |
-| ------------- | ------ | ------------------------------------------------------------------------------------------ |
-| `bucket`      | String | Name of bucket to upload to. Will default to grafanalabs-${repository.name}-${environment} |
-| `environment` | String | Environment for pushing artifacts (can be either dev or prod).                             |
+| Name                     | Type   | Description                                                                                |
+| ------------------------ | ------ | ------------------------------------------------------------------------------------------ |
+| `bucket`                 | String | Name of bucket to upload to. Will default to grafanalabs-${repository.name}-${environment} |
+| `environment`            | String | Environment for pushing artifacts (can be either dev or prod).                             |
+| `custom_service_account` | String | Custom service account to use for authentication.                                          |
 
 ## Outputs
 

--- a/actions/login-to-gcs/action.yaml
+++ b/actions/login-to-gcs/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: |
       Environment for uploading objects (can be either dev or prod).
     default: dev
+  custom_service_account:
+    description: |
+      Custom service account to use for authentication.
+    default: ""
 
 outputs:
   bucket:
@@ -48,7 +52,11 @@ runs:
         echo "bucket=${BUCKET}" | tee -a ${GITHUB_OUTPUT}
 
         # Construct service account
-        SERVICE_ACCOUNT="github-${{ github.repository_id }}-${{ inputs.environment }}-gcs@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        if [[ "${{ inputs.custom_service_account }}" == "" ]]; then
+          SERVICE_ACCOUNT="github-${{ github.repository_id }}-${{ inputs.environment }}-gcs@grafanalabs-workload-identity.iam.gserviceaccount.com"
+        else
+          SERVICE_ACCOUNT="${{ inputs.custom_service_account }}"
+        fi
         echo "service_account=${SERVICE_ACCOUNT}" | tee -a ${GITHUB_OUTPUT}
     - uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f # v2.1.7
       id: gcloud-auth

--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -113,15 +113,16 @@ jobs:
 
 ## Inputs
 
-| Name            | Type   | Description                                                                                                                                                                                  |
-| --------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bucket`        | String | (Required) Name of bucket to upload to. Can be gathered from `login-to-gcs` action.                                                                                                          |
-| `path`          | String | (Required) The path to a file or folder inside the action's filesystem that should be uploaded to the bucket. You can specify either the absolute path or the relative path from the action. |
-| `bucket_path`   | String | Bucket path where objects will be uploaded. Default is the bucket root.                                                                                                                      |
-| `environment`   | String | Environment for pushing artifacts (can be either dev or prod).                                                                                                                               |
-| `glob`          | String | Glob pattern.                                                                                                                                                                                |
-| `parent`        | String | Whether parent dir should be included in GCS destination. Dirs included in the `glob` statement are unaffected by this setting.                                                              |
-| `predefinedAcl` | String | Predefined ACL applied to the uploaded objects. Default is `projectPrivate`. See [Google Documentation][gcs-docs-upload-options] for a list of available options.                            |
+| Name                     | Type   | Description                                                                                                                                                                                  |
+| ------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bucket`                 | String | (Required) Name of bucket to upload to. Can be gathered from `login-to-gcs` action.                                                                                                          |
+| `path`                   | String | (Required) The path to a file or folder inside the action's filesystem that should be uploaded to the bucket. You can specify either the absolute path or the relative path from the action. |
+| `bucket_path`            | String | Bucket path where objects will be uploaded. Default is the bucket root.                                                                                                                      |
+| `environment`            | String | Environment for pushing artifacts (can be either dev or prod).                                                                                                                               |
+| `custom_service_account` | String | Custom service account to use for authentication. Used only when bucket input is not empty                                                                                                   |
+| `glob`                   | String | Glob pattern.                                                                                                                                                                                |
+| `parent`                 | String | Whether parent dir should be included in GCS destination. Dirs included in the `glob` statement are unaffected by this setting.                                                              |
+| `predefinedAcl`          | String | Predefined ACL applied to the uploaded objects. Default is `projectPrivate`. See [Google Documentation][gcs-docs-upload-options] for a list of available options.                            |
 
 ## Outputs
 

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -32,6 +32,10 @@ inputs:
       Apply a predefined set of access controls to the file(s).
       Default is projectPrivate (See https://googleapis.dev/nodejs/storage/latest/global.html#UploadOptions)
     default: projectPrivate
+  custom_service_account:
+    description: |
+      Custom service account to use for authentication.
+    default: ""
 
 outputs:
   uploaded:
@@ -69,6 +73,7 @@ runs:
       with:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}
+        custom-service-account: ${{ inputs.bucket && inputs.custom-service-account || '' }}
     - name: Construct path
       id: construct-path
       shell: bash


### PR DESCRIPTION
Adds `custom-service-account` input to `*-to-gcs` actions in case we need to login with a different service account rather than the one generated from tf code. This only works if a bucket is different than the default.

Here's a breakdown of how it works:
```
1. ${{ inputs.bucket && inputs.custom-service-account }}:

This part checks if inputs.bucket is not empty or null.
* If inputs.bucket is not empty, it evaluates to inputs.custom-service-account.
* If inputs.bucket is empty, it evaluates to false.

2. || '':

* This part is a logical OR operation.
* If the left side of the OR operation (inputs.bucket && inputs.custom-service-account) is false (i.e., inputs.bucket is empty), it evaluates to the right side, which is an empty string ''.
```