### PR TITLE
fix: force update existing tag when tagging major and minor versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref,
-                  sha
+                  sha,
+                  force: true
                 });
               } else {
                 console.log(`Creating tag ${tag} at ${sha}`);


### PR DESCRIPTION
There's a failure on `main` ([workflow](https://github.com/grafana/shared-workflows/actions/runs/13008605692/job/36280983638)), when tagging major/minor versions.

This happens because the ref exists already and cannot be overridden. According to [GitHub's documentation](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#update-a-reference), we need `force: true` param to make this work.