### PR TITLE
docs: fix wrong aws-auth reference in readme

### DIFF
--- a/actions/aws-auth/README.md
+++ b/actions/aws-auth/README.md
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - id: aws-auth
-        uses: grafana/shared-workflows/actions/aws-auth@argo-lint-v1.0.1
+        uses: grafana/shared-workflows/actions/aws-auth@aws-auth-v1.0.1
         with:
           aws-region: "us-west-1"
           role-arn: "arn:aws:iam::366620023056:role/github-actions/s3-test-access"


### PR DESCRIPTION
The README file in `aws-auth` action was wrongly pointing to `argo-lint` probably due to some bad c/p'ing. This PR updates the README.