### PR TITLE
refactor: simplify login-to-gar, removes describe service account

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -28,17 +28,8 @@ runs:
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
         service_account: ${{ steps.construct-service-account.outputs.service_account }}
       continue-on-error: true
-    - name: Check if access_token exists
-      id: set-access-token
-      shell: sh
-      run: |
-        if [ -n "${{ steps.auth_with_service_account.outputs.access_token }}" ]; then
-          echo "auth_service_account_status=true" >> $GITHUB_ENV
-        else
-          echo "auth_service_account_status=false" >> $GITHUB_ENV
-        fi
     - name: Service account deprecation warning
-      if: env.auth_service_account_status == 'true'
+      if: ${{ steps.auth_with_service_account.outputs.access_token != '' }}
       shell: sh
       run: |
         echo "::warning::Warning: Authenticating with a Service Account is going to be deprecated on April 30. \
@@ -47,7 +38,7 @@ runs:
         and stop using Service Accounts."
     # authenticate using the access_token from the auth_with_service_account step
     - name: Login to GAR
-      if: env.auth_service_account_status == 'true'
+      if: ${{ steps.auth_with_service_account.outputs.access_token != '' }}
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
         registry: ${{ inputs.registry }}
@@ -55,13 +46,13 @@ runs:
         password: ${{ steps.auth_with_service_account.outputs.access_token }}
     # if service account doesn't exist, then authenticate using direct workload identity federation
     - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-      if: env.auth_service_account_status == 'false'
+      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       name: Auth with direct WIF
       id: auth_with_direct_wif
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
     - name: "Use gcloud CLI to configure docker"
-      if: env.auth_service_account_status == 'false'
+      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       shell: sh
       run: "gcloud auth configure-docker ${{ inputs.registry }}"

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -19,40 +19,26 @@ runs:
       run: |
         SERVICE_ACCOUNT="github-${{ github.repository_id }}-${{ inputs.environment }}@grafanalabs-workload-identity.iam.gserviceaccount.com"
         echo "service_account=${SERVICE_ACCOUNT}" >> ${GITHUB_OUTPUT}
-    - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
-      name: Auth with github-describe-service-acc
-      id: gcloud-auth-describe-service-acc
-      with:
-        token_format: access_token
-        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: "github-describe-service-acc@grafanalabs-workload-identity.iam.gserviceaccount.com"
-    - name: "Set up Cloud SDK"
-      if: steps.cache-cloud-sdk.outputs.cache-hit != 'true'
-      uses: "google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a" # v2
-      with:
-        version: ">= 363.0.0"
-    - name: Check if service account exists
-      shell: sh
-      id: check_service_account
-      run: |
-        if gcloud iam service-accounts describe ${{ steps.construct-service-account.outputs.service_account }} > /dev/null 2>&1; then
-          echo "Service account exists"
-          echo "service_account_exists=true" >> ${GITHUB_OUTPUT}
-        else
-          echo "Service account does not exist"
-          echo "service_account_exists=false" >> ${GITHUB_OUTPUT}
-        fi
     # if service account exists, then authenticate using the service account
     - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
       name: Auth with service account
-      if: steps.check_service_account.outputs.service_account_exists == 'true'
       id: auth_with_service_account
       with:
         token_format: access_token
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
         service_account: ${{ steps.construct-service-account.outputs.service_account }}
+      continue-on-error: true
+    - name: Check if access_token exists
+      id: set-access-token
+      shell: sh
+      run: |
+        if [ -n "${{ steps.auth_with_service_account.outputs.access_token }}" ]; then
+          echo "auth_service_account_status=true" >> $GITHUB_ENV
+        else
+          echo "auth_service_account_status=false" >> $GITHUB_ENV
+        fi
     - name: Service account deprecation warning
-      if: steps.check_service_account.outputs.service_account_exists == 'true'
+      if: env.auth_service_account_status == 'true'
       shell: sh
       run: |
         echo "::warning::Warning: Authenticating with a Service Account is going to be deprecated on April 30. \
@@ -61,21 +47,21 @@ runs:
         and stop using Service Accounts."
     # authenticate using the access_token from the auth_with_service_account step
     - name: Login to GAR
+      if: env.auth_service_account_status == 'true'
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-      if: steps.check_service_account.outputs.service_account_exists == 'true'
       with:
         registry: ${{ inputs.registry }}
         username: oauth2accesstoken
         password: ${{ steps.auth_with_service_account.outputs.access_token }}
     # if service account doesn't exist, then authenticate using direct workload identity federation
     - uses: google-github-actions/auth@71f986410dfbc7added4569d411d040a91dc6935 # v2.1.8
+      if: env.auth_service_account_status == 'false'
       name: Auth with direct WIF
       id: auth_with_direct_wif
-      if: steps.check_service_account.outputs.service_account_exists == 'false'
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
     - name: "Use gcloud CLI to configure docker"
-      if: steps.check_service_account.outputs.service_account_exists == 'false'
+      if: env.auth_service_account_status == 'false'
       shell: sh
       run: "gcloud auth configure-docker ${{ inputs.registry }}"


### PR DESCRIPTION
We don't need to have one service account to check whether another service account exists or not. We can first try to authenticate using a service account, and if this fails then we can try authenticating with Direct WIF.

The flow:

* Workflow starts, and checks for the repo-specific service account:
  * If it exists, it authenticates, prints the warning message and then logs in to GAR.
  * If it doesn't exist, the authentication with a service account fails, but it won't fail the whole workflow (`continue-on-error = true`). Then it will jump to the Direct WIF bits, since the `access_token` won't exist.

Working examples:
* [Authenticate with a service account](https://github.com/grafana/dsotirakis-test-repo/actions/runs/13332044987/job/37238417455)
* [Authenticate with Direct WIF](https://github.com/grafana/dsotirakis-test-repo/actions/runs/13332044987/job/37238313394)