### PR TITLE
fix: install gcloud in login-to-gar action

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -52,6 +52,11 @@ runs:
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+    - name: "Set up Cloud SDK"
+      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
+      uses: "google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a" # v2.1.4
+      with:
+        version: ">= 363.0.0"
     - name: "Use gcloud CLI to configure docker"
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       shell: sh


### PR DESCRIPTION
Our self-hosted runners and the github-hosted runners have the `gcloud` cli installed by default.

There are some cases though where a job runs from a container that doesn't have the gcloud installed this action will fail.

This PR installs the `gcloud` cli. Will be adding some caching in a next PR.