### PR TITLE
fix: ensure every action disables git credential persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ will ensure actions in this repo are always used at the same commit. To do this:
     # action), so if multiple actions check `shared-workflows` out, they don't
     # overwrite each other
     path: _shared-workflows-your-action
+    persist-credentials: false
 
 - name: Use another action
   uses: ./_shared-workflows-your-action/actions/some-action

--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -23,6 +23,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: _shared-workflows-argo-lint
+        persist-credentials: false
 
     - name: Setup Argo
       uses: ./_shared-workflows-argo-lint/actions/setup-argo

--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -23,6 +23,8 @@ jobs:
     steps:
       - id: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - id: push-to-dockerhub
         uses: grafana/shared-workflows/actions/build-push-to-dockerhub@build-push-to-dockerhub-v0.1.1

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -75,6 +75,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: _shared-workflows-build-push-to-dockerhub
+        persist-credentials: false
 
     - name: Login to DockerHub
       if: ${{ inputs.push == 'true' }}

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -16,6 +16,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: _shared-workflows-dockerhub-login
+        persist-credentials: false
 
     - name: Get secrets for DockerHub login
       id: get-secrets

--- a/actions/generate-openapi-clients/README.md
+++ b/actions/generate-openapi-clients/README.md
@@ -36,6 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v1.0.1
+        with:
+          persist-credentials: false
+
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v1.0.1
         with:
           go-version: 1.18

--- a/actions/lint-pr-title/README.md
+++ b/actions/lint-pr-title/README.md
@@ -83,7 +83,9 @@ jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - id: lint-pr-title
         uses: grafana/shared-workflows/actions/lint-pr-title@lint-pr-title-v1.1.1

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -27,6 +27,8 @@ jobs:
     steps:
       - id: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - id: push-to-gar
         uses: grafana/shared-workflows/actions/push-to-gar-docker@push-to-gar-docker-v0.3.1

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -107,6 +107,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: shared-workflows
+        persist-credentials: false
 
     - name: Get repository name
       id: get-repository-name

--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-x64-small
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - uses: grafana/shared-workflows/actions/login-to-gcs@main
         id: login-to-gcs
 

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -54,6 +54,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: shared-workflows
+        persist-credentials: false
     - name: Resolve GCP project
       id: resolve-project
       shell: bash

--- a/actions/techdocs-rewrite-relative-links/README.md
+++ b/actions/techdocs-rewrite-relative-links/README.md
@@ -33,6 +33,7 @@ Then this link inside the file will be changed to ...
     repository: grafana/shared-workflows
     ref: techdocs-rewrite-relative-links-v1.0.1
     path: _shared-workflows
+    persist-credentials: false
 
 - name: Rewrite relative links
   uses: ./_shared-workflows/actions/techdocs-rewrite-relative-links

--- a/actions/techdocs-rewrite-relative-links/action.yaml
+++ b/actions/techdocs-rewrite-relative-links/action.yaml
@@ -75,6 +75,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: ${{ inputs.checkout-action-repository-path }}
+        persist-credentials: false
 
     - name: Setup go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -52,6 +52,7 @@ runs:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
         path: _shared-workflows-trigger-argo-workflow
+        persist-credentials: false
 
     - name: Setup argo
       uses: ./_shared-workflows-trigger-argo-workflow/actions/setup-argo

--- a/actions/validate-policy-bot-config/README.md
+++ b/actions/validate-policy-bot-config/README.md
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Validate Policy Bot configuration
         uses: grafana/shared-workflows/actions/validate-policy-bot-config@validate-policy-bot-config-v1.1.0
 ```


### PR DESCRIPTION
Reduces the possibility of inadvertently leaking the credentials in consuming workflows.

This has the potential to break workflows that rely on the persisted credentials and I haven't checked which ones may be likely to break

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>