### PR TITLE
ci: make configure-docker less verbose

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -60,4 +60,4 @@ runs:
     - name: "Use gcloud CLI to configure docker"
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       shell: sh
-      run: "gcloud auth configure-docker --quiet ${{ inputs.registry }}"
+      run: "gcloud auth configure-docker --verbosity error ${{ inputs.registry }}"

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -60,4 +60,4 @@ runs:
     - name: "Use gcloud CLI to configure docker"
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       shell: sh
-      run: "gcloud auth configure-docker ${{ inputs.registry }}"
+      run: "gcloud auth configure-docker --quiet ${{ inputs.registry }}"


### PR DESCRIPTION
Adds `--verbosity=error` to the `gcloud auth configure-docker` command.

**Without the flag:**

```
$ gcloud auth configure-docker us-docker.pkg.dev
WARNING: Your config file at [/Users/dimitris/.docker/config.json] contains these credential helper entries:

{
  "credHelpers": {
    "asia.gcr.io": "gcloud",
    "eu.gcr.io": "gcloud",
    "gcr.io": "gcloud",
    "marketplace.gcr.io": "gcloud",
    "staging-k8s.gcr.io": "gcloud",
    "us-docker.pkg.dev": "gcloud",
    "us.gcr.io": "gcloud"
  }
}
Adding credentials for: us-docker.pkg.dev
gcloud credential helpers already registered correctly.
```

**With the verbosity flag:**

```
$ gcloud auth configure-docker --verbosity error us-docker.pkg.dev
Adding credentials for: us-docker.pkg.dev
gcloud credential helpers already registered correctly.
```