### PR TITLE
feat: use auth_token in login-to-gar action

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -52,12 +52,10 @@ runs:
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-    - name: "Set up Cloud SDK"
+    - name: Login to GAR
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
-      uses: "google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a" # v2.1.4
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
-        version: ">= 363.0.0"
-    - name: "Use gcloud CLI to configure docker"
-      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
-      shell: sh
-      run: "gcloud auth configure-docker --verbosity error ${{ inputs.registry }}"
+        registry: ${{ inputs.registry }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth_with_direct_wif.outputs.auth_token }}


### PR DESCRIPTION
Instead of installing `gcloud` and then configuring docker manually (`gcloud auth configure-docker`), we can use `auth_token` to login to the docker registry.

Working example:

![image](https://github.com/user-attachments/assets/465bb9da-4842-4884-a99e-46d2044a93c0)
([workflow](https://github.com/grafana/dsotirakis-test-repo/actions/runs/13812420383/job/38636912634) - the error comes from the service account auth try and is expected)