### PR TITLE
fix(trigger-argo-workflows): support repos using Go workspaces

### DIFF
--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -115,6 +115,9 @@ runs:
           parameters+=("--workflow-template" "${{ inputs.workflow_template }}")
         fi
 
+        # Explicitly disable Go workspace support in case the repo uses that:
+        export GOWORK=off
+
         go run github.com/grafana/shared-workflows/actions/trigger-argo-workflow/cmd/trigger-argo-workflow \
           --log-level "${{ inputs.log_level }}" \
           --namespace "${{ inputs.namespace }}" \


### PR DESCRIPTION
If a repository has a `go.work` setup then doing `go run` in a subfolder that is not part of the workspace fails.