### PR TITLE
fix(gar/gcs): stop creating files and folders within workdir

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -27,6 +27,7 @@ runs:
         token_format: access_token
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
         service_account: ${{ steps.construct-service-account.outputs.service_account }}
+        create_credentials_file: false
       continue-on-error: true
     - name: Service account deprecation warning
       if: ${{ steps.auth_with_service_account.outputs.access_token != '' }}
@@ -52,6 +53,7 @@ runs:
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        create_credentials_file: false
     - name: Login to GAR
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/actions/login-to-gcs/action.yaml
+++ b/actions/login-to-gcs/action.yaml
@@ -63,3 +63,4 @@ runs:
       with:
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
         service_account: ${{ steps.construct-account-vars.outputs.service_account }}
+        create_credentials_file: false

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -106,7 +106,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: /tmp/shared-workflows
+        path: ../shared-workflows
         persist-credentials: false
 
     - name: Get repository name
@@ -138,7 +138,7 @@ runs:
 
     - name: Login to GAR
       if: ${{ inputs.push == 'true' }}
-      uses: /tmp/shared-workflows/actions/login-to-gar
+      uses: ../shared-workflows/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -106,7 +106,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: shared-workflows
+        path: /tmp/shared-workflows
         persist-credentials: false
 
     - name: Get repository name
@@ -138,7 +138,7 @@ runs:
 
     - name: Login to GAR
       if: ${{ inputs.push == 'true' }}
-      uses: ./shared-workflows/actions/login-to-gar
+      uses: /tmp/shared-workflows/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}
 

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -53,7 +53,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: shared-workflows
+        path: /tmp/shared-workflows
         persist-credentials: false
     - name: Resolve GCP project
       id: resolve-project
@@ -70,7 +70,7 @@ runs:
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
     - name: Login to GCS
       id: login-to-gcs
-      uses: ./shared-workflows/actions/login-to-gcs
+      uses: /tmp/shared-workflows/actions/login-to-gcs
       with:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -53,7 +53,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: /tmp/shared-workflows
+        path: ../shared-workflows
         persist-credentials: false
     - name: Resolve GCP project
       id: resolve-project
@@ -70,7 +70,7 @@ runs:
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
     - name: Login to GCS
       id: login-to-gcs
-      uses: /tmp/shared-workflows/actions/login-to-gcs
+      uses: ../shared-workflows/actions/login-to-gcs
       with:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow files to improve the handling of credentials when logging into Google services. The main change is the addition of the `create_credentials_file: false` parameter to prevent the creation of unnecessary credentials files.

Changes to `actions/login-to-gar/action.yaml`:

* Added `create_credentials_file: false` to the `with` section to prevent creating credentials files during the login process. [[1]](diffhunk://#diff-cd290a9f833339365a6f22e1b8b8d9c1fc7c0acf5103d0f042c6ada9a5d8dd46R30) [[2]](diffhunk://#diff-cd290a9f833339365a6f22e1b8b8d9c1fc7c0acf5103d0f042c6ada9a5d8dd46R56)

Changes to `actions/login-to-gcs/action.yaml`:

* Added `create_credentials_file: false` to the `with` section to prevent creating credentials files during the login process.

This is to stop the action from dirtying the current working directory causing issues for actions that rely on the state of the local git repository.