### PR TITLE
fix: update buildx version to `latest`

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -153,7 +153,7 @@ runs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       with:
         driver: ${{ inputs.docker-buildx-driver }}
-        version: v0.22.0 # see https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
+        version: latest # see https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
 
     - name: Build the container
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -153,6 +153,7 @@ runs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       with:
         driver: ${{ inputs.docker-buildx-driver }}
+        version: v0.22.0
 
     - name: Build the container
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -153,7 +153,7 @@ runs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       with:
         driver: ${{ inputs.docker-buildx-driver }}
-        version: v0.22.0
+        version: v0.22.0 # see https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
 
     - name: Build the container
       uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0


### PR DESCRIPTION
Due to [decommissioned cache service brownouts](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts), we need to update and pin the buildx version (see comment [here](https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479)) to prevent our actions from failing. 

Working example:
https://github.com/grafana/website/actions/runs/14350268712/job/40227545764?pr=25031#step:21:1