### PR TITLE
feat: expose exportEnv in get-vault-secrets

### DIFF
--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -27,6 +27,11 @@ inputs:
       The Vault instance to use (`dev` or `ops`). Defaults to `ops`.
     default: ops
 
+  export_env:
+    description: |
+      Whether to export secrets as environment variables, making them available to all subsequent steps. Defaults to `true`.
+    default: "true"
+
 runs:
   using: composite
   steps:
@@ -68,3 +73,4 @@ runs:
           Proxy-Authorization-Token: Bearer ${{ steps.get-github-jwt-token.outputs.github-jwt }}
         secrets: |
           ${{ steps.translate-secrets.outputs.secrets }}
+        exportEnv: ${{ inputs.export_env }}


### PR DESCRIPTION
- added a new input `export_env` to set the [exportEnv](https://github.com/hashicorp/vault-action?tab=readme-ov-file#exportenv) input of hashicorp/vault-action
- default behavior is unchanged (defaults to `true`).

Closes #518.