### PR TITLE
feat(push-to-gar-docker): add target input for multi-stage builds

### DIFF
--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -71,7 +71,7 @@ input.
 | `docker-buildx-driver` | String  | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                                   |
 | `repository_name`      | String  | Override the 'repo_name' which is included as part of the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.       |
 | `labels`               | List    | List of custom labels to add to the image as metadata (see the [metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file#inputs)) for details             |
-| `target`               | String  | Name of the [build stage](https://docs.docker.com/build/building/multi-stage/) to target.
+| `target`               | String  | Name of the [build stage](https://docs.docker.com/build/building/multi-stage/) to target.                                                                                      |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -71,6 +71,7 @@ input.
 | `docker-buildx-driver` | String  | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                                   |
 | `repository_name`      | String  | Override the 'repo_name' which is included as part of the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.       |
 | `labels`               | List    | List of custom labels to add to the image as metadata (see the [metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file#inputs)) for details             |
+| `target`               | String  | Name of the [build stage](https://docs.docker.com/build/building/multi-stage/) to target.
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -68,6 +68,10 @@ inputs:
     description: |
       List of custom labels to add to the image as metadata.
     required: false
+  target:
+    description: |
+      Sets the target stage to build
+    required: false
 
 outputs:
   version:
@@ -164,6 +168,7 @@ runs:
         push: ${{ inputs.push == 'true' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ inputs.labels }}
+        target: ${{ inputs.target }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         file: ${{ inputs.file }}


### PR DESCRIPTION
Expose the underlying `target` input from docker's [build-push-action](https://github.com/docker/build-push-action/blob/master/action.yml#L104)