### PR TITLE
ci: don't persist shared workflows folder after action is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ will ensure actions in this repo are always used at the same commit. To do this:
   uses: ./_shared-workflows-your-action/actions/some-action
   with:
     some-input: some-value
+
+# This step ensures the checkout directory is cleaned up even if previous steps fail
+- name: Cleanup checkout directory
+  if: ${{ !cancelled() }}
+  shell: bash
+  run: |
+    rm -rf _shared-workflows-your-action
 ```
 
 ### Use separate files for shell scripts so they're linted
@@ -127,7 +134,7 @@ Also, the following block should be added in the README file which will be respo
 
 `README.md`:
 
-````markdown
+```markdown
 # my-new-action
 
 This is my new action which does awesome stuff!
@@ -149,6 +156,3 @@ jobs:
 ```
 
 <!-- x-release-please-end-version -->
-````
-
-Every semver-like string between the `x-release-please-start-version` and `x-release-please-end-version` comments will be updated with the new version whenever the component is released.

--- a/README.md
+++ b/README.md
@@ -69,11 +69,16 @@ will ensure actions in this repo are always used at the same commit. To do this:
     some-input: some-value
 
 # This step ensures the checkout directory is cleaned up even if previous steps fail
-- name: Cleanup checkout directory
-  if: ${{ !cancelled() }}
-  shell: bash
-  run: |
-    rm -rf _shared-workflows-your-action
+  - name: Cleanup checkout directory
+    if: ${{ !cancelled() }}
+    shell: bash
+    run: |
+      # Check that the directory looks OK before removing it
+      if ! [ -d "_shared-workflows-push-to-gar/.git" ]; then
+      echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
+      exit 0
+      fi
+      rm -rf _shared-workflows-push-to-gar
 ```
 
 ### Use separate files for shell scripts so they're linted
@@ -154,6 +159,8 @@ jobs:
       - id: do-stuff
         uses: grafana/shared-workflows/actions/my-new-action@my-new-action-v1.0.0
 ```
-````
 
 <!-- x-release-please-end-version -->
+````
+
+Every semver-like string between the `x-release-please-start-version` and `x-release-please-end-version` comments will be updated with the new version whenever the component is released.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Also, the following block should be added in the README file which will be respo
 
 `README.md`:
 
-```markdown
+````markdown
 # my-new-action
 
 This is my new action which does awesome stuff!
@@ -154,5 +154,6 @@ jobs:
       - id: do-stuff
         uses: grafana/shared-workflows/actions/my-new-action@my-new-action-v1.0.0
 ```
+````
 
 <!-- x-release-please-end-version -->

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -110,7 +110,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: shared-workflows
+        path: _shared-workflows-push-to-gar
         persist-credentials: false
 
     - name: Get repository name
@@ -142,7 +142,7 @@ runs:
 
     - name: Login to GAR
       if: ${{ inputs.push == 'true' }}
-      uses: ./shared-workflows/actions/login-to-gar
+      uses: ./_shared-workflows-push-to-gar/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -177,7 +177,7 @@ runs:
         build-contexts: ${{ inputs.build-contexts }}
 
     - name: Cleanup checkout directory
-      if: always()
+      if: ${{ !cancelled() }}
       shell: bash
       run: |
         rm -rf _shared-workflows-push-to-gar

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -175,3 +175,9 @@ runs:
         platforms: ${{ inputs.platforms }}
         ssh: ${{ inputs.ssh }}
         build-contexts: ${{ inputs.build-contexts }}
+
+    - name: Cleanup checkout directory
+      if: always()
+      shell: bash
+      run: |
+        rm -rf _shared-workflows-push-to-gar

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -180,4 +180,10 @@ runs:
       if: ${{ !cancelled() }}
       shell: bash
       run: |
+        # Check that the directory looks OK before removing it
+        if ! [ -d "_shared-workflows-push-to-gar/.git" ]; then
+          echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
+          exit 0
+        fi
+
         rm -rf _shared-workflows-push-to-gar

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -95,3 +95,9 @@ runs:
         parent: ${{ inputs.parent }}
         predefinedAcl: ${{ inputs.predefinedAcl }}
         process_gcloudignore: false
+    
+    - name: Cleanup checkout directory
+      if: always()
+      shell: bash
+      run: |
+        rm -rf _shared-workflows-push-to-gcs

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -95,7 +95,7 @@ runs:
         parent: ${{ inputs.parent }}
         predefinedAcl: ${{ inputs.predefinedAcl }}
         process_gcloudignore: false
-    
+
     - name: Cleanup checkout directory
       if: always()
       shell: bash

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -53,7 +53,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: shared-workflows
+        path: _shared-workflows-push-to-gcs
         persist-credentials: false
     - name: Resolve GCP project
       id: resolve-project
@@ -70,7 +70,7 @@ runs:
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
     - name: Login to GCS
       id: login-to-gcs
-      uses: ./shared-workflows/actions/login-to-gcs
+      uses: ./_shared-workflows-push-to-gcs/actions/login-to-gcs
       with:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -97,7 +97,12 @@ runs:
         process_gcloudignore: false
 
     - name: Cleanup checkout directory
-      if: always()
+      if: ${{ !cancelled() }}
       shell: bash
       run: |
+        # Check that the directory looks OK before removing it
+        if ! [ -d "_shared-workflows-push-to-gcs/.git" ]; then
+          echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
+          exit 0
+        fi
         rm -rf _shared-workflows-push-to-gcs


### PR DESCRIPTION
When CI jobs are running git status after using `push-to-gar-docker` or `push-to-gcs` actions, the checked out `shared-workflows` directory appears. This breaks some CI check workflows, where the expectation is that there's not going to be any diff after certain operations (like building npm, or linting etc.). 

This PR ensures that at the end of each the above two actions, the directory will be cleaned up. 