### PR TITLE
ci: try setting coverageThreshold explicitly

### DIFF
--- a/actions/lint-pr-title/bunfig.toml
+++ b/actions/lint-pr-title/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+coverageThreshold = { functions = 0.01, lines = 0.01 }


### PR DESCRIPTION
`lint-pr-title` action fails in this repo for a while now, after [this PR](https://github.com/grafana/shared-workflows/pull/896) was merged. Looks like there's an issue with the newest bun versions >`1.2.9`.

More to come..