### PR TITLE
fix(lint-pr-title): do not run main on import

### DIFF
--- a/actions/lint-pr-title/src/index.ts
+++ b/actions/lint-pr-title/src/index.ts
@@ -63,4 +63,6 @@ export async function main() {
   }
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Previously, main was also executed during testing, which led to unexpectedly failed tests. This change prevents main from being run unless it's also the entrypoint.