### PR TITLE
ci: stop persisting credentials in google auth steps

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -52,6 +52,7 @@ runs:
       with:
         project_id: "grafanalabs-workload-identity"
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
+        create_credentials_file: false
     - name: Login to GAR
       if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0


### PR DESCRIPTION
Stop persisting credentials for `login-to-gar` action, in the case where it uses Direct WIF for authentication.
Credentials are no longer needed since the step uses an `auth_token`.

**NOTE**: We cannot do this for authentication steps that use service accounts, since the credential files are needed for this operation. `login-to-gar` will soon stop using service accounts (unless pinned).

[Working example](https://github.com/grafana/dsotirakis-test-repo/actions/runs/14613561911/workflow).