### PR TITLE
ci: remove gcp credentials after composite action finishes

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -12,6 +12,7 @@ inputs:
   delete_credentials_file:
     description: |
       Delete the credentials file after the action is finished. 
+      If you want to keep the credentials file for a later step, set this to false.
     default: "true"
 
 runs:

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: |
       Environment for pushing artifacts (can be either dev or prod).
     default: dev
+  delete_credentials_file:
+    description: |
+      Delete the credentials file after the action is finished. 
+    default: "true"
 
 runs:
   using: composite
@@ -66,3 +70,13 @@ runs:
       env:
         REGISTRY: ${{ inputs.registry }}
       run: docker-credential-gcr configure-docker --registries="${REGISTRY}"
+    - name: Delete Google Application Credentials file
+      if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}
+      shell: sh
+      run: |
+        if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
+          rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+          echo "::notice::Successfully deleted credentials file"
+        else
+          echo "::warning::Credentials file not found at ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+        fi

--- a/actions/login-to-gcs/action.yaml
+++ b/actions/login-to-gcs/action.yaml
@@ -13,6 +13,11 @@ inputs:
     description: |
       Custom service account to use for authentication.
     default: ""
+  delete_credentials_file:
+    description: |
+      Delete the credentials file after the action is finished.
+      If you want to keep the credentials file for a later step, set this to false.
+    default: "true"
 
 outputs:
   bucket:
@@ -69,3 +74,13 @@ runs:
       with:
         workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
         service_account: ${{ steps.construct-account-vars.outputs.service_account }}
+    - name: Delete Google Application Credentials file
+      if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}
+      shell: sh
+      run: |
+        if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
+          rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+          echo "::notice::Successfully deleted credentials file"
+        else
+          echo "::warning::Credentials file not found at ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+        fi

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -53,25 +53,26 @@ input.
 
 ## Inputs
 
-| Name                   | Type    | Description                                                                                                                                                                    |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `registry`             | String  | Google Artifact Registry to store docker images in.                                                                                                                            |
-| `tags`                 | List    | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                                            |
-| `context`              | List    | Path to the Docker build context.                                                                                                                                              |
-| `environment`          | Bool    | Environment for pushing artifacts (can be either dev or prod).                                                                                                                 |
-| `image_name`           | String  | Name of the image to be pushed to GAR.                                                                                                                                         |
-| `build-args`           | String  | List of arguments necessary for the Docker image to be built.                                                                                                                  |
-| `push`                 | Boolean | Whether to push the image to the registry.                                                                                                                                     |
-| `file`                 | String  | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                                           |
-| `platforms`            | List    | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                                               |
-| `cache-from`           | String  | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                 |
-| `cache-to`             | String  | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                    |
-| `ssh`                  | List    | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs)) |
-| `build-contexts`       | List    | List of additional [build contexts](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) (e.g., `name=path`)                                                 |
-| `docker-buildx-driver` | String  | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                                   |
-| `repository_name`      | String  | Override the 'repo_name' which is included as part of the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.       |
-| `labels`               | List    | List of custom labels to add to the image as metadata (see the [metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file#inputs)) for details             |
-| `target`               | String  | Name of the [build stage](https://docs.docker.com/build/building/multi-stage/) to target.                                                                                      |
+| Name                      | Type    | Description                                                                                                                                                                    |
+| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `registry`                | String  | Google Artifact Registry to store docker images in.                                                                                                                            |
+| `tags`                    | List    | Tags that should be used for the image (see the [metadata-action][mda] for details)                                                                                            |
+| `context`                 | List    | Path to the Docker build context.                                                                                                                                              |
+| `environment`             | Bool    | Environment for pushing artifacts (can be either dev or prod).                                                                                                                 |
+| `image_name`              | String  | Name of the image to be pushed to GAR.                                                                                                                                         |
+| `build-args`              | String  | List of arguments necessary for the Docker image to be built.                                                                                                                  |
+| `push`                    | Boolean | Whether to push the image to the registry.                                                                                                                                     |
+| `file`                    | String  | Path and filename of the dockerfile to build from. (Default: `{context}/Dockerfile`)                                                                                           |
+| `platforms`               | List    | List of platforms the image should be built for (e.g. `linux/amd64,linux/arm64`)                                                                                               |
+| `cache-from`              | String  | Where cache should be fetched from ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                 |
+| `cache-to`                | String  | Where cache should be stored to ([more about GHA and container caching](https://www.kenmuse.com/blog/implementing-docker-layer-caching-in-github-actions/))                    |
+| `ssh`                     | List    | List of SSH agent socket or keys to expose to the build ([more about ssh for docker/build-push-action](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs)) |
+| `build-contexts`          | List    | List of additional [build contexts](https://github.com/docker/build-push-action?tab=readme-ov-file#inputs) (e.g., `name=path`)                                                 |
+| `docker-buildx-driver`    | String  | The [driver](https://github.com/docker/setup-buildx-action/tree/v3/?tab=readme-ov-file#customizing) to use for Docker Buildx                                                   |
+| `repository_name`         | String  | Override the 'repo_name' which is included as part of the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.       |
+| `labels`                  | List    | List of custom labels to add to the image as metadata (see the [metadata-action](https://github.com/docker/metadata-action?tab=readme-ov-file#inputs)) for details             |
+| `target`                  | String  | Name of the [build stage](https://docs.docker.com/build/building/multi-stage/) to target.                                                                                      |
+| `delete_credentials_file` | Boolean | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false. (Default: `true`)                      |
 
 [mda]: https://github.com/docker/metadata-action?tab=readme-ov-file#tags-input
 

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -72,6 +72,11 @@ inputs:
     description: |
       Sets the target stage to build
     required: false
+  delete_credentials_file:
+    description: |
+      Delete the credentials file after the action is finished.
+      If you want to keep the credentials file for a later step, set this to false.
+    default: "true"
 
 outputs:
   version:

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -148,7 +148,7 @@ runs:
       uses: ./_shared-workflows-push-to-gar/actions/login-to-gar
       with:
         environment: ${{ inputs.environment }}
-
+        delete_credentials_file: false
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
@@ -190,3 +190,14 @@ runs:
         fi
 
         rm -rf _shared-workflows-push-to-gar
+
+    - name: Delete Google Application Credentials file
+      if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}
+      shell: sh
+      run: |
+        if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
+          rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+          echo "::notice::Successfully deleted credentials file"
+        else
+          echo "::warning::Credentials file not found at ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+        fi

--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -116,16 +116,17 @@ jobs:
 
 ## Inputs
 
-| Name              | Type   | Description                                                                                                                                                                                  |
-| ----------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bucket`          | String | (Required) Name of bucket to upload to. Can be gathered from `login-to-gcs` action.                                                                                                          |
-| `path`            | String | (Required) The path to a file or folder inside the action's filesystem that should be uploaded to the bucket. You can specify either the absolute path or the relative path from the action. |
-| `bucket_path`     | String | Bucket path where objects will be uploaded. Default is the bucket root.                                                                                                                      |
-| `environment`     | String | Environment for pushing artifacts (can be either dev or prod).                                                                                                                               |
-| `service_account` | String | Service account to use for authentication, different than the default one. Used only when bucket input is not empty (i.e. when the bucket is not the default one).                           |
-| `glob`            | String | Glob pattern.                                                                                                                                                                                |
-| `parent`          | String | Whether parent dir should be included in GCS destination. Dirs included in the `glob` statement are unaffected by this setting.                                                              |
-| `predefinedAcl`   | String | Predefined ACL applied to the uploaded objects. Default is `projectPrivate`. See [Google Documentation][gcs-docs-upload-options] for a list of available options.                            |
+| Name                      | Type    | Description                                                                                                                                                                                  |
+| ------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bucket`                  | String  | (Required) Name of bucket to upload to. Can be gathered from `login-to-gcs` action.                                                                                                          |
+| `path`                    | String  | (Required) The path to a file or folder inside the action's filesystem that should be uploaded to the bucket. You can specify either the absolute path or the relative path from the action. |
+| `bucket_path`             | String  | Bucket path where objects will be uploaded. Default is the bucket root.                                                                                                                      |
+| `environment`             | String  | Environment for pushing artifacts (can be either dev or prod).                                                                                                                               |
+| `service_account`         | String  | Service account to use for authentication, different than the default one. Used only when bucket input is not empty (i.e. when the bucket is not the default one).                           |
+| `glob`                    | String  | Glob pattern.                                                                                                                                                                                |
+| `parent`                  | String  | Whether parent dir should be included in GCS destination. Dirs included in the `glob` statement are unaffected by this setting.                                                              |
+| `predefinedAcl`           | String  | Predefined ACL applied to the uploaded objects. Default is `projectPrivate`. See [Google Documentation][gcs-docs-upload-options] for a list of available options.                            |
+| `delete_credentials_file` | Boolean | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false. (Default: `true`)                                    |
 
 ## Outputs
 

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -36,6 +36,11 @@ inputs:
     description: |
       Custom service account to use for authentication.
     default: ""
+  delete_credentials_file:
+    description: |
+      Delete the credentials file after the action is finished.
+      If you want to keep the credentials file for a later step, set this to false.
+    default: "true"
 
 outputs:
   uploaded:
@@ -77,6 +82,7 @@ runs:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}
         service_account: ${{ inputs.bucket && inputs.service_account || '' }}
+        delete_credentials_file: false
     - name: Construct path
       id: construct-path
       shell: bash
@@ -109,3 +115,14 @@ runs:
           exit 0
         fi
         rm -rf _shared-workflows-push-to-gcs
+
+    - name: Delete Google Application Credentials file
+      if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}
+      shell: sh
+      run: |
+        if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
+          rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+          echo "::notice::Successfully deleted credentials file"
+        else
+          echo "::warning::Credentials file not found at ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+        fi


### PR DESCRIPTION
Resolves: https://github.com/grafana/shared-workflows/issues/919

What happens is that actions that run after the reusable actions which produce gcp credentials, are being left "dirty" since the credentials are persisted in the runner.

We are introducing a new step which actually removes the credentials instantly when the composite action runs, and doesn't have to wait until the post run steps. This way we can ensure that credentials won't be left on the runner without purpose. The user has to know whether they'll still need the credentials after the composite action finishes, and change the `delete_credentials_file` boolean variable accordingly.

For `push-to-*` actions in this repo, we have to make sure that the credentials file won't be deleted after the `login-to-*` action, since the final push won't happen and will fail with authentication issues.

Setting the deletion of the credentials file by default to `true`.