### PR TITLE
fix(get-vault-secrets): add outputs for export_env false

### DIFF
--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -38,11 +38,11 @@ jobs:
             ENVVAR2=test-secret:key1
 
       # Use the secrets
-      # You can use the envvars directly in scripts or use the `${{ env.* }}` accessor in the workflow
+      # You can use the envvars directly in scripts
       - name: echo
         run: |
           echo "$ENVVAR1"
-          echo "${{ env.ENVVAR2 }}"
+          echo "${ENVVAR2}"
 ```
 
 <!-- x-release-please-end-version -->
@@ -81,11 +81,11 @@ jobs:
       # Use the secrets from the JSON output in the env block
       - name: echo
         env:
-          SECRET1: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET1 }}
-          SECRET2: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET2 }}
+          ENVVAR1: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET1 }}
+          ENVVAR2: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET2 }}
         run: |
-          echo "$SECRET1"
-          echo "${{ env.SECRET2 }}"
+          echo "$ENVVAR1"
+          echo "${ENVVAR2}"
 ```
 
 This approach is useful when you need to pass secrets to other actions or reusable workflows as inputs, while keeping them secure. It's also beneficial when you want to limit which steps have access to the secrets, as environment variables are available to all subsequent steps in a job, whereas outputs require explicit passing to each step that needs them.

--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -6,7 +6,9 @@
 From a `grafana/` org repository, get a secret from the Grafana vault instance.
 The secret format is defined here: <https://github.com/hashicorp/vault-action>
 
-Example workflow:
+## Examples
+
+### Using Environment Variables (default)
 
 <!-- x-release-please-start-version -->
 
@@ -44,3 +46,46 @@ jobs:
 ```
 
 <!-- x-release-please-end-version -->
+
+### Using Outputs
+
+You can also use the action with `export_env: false` to get secrets as outputs instead of environment variables:
+
+```yaml
+name: CI
+on:
+  pull_request:
+
+# These permissions are needed to assume roles from Github's OIDC.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.1.0
+        with:
+          # Secrets placed in the ci/common/<path> path in Vault
+          common_secrets: |
+            SECRET1=test-secret:testing
+          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
+          repo_secrets: |
+            SECRET2=test-secret:key1
+          # Set to false to get secrets as outputs instead of environment variables
+          export_env: false
+
+      # Use the secrets from the JSON output in the env block
+      - name: echo
+        env:
+          SECRET1: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET1 }}
+          SECRET2: ${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET2 }}
+        run: |
+          echo "$SECRET1"
+          echo "${{ env.SECRET2 }}"
+```
+
+This approach is useful when you need to pass secrets to other actions or reusable workflows as inputs, while keeping them secure. It's also beneficial when you want to limit which steps have access to the secrets, as environment variables are available to all subsequent steps in a job, whereas outputs require explicit passing to each step that needs them.

--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -51,6 +51,8 @@ jobs:
 
 You can also use the action with `export_env: false` to get secrets as outputs instead of environment variables:
 
+<!-- x-release-please-start-version -->
+
 ```yaml
 name: CI
 on:
@@ -87,5 +89,7 @@ jobs:
           echo "$ENVVAR1"
           echo "${ENVVAR2}"
 ```
+
+<!-- x-release-please-end-version -->
 
 This approach is useful when you need to pass secrets to other actions or reusable workflows as inputs, while keeping them secure. It's also beneficial when you want to limit which steps have access to the secrets, as environment variables are available to all subsequent steps in a job, whereas outputs require explicit passing to each step that needs them.

--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -32,6 +32,11 @@ inputs:
       Whether to export secrets as environment variables, making them available to all subsequent steps. Defaults to `true`.
     default: "true"
 
+outputs:
+  secrets:
+    description: "JSON object containing all the secrets"
+    value: ${{ steps.import-secrets.outputs.secrets }}
+
 runs:
   using: composite
   steps:

--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -35,7 +35,7 @@ inputs:
 outputs:
   secrets:
     description: "JSON object containing all the secrets"
-    value: ${{ steps.import-secrets.outputs.secrets }}
+    value: ${{ toJSON(steps.import-secrets.outputs) }}
 
 runs:
   using: composite


### PR DESCRIPTION
The option to set export_env to false was given, but there was no way to retrieve the secrets when that was set.