### PR TITLE
fix(zizmor): fix check for new versions

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -9,7 +9,7 @@
         "(?:^|/)action\\.ya?ml$",
       ],
       matchStrings: [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_-]+?[_-](?:VERSION|version)\\s*:\\s*[\"']?(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
+        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?\\s+[A-Za-z0-9_-]+[_-](?:VERSION|version)\\s*[:=]\\s*[\"']?(?<currentValue>[^\"'@\\n]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?[\"']?",
       ],
     },
   ],

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -69,12 +69,12 @@ jobs:
         shell: sh
         env:
           # renovate: datasource=github-tags depName=woodruffw/zizmor
-          ZIZMOR_RELEASE: 1.6.0
+          ZIZMOR_VERSION: 1.6.0
         run: >-
           RUSTFLAGS=-Awarnings
           cargo
           install
-          --version "${ZIZMOR_RELEASE}"
+          --version "${ZIZMOR_VERSION}"
           zizmor
 
       - name: Run zizmor


### PR DESCRIPTION
The variable needs to be named `..._VERSION` for the `# renovate:` comment to work.

Additionally, a fix is needed in the regex used for such comments. It currently matches too much in YAML files, so lines _after_ the version are caught and this breaks the logic. Fortunately, the same fix had been implemented internally for the same reason, so we can copy it here.
