### PR TITLE
feat: create version of zizmor workflow to be used as a ruleset

### DIFF
--- a/.github/workflows/rule-zizmor.yml
+++ b/.github/workflows/rule-zizmor.yml
@@ -1,11 +1,11 @@
-name: zizmor GitHub Actions static analysis
+name: Run Zizmor Ruleset
 on:
   push:
   pull_request:
 
 jobs:
   zizmor:
-    name: Run zizmor from current branch (self test)
+    name: Zizmor Ruleset
 
     permissions:
       actions: read

--- a/.github/workflows/rule-zizmor.yml
+++ b/.github/workflows/rule-zizmor.yml
@@ -1,0 +1,19 @@
+name: zizmor GitHub Actions static analysis
+on:
+  push:
+  pull_request:
+
+jobs:
+  zizmor:
+    name: Run zizmor from current branch (self test)
+
+    permissions:
+      actions: read
+      contents: read
+
+      pull-requests: write
+      security-events: write
+
+    uses: ./.github/workflows/reusable-zizmor.yml
+    with:
+      codeql-enabled: false


### PR DESCRIPTION
We want to use Zizmor as an organization wide ruleset, to do this we need to have a workflow that is in a publicly accessible repository (like this one). The current options for Zizmor in this repo are the `reusable-zizmor` which we can't use for this use case because rulesets require the workflow to be defined as triggering on `pull_request` or `push`. The other option is to use the `self-zizmor` which utilises the CodeQL integration, which we don't want to use in the current iteration.

Due to the above reasoning, we have created an almost identical action to the `self-zizmor` that just disables the `codeql-enabled` input so that we don't upload the SARIF results to GitHub at the moment