### PR TITLE
fix: workflow runs from forks

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -29,6 +29,8 @@ on:
         default: false
         type: boolean
 
+  merge_group:
+
 jobs:
   renovate:
     permissions:
@@ -36,6 +38,10 @@ jobs:
       id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
+
+    # We need a secret for the GitHub app, which isn't available for a fork, so
+    # don't run there.
+    if: github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -137,14 +137,14 @@ jobs:
           echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Hide any previous comments
-        if: always()
+        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
         id: hide-comments
         uses: int128/hide-comment-action@0a9e7919192e41201af6ebd979df163956982d07 # v1.41.0
         with:
           ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
 
       - name: Comment with zizmor results
-        if: steps.zizmor-plain.outputs.zizmor-exit-code != 0
+        if: steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: int128/comment-action@f81cfa94a4c24151591df1d74268a640875bfc8d # v1.37.0
         with:
           post: |

--- a/.github/workflows/test-find-pr-for-commit.yml
+++ b/.github/workflows/test-find-pr-for-commit.yml
@@ -23,6 +23,9 @@ permissions:
 
 jobs:
   test:
+    # TODO: fix the tests to work with forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     strategy:
       max-parallel: 1
       matrix:

--- a/.github/workflows/test-login-to-gar.yaml
+++ b/.github/workflows/test-login-to-gar.yaml
@@ -32,6 +32,8 @@ jobs:
           - dev
           - prod
     runs-on: ubuntu-latest
+    # Don't run for forks - they don't have access to secrets
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
This PR is from a fork!

See the commit tab for details of these fixes:

- **ci(reusable-zizmor): fix when run from a fork and there are findings**
- **ci(test-login-to-gar): don't run for forks**
- **ci(renovete): fix workflow runs from forks, run in merge queue**
- **ci(test-find-pr-for-commit): don't run for forks**
