### PR TITLE
feat(zizmor): use a default config file

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -48,12 +48,14 @@ jobs:
 
 ## Inputs
 
-| Name           | Type   | Description                                                                                                               | Default Value | Required |
-| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| min-severity   | string | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                  | medium        | false    |
-| min-confidence | string | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                         | low           | false    |
-| fail-severity  | string | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high] | high          | false    |
-| runs-on        | string | The runner to use for jobs. Configure this to use self-hosted runners.                                                    | ubuntu-latest | false    |
+| Name                      | Type    | Description                                                                                                                                                                                                                        | Default Value | Required |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| min-severity              | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                                                                                                                           | medium        | false    |
+| min-confidence            | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                                                                                                                                  | low           | false    |
+| fail-severity             | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high]                                                                                                          | high          | false    |
+| runs-on                   | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                                                                                                                             | ubuntu-latest | false    |
+| default-config            | boolean | The default Zizmor configuration to use. If `always-use-default-config` is `true`, this configuration will always be used. Otherwise, it will be used if the repository does not have a `.github/zizmor.yml` or `zizmor.yml` file. | true          | false    |
+| always-use-default-config | boolean | Whether to always use `default-config`.                                                                                                                                                                                            | false         | false    |
 
 ## Getting started
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -27,6 +27,27 @@ on:
         type: string
         default: "ubuntu-latest"
 
+      # TODO: This should _not_ be inline. It should be a file like
+      # `.github/zizmor.yml` alongside the reusable workflow. But
+      # unfortunately we didn't find a way to load such a file so far.
+      default-config:
+        description: The default configuration to use.
+        required: false
+        type: string
+        default: |
+          rules:
+            unpinned-uses:
+              config:
+                policies:
+                  actions/*: any # trust GitHub
+                  grafana/*: any # trust Grafana
+
+      always-use-default-config:
+        description: Whether to always use the default configuration.
+        required: false
+        type: boolean
+        default: false
+
 permissions: {}
 
 jobs:
@@ -54,6 +75,38 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Set up Zizmor configuration
+        id: setup-config
+        env:
+          DEFAULT_ZIZMOR_CONFIG: ${{ inputs.default-config }}
+          FORCE_DEFAULT_CONFIG: ${{ inputs.always-use-default-config && 'true' || '' }}
+        shell: sh
+        run: |
+          if [ -z "${FORCE_DEFAULT_CONFIG}" ]; then
+            echo "Checking for user-provided zizmor configuration..."
+            if [ -f "zizmor.yml" ]; then
+              # No action needed, zizmor will find it
+              echo "Using zizmor.yml found in repository root."
+              exit 0
+            fi
+
+            if [ -f ".github/zizmor.yml" ]; then
+              # No action needed, zizmor will find it
+              echo "Using .github/zizmor.yml found in repository."
+              exit 0
+            fi
+
+            echo "No user-provided zizmor.yml found in root or .github/. Using default zizmor config."
+          else
+            echo "always-use-default-config is set. Using default config."
+          fi
+
+          ZIZMOR_CONFIG="${{ runner.temp }}/zizmor.yml"
+          cat <<EOC | tee ${ZIZMOR_CONFIG}
+          ${DEFAULT_ZIZMOR_CONFIG}
+          EOC
+          echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
+
       - name: Setup Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
         with:
@@ -74,12 +127,14 @@ jobs:
       - name: Run zizmor
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIZMOR_CONFIG: ${{ steps.setup-config.outputs.zizmor-config }}
         shell: sh
         run: >-
           zizmor
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
+          ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
           .
           > results.sarif
@@ -104,6 +159,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIZMOR_CONFIG: ${{ steps.setup-config.outputs.zizmor-config }}
         run: |
           set -o pipefail
 
@@ -116,6 +172,7 @@ jobs:
             --min-severity "${MIN_SEVERITY}" \
             --min-confidence "${MIN_CONFIDENCE}" \
             ${RUNNER_DEBUG:+"--verbose"} \
+            ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?
@@ -129,6 +186,12 @@ jobs:
           fi
 
           echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Remove zizmor config
+        env:
+          ZIZMOR_CONFIG: ${{ steps.setup-config.outputs.zizmor-config }}
+        if: steps.setup-config.outputs.zizmor-config
+        run: rm "${ZIZMOR_CONFIG}"
 
       - name: Hide any previous comments
         if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
If the target repo hasn't got its own config file, we'll use our defaults. In this way we can provide defaults for our users but let them be overridden.

Note that this is inline in the CI job itself. I don't think that's ideal but I didn't find a better way to do this. It doesn't seem possible for reusable workflows to find out their own ref, which is what they'd need to do to get a sibling file from their repo.

I've made a support ticket with GitHub about that. If they give me a fix I'll implement that.