### PR TITLE
fix(zizmor): try code scanning by default

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -48,13 +48,12 @@ jobs:
 
 ## Inputs
 
-| Name           | Type    | Description                                                                                                               | Default Value | Required |
-| -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| min-severity   | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                  | medium        | false    |
-| min-confidence | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                         | low           | false    |
-| fail-severity  | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high] | high          | false    |
-| runs-on        | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                    | ubuntu-latest | false    |
-| codeql-enabled | boolean | If Code Scanning is enabled in the repo to upload to GitHub security                                                      | true          | false    |
+| Name           | Type   | Description                                                                                                               | Default Value | Required |
+| -------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| min-severity   | string | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                  | medium        | false    |
+| min-confidence | string | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                         | low           | false    |
+| fail-severity  | string | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high] | high          | false    |
+| runs-on        | string | The runner to use for jobs. Configure this to use self-hosted runners.                                                    | ubuntu-latest | false    |
 
 ## Getting started
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Upload to code-scanning
         if: inputs.codeql-enabled
         uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
+        continue-on-error: true
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -27,12 +27,6 @@ on:
         type: string
         default: "ubuntu-latest"
 
-      codeql-enabled:
-        description: "Whether to upload results to code scanning"
-        required: false
-        type: boolean
-        default: true
-
 permissions: {}
 
 jobs:
@@ -98,7 +92,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        if: inputs.codeql-enabled
         uses: github/codeql-action/upload-sarif@28deaeda66b76a05916b6923827895f2b14ab387 # v3.28.16
         continue-on-error: true
         with:


### PR DESCRIPTION
Ensure that zizmor can always run, even if Advanced Security is not enabled in a specific repository.

This change forces the workflow to continue even if the upload fails