### PR TITLE
fix: make default `delete_credentials_file` value false

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -13,7 +13,7 @@ inputs:
     description: |
       Delete the credentials file after the action is finished. 
       If you want to keep the credentials file for a later step, set this to false.
-    default: "true"
+    default: "false"
 
 runs:
   using: composite

--- a/actions/login-to-gcs/action.yaml
+++ b/actions/login-to-gcs/action.yaml
@@ -17,7 +17,7 @@ inputs:
     description: |
       Delete the credentials file after the action is finished.
       If you want to keep the credentials file for a later step, set this to false.
-    default: "true"
+    default: "false"
 
 outputs:
   bucket:


### PR DESCRIPTION
Deleting credentials blocks some steps operations as `docker pull`. Making the default value `false` until we fix the issue, so we won't block anybody who uses the main version of the actions.