### PR TITLE
perf: use prebuilt zizmor wheel

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -121,7 +121,7 @@ jobs:
           enable-cache: true
           activate-environment: true
           cache-suffix: ${{ env.ZIZMOR_VERSION }}
-          cache-dependency-glob: ''
+          cache-dependency-glob: ""
 
       - name: Install Zizmor
         shell: bash

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -113,22 +113,18 @@ jobs:
           EOC
           echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
 
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # v1.12.0
-        with:
-          cache-on-failure: true
+      - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
 
-      - name: Get zizmor
-        shell: sh
+      - name: 🐍 Create UV venv & install Zizmor
+        shell: bash
         env:
-          # renovate: datasource=github-tags depName=woodruffw/zizmor
+          # renovate: datasource=pypi depName=zizmor
           ZIZMOR_VERSION: 1.6.0
-        run: >-
-          RUSTFLAGS=-Awarnings
-          cargo
-          install
-          --version "${ZIZMOR_VERSION}"
-          zizmor
+        run: |
+          echo "🐣 Creating UV virtualenv"
+          uv venv
+          echo "⬇️ Installing Zizmor ${ZIZMOR_VERSION}"
+          uv pip install --no-cache-dir "zizmor==${ZIZMOR_VERSION}"
 
       - name: Zizmor cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -142,7 +138,7 @@ jobs:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         shell: sh
         run: >-
-          zizmor
+          uvx zizmor
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
@@ -180,7 +176,7 @@ jobs:
           # don't fail the build if zizmor fails - we want to capture the output
           # and the exit code
           set +e
-          zizmor \
+          uvx zizmor \
             --format plain \
             --min-severity "${MIN_SEVERITY}" \
             --min-confidence "${MIN_CONFIDENCE}" \

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -121,6 +121,7 @@ jobs:
           enable-cache: true
           activate-environment: true
           cache-suffix: ${{ env.ZIZMOR_VERSION }}
+          cache-dependency-glob: ''
 
       - name: Install Zizmor
         shell: bash

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -113,16 +113,18 @@ jobs:
           EOC
           echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
 
-      - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
+      - name: Setup UV
+        uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1
+        with:
+          enable-cache: true
+          activate-environment: true
 
-      - name: Create UV venv & install Zizmor
+      - name: Install Zizmor
         shell: bash
         env:
           # renovate: datasource=pypi depName=zizmor
           ZIZMOR_VERSION: 1.6.0
         run: |
-          echo "Creating UV virtualenv"
-          uv venv
           echo "Installing Zizmor ${ZIZMOR_VERSION}"
           uv pip install --no-cache-dir "zizmor==${ZIZMOR_VERSION}"
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -115,15 +115,15 @@ jobs:
 
       - uses: astral-sh/setup-uv@c7f87aa956e4c323abf06d5dec078e358f6b4d04 # v6.0.0
 
-      - name: 🐍 Create UV venv & install Zizmor
+      - name: Create UV venv & install Zizmor
         shell: bash
         env:
           # renovate: datasource=pypi depName=zizmor
           ZIZMOR_VERSION: 1.6.0
         run: |
-          echo "🐣 Creating UV virtualenv"
+          echo "Creating UV virtualenv"
           uv venv
-          echo "⬇️ Installing Zizmor ${ZIZMOR_VERSION}"
+          echo "Installing Zizmor ${ZIZMOR_VERSION}"
           uv pip install --no-cache-dir "zizmor==${ZIZMOR_VERSION}"
 
       - name: Zizmor cache

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -74,6 +74,8 @@ jobs:
       MIN_SEVERITY: ${{ inputs.min-severity }}
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
       GH_TOKEN: ${{ inputs.github-token || github.token }}
+      # renovate: datasource=pypi depName=zizmor
+      ZIZMOR_VERSION: 1.6.0
 
     steps:
       - name: Checkout code
@@ -118,12 +120,10 @@ jobs:
         with:
           enable-cache: true
           activate-environment: true
+          cache-suffix: ${{ env.ZIZMOR_VERSION }}
 
       - name: Install Zizmor
         shell: bash
-        env:
-          # renovate: datasource=pypi depName=zizmor
-          ZIZMOR_VERSION: 1.6.0
         run: |
           echo "Installing Zizmor ${ZIZMOR_VERSION}"
           uv pip install --no-cache-dir "zizmor==${ZIZMOR_VERSION}"


### PR DESCRIPTION
Use the pre-built zizmor wheel to avoid building the binary on the first run.

If we see a future where we want to build the Zizmor binary from a commit hash instead of a pre-built wheel it's probably easier to close this PR and continue to use the Rust toolchain.