### PR TITLE
feat(zizmor): enable running offline only

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -15,6 +15,10 @@ show the current results.
 [zizmor]: https://woodruffw.github.io/zizmor/
 [zizmor-checks]: https://woodruffw.github.io/zizmor/audits/
 
+## Examples
+
+**Fast Offline Checks**
+
 ```yaml
 name: Zizmor GitHub Actions static analysis
 on:
@@ -50,17 +54,51 @@ jobs:
       fail-severity: any
 ```
 
+**Slower Online Checks**
+
+```yaml
+name: Zizmor GitHub Actions static analysis (online checks)
+on:
+  pull_request:
+    paths:
+      - ".github/**"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/**"
+
+jobs:
+  scorecard:
+    name: Analyse
+
+    permissions:
+      actions: read
+      contents: read
+
+      # required to comment on pull requests with the results of the check
+      pull-requests: write
+      # required to upload the results to GitHub's code scanning service
+      security-events: write
+
+    uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@<some sha>
+    with:
+      # example: fail if there are any findings
+      fail-severity: any
+      extra-args: "--gh-token=${{ github.token }}"
+```
+
 ## Inputs
 
-| Name                      | Type    | Description                                                                                                                                                                                                                        | Default Value   | Required |
-| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | -------- |
-| min-severity              | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                                                                                                                           | medium          | false    |
-| min-confidence            | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                                                                                                                                  | low             | false    |
-| fail-severity             | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high]                                                                                                          | high            | false    |
-| runs-on                   | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                                                                                                                             | ubuntu-latest   | false    |
-| default-config            | boolean | The default Zizmor configuration to use. If `always-use-default-config` is `true`, this configuration will always be used. Otherwise, it will be used if the repository does not have a `.github/zizmor.yml` or `zizmor.yml` file. | true            | false    |
-| always-use-default-config | boolean | Whether to always use `default-config`.                                                                                                                                                                                            | false           | false    |
-| github-token              | string  | The GitHub token to use when authenticating with the GitHub API                                                                                                                                                                    | ${github.token} | false    |
+| Name                      | Type    | Description                                                                                                                                                                                                                        | Default Value | Required |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
+| min-severity              | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                                                                                                                           | medium        | false    |
+| min-confidence            | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                                                                                                                                  | low           | false    |
+| fail-severity             | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high]                                                                                                          | high          | false    |
+| runs-on                   | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                                                                                                                             | ubuntu-latest | false    |
+| default-config            | boolean | The default Zizmor configuration to use. If `always-use-default-config` is `true`, this configuration will always be used. Otherwise, it will be used if the repository does not have a `.github/zizmor.yml` or `zizmor.yml` file. | true          | false    |
+| always-use-default-config | boolean | Whether to always use `default-config`.                                                                                                                                                                                            | false         | false    |
+| extra-args                | string  | Extra arguments to pass into zizmor                                                                                                                                                                                                | ""            | false    |
 
 ## Getting started
 

--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -17,7 +17,7 @@ show the current results.
 
 ## Examples
 
-**Fast Offline Checks**
+**Online Checks**
 
 ```yaml
 name: Zizmor GitHub Actions static analysis
@@ -54,7 +54,7 @@ jobs:
       fail-severity: any
 ```
 
-**Slower Online Checks**
+**Faster Offline Checks**
 
 ```yaml
 name: Zizmor GitHub Actions static analysis (online checks)
@@ -85,20 +85,21 @@ jobs:
     with:
       # example: fail if there are any findings
       fail-severity: any
-      extra-args: "--gh-token=${{ github.token }}"
+      extra-args: "--offline"
 ```
 
 ## Inputs
 
-| Name                      | Type    | Description                                                                                                                                                                                                                        | Default Value | Required |
-| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | -------- |
-| min-severity              | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                                                                                                                           | medium        | false    |
-| min-confidence            | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                                                                                                                                  | low           | false    |
-| fail-severity             | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high]                                                                                                          | high          | false    |
-| runs-on                   | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                                                                                                                             | ubuntu-latest | false    |
-| default-config            | boolean | The default Zizmor configuration to use. If `always-use-default-config` is `true`, this configuration will always be used. Otherwise, it will be used if the repository does not have a `.github/zizmor.yml` or `zizmor.yml` file. | true          | false    |
-| always-use-default-config | boolean | Whether to always use `default-config`.                                                                                                                                                                                            | false         | false    |
-| extra-args                | string  | Extra arguments to pass into zizmor                                                                                                                                                                                                | ""            | false    |
+| Name                      | Type    | Description                                                                                                                                                                                                                        | Default Value   | Required |
+| ------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | -------- |
+| min-severity              | string  | Only show results at or above this severity [possible values: unknown, informational, low, medium, high]                                                                                                                           | medium          | false    |
+| min-confidence            | string  | Only show results at or above this confidence level [possible values: unknown, low, medium, high]                                                                                                                                  | low             | false    |
+| fail-severity             | string  | Fail the build if any result is at or above this severity [possible values: never, any, informational, low, medium, high]                                                                                                          | high            | false    |
+| runs-on                   | string  | The runner to use for jobs. Configure this to use self-hosted runners.                                                                                                                                                             | ubuntu-latest   | false    |
+| default-config            | boolean | The default Zizmor configuration to use. If `always-use-default-config` is `true`, this configuration will always be used. Otherwise, it will be used if the repository does not have a `.github/zizmor.yml` or `zizmor.yml` file. | true            | false    |
+| always-use-default-config | boolean | Whether to always use `default-config`.                                                                                                                                                                                            | false           | false    |
+| github-token              | string  | Use a different token to the default                                                                                                                                                                                               | ${github.token} | false    |
+| extra-args                | string  | Extra arguments to pass into zizmor                                                                                                                                                                                                | ""              | false    |
 
 ## Getting started
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -370,7 +370,7 @@ jobs:
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
-          ${ZIZMOR_EXTRA_ARGS}
+          "${ZIZMOR_EXTRA_ARGS}"
           .
           > results.sarif
 
@@ -409,7 +409,7 @@ jobs:
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
-            ${ZIZMOR_EXTRA_ARGS} \
+            "${ZIZMOR_EXTRA_ARGS}" \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -38,6 +38,12 @@ on:
         required: false
         type: string
 
+      offline:
+        description: Enable Zizmor to be run in offline mode to avoid GitHub API limits
+        required: false
+        type: boolean
+        default: false
+
 permissions: {}
 
 jobs:
@@ -219,6 +225,7 @@ jobs:
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       # renovate: datasource=pypi depName=zizmor
       ZIZMOR_VERSION: 1.6.0
+      ZIZMOR_OFFLINE: ${{ inputs.offline && 'true' || '' }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -363,6 +370,7 @@ jobs:
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
+          ${ZIZMOR_OFFLINE:+--offline}
           .
           > results.sarif
 
@@ -401,6 +409,7 @@ jobs:
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
+            ${ZIZMOR_OFFLINE:+--offline} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -33,21 +33,6 @@ on:
         type: string
         default: ${{ github.token }}
 
-      # TODO: This should _not_ be inline. It should be a file like
-      # `.github/zizmor.yml` alongside the reusable workflow. But
-      # unfortunately we didn't find a way to load such a file so far.
-      default-config:
-        description: The default configuration to use.
-        required: false
-        type: string
-        default: |
-          rules:
-            unpinned-uses:
-              config:
-                policies:
-                  actions/*: any # trust GitHub
-                  grafana/*: any # trust Grafana
-
       always-use-default-config:
         description: Whether to always use the default configuration.
         required: false

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -33,11 +33,6 @@ on:
         type: boolean
         default: false
 
-      github-token:
-        description: "The GitHub token to use for the job"
-        required: false
-        type: string
-
       extra-args:
         description: Extra arguments to pass to Zizmor
         required: false
@@ -222,7 +217,6 @@ jobs:
     env:
       MIN_SEVERITY: ${{ inputs.min-severity }}
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
-      GH_TOKEN: ${{ inputs.github-token || github.token }}
       # renovate: datasource=pypi depName=zizmor
       ZIZMOR_VERSION: 1.6.0
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -363,7 +363,7 @@ jobs:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         shell: sh
         run: >-
-          uvx zizmor
+          uvx zizmor@${ZIZMOR_VERSION}
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
@@ -402,7 +402,7 @@ jobs:
           # don't fail the build if zizmor fails - we want to capture the output
           # and the exit code
           set +e
-          uvx zizmor \
+          uvx zizmor@${ZIZMOR_VERSION} \
             --format plain \
             --min-severity "${MIN_SEVERITY}" \
             --min-confidence "${MIN_CONFIDENCE}" \

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -386,7 +386,7 @@ jobs:
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
-          ${ZIZMOR_EXTRA_ARGS:+"${ZIZMOR_EXTRA_ARGS}"}
+          ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}}
           .
           > results.sarif
 
@@ -425,7 +425,7 @@ jobs:
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
-            ${ZIZMOR_EXTRA_ARGS:+"${ZIZMOR_EXTRA_ARGS}"} \
+            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -357,7 +357,7 @@ jobs:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         shell: sh
         run: >-
-          uvx zizmor@${ZIZMOR_VERSION}
+          uvx zizmor@"${ZIZMOR_VERSION}"
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
@@ -396,7 +396,7 @@ jobs:
           # don't fail the build if zizmor fails - we want to capture the output
           # and the exit code
           set +e
-          uvx zizmor@${ZIZMOR_VERSION} \
+          uvx zizmor@"${ZIZMOR_VERSION}" \
             --format plain \
             --min-severity "${MIN_SEVERITY}" \
             --min-confidence "${MIN_CONFIDENCE}" \

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -346,12 +346,6 @@ jobs:
           cache-suffix: ${{ env.ZIZMOR_VERSION }}
           cache-dependency-glob: ""
 
-      - name: Install Zizmor
-        shell: bash
-        run: |
-          echo "Installing Zizmor ${ZIZMOR_VERSION}"
-          uv pip install --no-cache-dir "zizmor==${ZIZMOR_VERSION}"
-
       - name: Zizmor cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
         with:

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -370,7 +370,7 @@ jobs:
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
-          ${ZIZMOR_OFFLINE:+--offline}
+          ${ZIZMOR_OFFLINE:+"--offline"}
           .
           > results.sarif
 
@@ -408,8 +408,8 @@ jobs:
             --min-confidence "${MIN_CONFIDENCE}" \
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
+            ${ZIZMOR_OFFLINE:+"--offline"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
-            ${ZIZMOR_OFFLINE:+--offline} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -27,6 +27,27 @@ on:
         type: string
         default: "ubuntu-latest"
 
+      github-token:
+        description: Use a different token to the default
+        required: false
+        type: string
+        default: ${{ github.token }}
+
+      # TODO: This should _not_ be inline. It should be a file like
+      # `.github/zizmor.yml` alongside the reusable workflow. But
+      # unfortunately we didn't find a way to load such a file so far.
+      default-config:
+        description: The default configuration to use.
+        required: false
+        type: string
+        default: |
+          rules:
+            unpinned-uses:
+              config:
+                policies:
+                  actions/*: any # trust GitHub
+                  grafana/*: any # trust Grafana
+
       always-use-default-config:
         description: Whether to always use the default configuration.
         required: false
@@ -219,6 +240,7 @@ jobs:
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
       # renovate: datasource=pypi depName=zizmor
       ZIZMOR_VERSION: 1.6.0
+      GH_TOKEN: ${{ inputs.github-token || github.token }}
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
 
     steps:

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -364,13 +364,13 @@ jobs:
         shell: sh
         run: >-
           uvx zizmor
+          ${ZIZMOR_OFFLINE:+"--offline"}
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
-          ${ZIZMOR_OFFLINE:+"--offline"}
           .
           > results.sarif
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -370,7 +370,7 @@ jobs:
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
-          "${ZIZMOR_EXTRA_ARGS}"
+          ${ZIZMOR_EXTRA_ARGS:+"${ZIZMOR_EXTRA_ARGS}"}
           .
           > results.sarif
 
@@ -409,7 +409,7 @@ jobs:
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
-            "${ZIZMOR_EXTRA_ARGS}" \
+            ${ZIZMOR_EXTRA_ARGS:+"${ZIZMOR_EXTRA_ARGS}"} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -38,11 +38,11 @@ on:
         required: false
         type: string
 
-      offline:
-        description: Enable Zizmor to be run in offline mode to avoid GitHub API limits
+      extra-args:
+        description: Extra arguments to pass to Zizmor
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: ""
 
 permissions: {}
 
@@ -225,7 +225,7 @@ jobs:
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       # renovate: datasource=pypi depName=zizmor
       ZIZMOR_VERSION: 1.6.0
-      ZIZMOR_OFFLINE: ${{ inputs.offline && 'true' || '' }}
+      ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -364,13 +364,13 @@ jobs:
         shell: sh
         run: >-
           uvx zizmor
-          ${ZIZMOR_OFFLINE:+"--offline"}
           --format sarif
           --min-severity "${MIN_SEVERITY}"
           --min-confidence "${MIN_CONFIDENCE}"
           --cache-dir "${ZIZMOR_CACHE_DIR}"
           ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"}
           ${RUNNER_DEBUG:+"--verbose"}
+          ${ZIZMOR_EXTRA_ARGS}
           .
           > results.sarif
 
@@ -408,8 +408,8 @@ jobs:
             --min-confidence "${MIN_CONFIDENCE}" \
             --cache-dir "${ZIZMOR_CACHE_DIR}" \
             ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_OFFLINE:+"--offline"} \
             ${ZIZMOR_CONFIG:+--config "${ZIZMOR_CONFIG}"} \
+            ${ZIZMOR_EXTRA_ARGS} \
             . \
             | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?

--- a/.github/workflows/self-zizmor.yml
+++ b/.github/workflows/self-zizmor.yml
@@ -22,16 +22,3 @@ jobs:
       security-events: write
 
     uses: ./.github/workflows/reusable-zizmor.yml
-  zizmor-offline:
-    name: Run zizmor offline for current branch (self test)
-
-    permissions:
-      actions: read
-      contents: read
-
-      pull-requests: write
-      security-events: write
-
-    uses: ./.github/workflows/reusable-zizmor.yml
-    with:
-      extra-args: --offline --collect=all

--- a/.github/workflows/self-zizmor.yml
+++ b/.github/workflows/self-zizmor.yml
@@ -22,3 +22,16 @@ jobs:
       security-events: write
 
     uses: ./.github/workflows/reusable-zizmor.yml
+  zizmor-offline:
+    name: Run zizmor offline for current branch (self test)
+
+    permissions:
+      actions: read
+      contents: read
+
+      pull-requests: write
+      security-events: write
+
+    uses: ./.github/workflows/reusable-zizmor.yml
+    with:
+      extra-args: --offline --collect=all

--- a/.github/workflows/test-zizmor-offline.yml
+++ b/.github/workflows/test-zizmor-offline.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-
+      id-token: write
       pull-requests: write
       security-events: write
 

--- a/.github/workflows/test-zizmor-offline.yml
+++ b/.github/workflows/test-zizmor-offline.yml
@@ -1,0 +1,22 @@
+name: Test reusable Zizmor in offline mode
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor-offline:
+    name: Run zizmor offline for current branch (self test)
+
+    permissions:
+      actions: read
+      contents: read
+
+      pull-requests: write
+      security-events: write
+
+    uses: ./.github/workflows/reusable-zizmor.yml
+    with:
+      extra-args: --offline --collect=all


### PR DESCRIPTION
In our more popular repositories, we're seeing that the per-repo limit of 15,000 API calls are being hit rather quickly now that zizmor is enabled across everywhere. This enables the action to be configured in a way that will not hit the GitHub API (which does reduce the number of things that the binary will pickup). This should reduce the number of failures that we're seeing in those repositories.

After this change, GitHub tokens should now be used via an `extra-args` parameter of `--gh-token` which will be passed into zizmor