### PR TITLE
feat: adding new remove-checkout-credentials-action

### DIFF
--- a/.github/workflows/test-remove-checkout-credentials.yaml
+++ b/.github/workflows/test-remove-checkout-credentials.yaml
@@ -1,0 +1,45 @@
+name: Test remove-checkout-credentials action
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "actions/remove-checkout-credentials/**"
+      - ".github/workflows/test-remove-checkout-credentials.yaml"
+
+  pull_request:
+    paths:
+      - "actions/remove-checkout-credentials/**"
+      - ".github/workflows/test-remove-checkout-credentials.yaml"
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: true
+
+      - name: Run cleanup
+        uses: ./actions/remove-checkout-credentials
+
+      - name: Check if secrets are present
+        run: |
+          set +e
+          if git config get --local --name-only http.https://github.com/.extraheader 2> /dev/null
+          then
+            echo "HTTP config is still present!"
+            exit 1
+          fi

--- a/actions/remove-checkout-credentials/README.md
+++ b/actions/remove-checkout-credentials/README.md
@@ -1,0 +1,33 @@
+# remove-checkout-credentials
+
+This action can be used in combination with `actions/checkout` and removes credentials set by that action.
+For `actions/checkout` it is recommended to pass the `persist-credentials: false` setting but that might not be possible in various setups where the credentials _are_ needed for at least another action.
+`remove-checkout-credentials` is exactly for those cases, to act as cleanup.
+
+## Example
+
+```
+name: CI
+on:
+  pull_request: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+
+      # Actions that rely on the credentials within .git/config
+      # ...
+
+      - uses: grafana/shared-workflows/actions/remove-checkout-credentials@main
+
+      # Actions that do not need the credentials anymore
+      # ...
+```

--- a/actions/remove-checkout-credentials/action.yaml
+++ b/actions/remove-checkout-credentials/action.yaml
@@ -1,0 +1,43 @@
+name: Remove checkout credentials
+description: This action removes credentials stored by the actions/checkout action
+
+inputs:
+  path:
+    description: Path of the checkout
+
+runs:
+  using: composite
+  steps:
+    - name: Remove credentials
+      shell: bash
+      env:
+        CHECKOUT_PATH: "${{ inputs.path || '.' }}"
+      run: |
+        cd "${CHECKOUT_PATH}"
+
+        set +e
+        git config get --name-only --local core.sshCommand 2> /dev/null
+        if [ "$?" == "0" ]; then
+          export DELETE_SSH=true
+        else
+          export DELETE_SSH=false
+        fi
+        git config get --name-only --local http.https://github.com/.extraheader 2> /dev/null
+        if [ "$?" == "0" ]; then
+          export DELETE_HTTP=true
+        else
+          export DELETE_HTTP=false
+        fi
+        set -e
+
+        # Delete the GITHUB_TOKEN if it's configured
+        if [ "${DELETE_HTTP}" == "true" ]; then
+          echo "::notice::Removing HTTP config"
+          git config unset --local http.https://github.com/.extraheader && echo "::notice::HTTP config removed"
+        fi
+
+        # Delete the sshCommand if it's configured
+        if [ "${DELETE_SSH}" == "true" ]; then
+        echo "::notice::Removing SSH config"
+          git config unset --local core.sshCommand && echo "::notice::SSH config removed"
+        fi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -234,6 +234,23 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/remove-checkout-credentials/README.md
+  name: remove-checkout-credentials
+  title: remove-checkout-credentials
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Composite action to send a Slack message
   links:
   - title: README


### PR DESCRIPTION
This action can be used to clean up Git credentials after an `actions/checkout` call in case `persist-credentials: false` is not an option.