### PR TITLE
docs: add inputs section in login-to-gar action

### DIFF
--- a/actions/login-to-gar/README.md
+++ b/actions/login-to-gar/README.md
@@ -29,3 +29,11 @@ jobs:
 ```
 
 <!-- x-release-please-end-version -->
+
+## Inputs
+
+| Name                      | Description                                                                                                                             | Default             |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
+| `registry`                | Google Artifact Registry to authenticate against.                                                                                       | `us-docker.pkg.dev` |
+| `environment`             | Environment for pushing artifacts (can be either dev or prod).                                                                          | `dev`               |
+| `delete_credentials_file` | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false. | `false`             |


### PR DESCRIPTION
Adds inputs description in `login-to-gar` action. 