### PR TITLE
docs(get-vault-secrets): move permissions to job-level in example wor…

### DIFF
--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -17,14 +17,14 @@ name: CI
 on:
   pull_request:
 
-# These permissions are needed to assume roles from Github's OIDC.
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
       - id: get-secrets


### PR DESCRIPTION
Moved the permissions block to the job level in the example workflow definition in the `get-vault-secrets` action's readme.

Closes #955.