### PR TITLE
docs(multiple-actions): move permissions to job level in workflows

### DIFF
--- a/actions/aws-auth/README.md
+++ b/actions/aws-auth/README.md
@@ -11,13 +11,11 @@ name: Authenticate to AWS
 on:
   pull_request:
 
-permissions:
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - id: aws-auth
         uses: grafana/shared-workflows/actions/aws-auth@aws-auth-v1.0.1

--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -12,14 +12,12 @@ name: Push to DockerHub
 on:
   pull_request:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - id: checkout
         uses: actions/checkout@v4

--- a/actions/dockerhub-login/README.md
+++ b/actions/dockerhub-login/README.md
@@ -12,14 +12,12 @@ name: Push to DockerHub
 on:
   pull_request:
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Login to DockerHub
         uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login-v1.0.1

--- a/actions/find-pr-for-commit/README.md
+++ b/actions/find-pr-for-commit/README.md
@@ -38,12 +38,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   comment-on-pr-for-commit:
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Find PR for current commit
         id: find-pr
@@ -61,12 +60,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   comment-on-pr-for-commit:
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Find PR for specific commit
         id: find-pr
@@ -86,12 +84,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   comment-on-pr-for-commit:
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Find PR for named revision
         id: find-pr

--- a/actions/generate-openapi-clients/README.md
+++ b/actions/generate-openapi-clients/README.md
@@ -28,12 +28,11 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write # Only needed if `commit-changes` is set to true
-
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Only needed if `commit-changes` is set to true
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v1.0.1
         with:

--- a/actions/login-to-gar/README.md
+++ b/actions/login-to-gar/README.md
@@ -11,15 +11,13 @@ name: CI
 on:
   pull_request:
 
-# These permissions are needed to assume roles from Github's OIDC.
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   login:
     runs-on: ubuntu-latest
-
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: grafana/shared-workflows/actions/login-to-gar@login-to-gar-v0.4.0
         id: login-to-gar

--- a/actions/login-to-gcs/README.md
+++ b/actions/login-to-gcs/README.md
@@ -15,13 +15,12 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   login-to-gcs:
     name: login-to-gcs
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: grafana/shared-workflows/actions/login-to-gcs@login-to-gcs-v0.2.0
         id: login-to-gcs

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -15,15 +15,13 @@ name: CI
 on:
   pull_request:
 
-# These permissions are needed to assume roles from Github's OIDC.
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-
+    # These permissions are needed to assume roles from Github's OIDC.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - id: checkout
         uses: actions/checkout@v4

--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -18,14 +18,13 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   upload-to-gcs:
     name: upload
     runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/actions/remove-checkout-credentials/README.md
+++ b/actions/remove-checkout-credentials/README.md
@@ -6,18 +6,16 @@ For `actions/checkout` it is recommended to pass the `persist-credentials: false
 
 ## Example
 
-```
+```yaml
 name: CI
 on:
   pull_request: {}
 
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/actions/setup-argo/README.md
+++ b/actions/setup-argo/README.md
@@ -6,11 +6,10 @@ Setup Argo cli and add it to the PATH, this action will pull the binary from Git
 
 <!-- x-release-please-start-version -->
 
-```
+```yaml
 uses: grafana/shared-workflows/actions/setup-argo@setup-argo-v1.0.1
 with:
   version: 1.0.1 # Version of the Argo CLI to install.
-
 ```
 
 <!-- x-release-please-end-version -->

--- a/actions/setup-conftest/README.md
+++ b/actions/setup-conftest/README.md
@@ -6,11 +6,10 @@ Setup conftest and add it to the PATH, this action will pull the binary from Git
 
 <!-- x-release-please-start-version -->
 
-```
+```yaml
 uses: grafana/shared-workflows/actions/setup-conftest@setup-conftest-v1.0.1
 with:
   version: 1.0.1 # Version of conftest to install.
-
 ```
 
 <!-- x-release-please-end-version -->

--- a/actions/setup-jrsonnet/README.md
+++ b/actions/setup-jrsonnet/README.md
@@ -6,11 +6,10 @@ Setup jrsonnet CLI and add it to the PATH, this action will pull the binary from
 
 <!-- x-release-please-start-version -->
 
-```
+```yaml
 uses: grafana/shared-workflows/actions/setup-jrsonnet@setup-jrsonnet-v1.0.0
 with:
   version: 1.0.0-test # Version of the jrsonnet CLI to install.
-
 ```
 
 <!-- x-release-please-end-version -->

--- a/actions/validate-policy-bot-config/README.md
+++ b/actions/validate-policy-bot-config/README.md
@@ -20,7 +20,8 @@ on:
       - ".policy.yml"
   push:
     paths:
-      - ".policy.yml
+      - ".policy.yml"
+
 jobs:
   validate-policy-bot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Moved permissions block from top-level to job-level for each action's example workflow in their readme's.

The same work as defined #955.