### PR TITLE
fix(reusable-zizmor): fix runs from forks

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -17,7 +17,7 @@ show the current results.
 
 ## Examples
 
-**Online Checks**
+### Online Checks
 
 ```yaml
 name: Zizmor GitHub Actions static analysis
@@ -39,13 +39,17 @@ jobs:
       actions: read
       contents: read
 
-      # used in the `job-workflow-ref` job to fetch an OIDC token, which allows
-      # the run to determine its ref
+      # used in the `job-workflow-ref` job to fetch an OIDC token, which
+      # allows the run to determine its ref. That's used to find the default
+      # configuration file. This doesn't work from forks. In that case,
+      # Zizmor's default config behaviour will be used.
       id-token: write
 
       # required to comment on pull requests with the results of the check
       pull-requests: write
-      # required to upload the results to GitHub's code scanning service
+      # required to upload the results to GitHub's code scanning service. This
+      # doesn't work if the repo doesn't have Advanced Security enabled. In that
+      # case we'll skip the upload.
       security-events: write
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@<some sha>
@@ -54,7 +58,7 @@ jobs:
       fail-severity: any
 ```
 
-**Faster Offline Checks**
+### Faster Offline Checks
 
 ```yaml
 name: Zizmor GitHub Actions static analysis (online checks)
@@ -76,9 +80,17 @@ jobs:
       actions: read
       contents: read
 
+      # used in the `job-workflow-ref` job to fetch an OIDC token, which
+      # allows the run to determine its ref. That's used to find the default
+      # configuration file. This doesn't work from forks. In that case,
+      # Zizmor's default config behaviour will be used.
+      id-token: write
+
       # required to comment on pull requests with the results of the check
       pull-requests: write
-      # required to upload the results to GitHub's code scanning service
+      # required to upload the results to GitHub's code scanning service. This
+      # doesn't work if the repo doesn't have Advanced Security enabled. In that
+      # case we'll skip the upload.
       security-events: write
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@<some sha>

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -99,6 +99,15 @@ jobs:
             const { jwtVerify, createRemoteJWKSet } = require('jose');
 
             async function retrieveIdToken(audience) {
+              // Perform an explicit check to see if we can get the ID token or
+              // not, so we can show a better error.
+              const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL']
+              if (!runtimeUrl) {
+                throw new Error(
+                  "We're unable to look up the version of the Zizmor workflow being called, so we can't fetch the `grafana` default configuration. Zizmor's own default will be used. Is the `is-token: write` permission set? If so, is this a run from a fork? Unfortunately we're unable to do this lookup for pull requests from forks currently."
+                )
+              }
+
               core.debug(`Attempting to retrieve ID token with audience: ${audience}...`);
 
               const idToken = await core.getIDToken(audience);
@@ -199,7 +208,9 @@ jobs:
               core.setOutput('repo', repo);
               core.setOutput('sha', sha);
             } catch (error) {
-              core.setFailed(`Script failed: ${error.message}`);
+              // On errors, we log an error messge, but we don't fail. It's
+              // better to run with the default config than not run at all.
+              core.error(`Script failed: ${error.message}`);
 
               if (error.stack) {
                 console.error(`Stack trace: ${error.stack}`);


### PR DESCRIPTION
Forks can't get an ID token. We use this method to look up the version we're called at: get an OIDC ID token and then use the `job_workflow_ref` claim. We're currently hard failing when this doesn't work, which means we throw an error for runs from forks.

We do this whole ID token dance to find our current ref, so we can fetch the org-wide config. This is important but it's not _critical_ - not enough to fail the run. It would be better to succeed by falling back to using the default config from _upstream_.