### PR TITLE
fix: only use zizmor config if it exists

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -75,7 +75,6 @@ jobs:
       owner: ${{ steps.get-job-workflow-ref.outputs.owner }}
       repo: ${{ steps.get-job-workflow-ref.outputs.repo }}
       sha: ${{ steps.get-job-workflow-ref.outputs.sha }}
-      success: ${{ steps.get-job-workflow-ref.outputs.success }}
 
     steps:
       - id: setup-node
@@ -208,7 +207,6 @@ jobs:
               core.setOutput('owner', owner);
               core.setOutput('repo', repo);
               core.setOutput('sha', sha);
-              core.setOutput('success', 'true');
             } catch (error) {
               // On errors, we log an error messge, but we don't fail. It's
               // better to run with the default config than not run at all.
@@ -242,6 +240,7 @@ jobs:
       ZIZMOR_VERSION: 1.6.0
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
+      DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.sha }}
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
@@ -258,14 +257,14 @@ jobs:
       - name: Restore config from cache
         id: cache-config
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        if: needs.job-workflow-ref.outputs.success == 'true'
+        if: env.DEFAULT_ZIZMOR_CONFIG_DOWNLOADED
         with:
           path: ${{ runner.temp }}/zizmor.yml
           key: zizmor-config-${{ needs.job-workflow-ref.outputs.repo }}-${{ needs.job-workflow-ref.outputs.sha }}
 
       - name: Fetch Zizmor Config
         id: fetch-config
-        if: steps.cache-config.outputs.cache-hit != 'true' && needs.job-workflow-ref.outputs.success == 'true'
+        if: steps.cache-config.outputs.cache-hit != 'true' && env.DEFAULT_ZIZMOR_CONFIG_DOWNLOADED
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           OWNER: ${{ needs.job-workflow-ref.outputs.owner }}
@@ -330,7 +329,6 @@ jobs:
         id: setup-config
         env:
           FORCE_DEFAULT_CONFIG: ${{ inputs.always-use-default-config && 'true' || '' }}
-          DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.success == 'true' && 'true' || '' }}
         shell: sh
         run: |
           if [ -z "${FORCE_DEFAULT_CONFIG}" ]; then

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -75,6 +75,7 @@ jobs:
       owner: ${{ steps.get-job-workflow-ref.outputs.owner }}
       repo: ${{ steps.get-job-workflow-ref.outputs.repo }}
       sha: ${{ steps.get-job-workflow-ref.outputs.sha }}
+      success: ${{ steps.get-job-workflow-ref.outputs.success }}
 
     steps:
       - id: setup-node
@@ -207,6 +208,7 @@ jobs:
               core.setOutput('owner', owner);
               core.setOutput('repo', repo);
               core.setOutput('sha', sha);
+              core.setOutput('success', 'true');
             } catch (error) {
               // On errors, we log an error messge, but we don't fail. It's
               // better to run with the default config than not run at all.
@@ -256,13 +258,14 @@ jobs:
       - name: Restore config from cache
         id: cache-config
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: needs.job-workflow-ref.outputs.success == 'true'
         with:
           path: ${{ runner.temp }}/zizmor.yml
           key: zizmor-config-${{ needs.job-workflow-ref.outputs.repo }}-${{ needs.job-workflow-ref.outputs.sha }}
 
       - name: Fetch Zizmor Config
         id: fetch-config
-        if: steps.cache-config.outputs.cache-hit != 'true'
+        if: steps.cache-config.outputs.cache-hit != 'true' && needs.job-workflow-ref.outputs.success == 'true'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           OWNER: ${{ needs.job-workflow-ref.outputs.owner }}
@@ -327,6 +330,7 @@ jobs:
         id: setup-config
         env:
           FORCE_DEFAULT_CONFIG: ${{ inputs.always-use-default-config && 'true' || '' }}
+          DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.success == 'true' && 'true' || '' }}
         shell: sh
         run: |
           if [ -z "${FORCE_DEFAULT_CONFIG}" ]; then
@@ -352,7 +356,7 @@ jobs:
           # we'll use the default configuration that's built in.
 
           ZIZMOR_CONFIG="${{ runner.temp }}/zizmor.yml"
-          if [ -f "${ZIZMOR_CONFIG}" ]; then
+          if [ -n "${DEFAULT_ZIZMOR_CONFIG_DOWNLOADED}" ]; then
             echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
           fi
 

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -352,9 +352,6 @@ jobs:
             echo "always-use-default-config is set. Using default config."
           fi
 
-          # Some forks are having issues with cloning the zizmor config file, so in the worst case
-          # we'll use the default configuration that's built in.
-
           ZIZMOR_CONFIG="${{ runner.temp }}/zizmor.yml"
           if [ -n "${DEFAULT_ZIZMOR_CONFIG_DOWNLOADED}" ]; then
             echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -348,8 +348,13 @@ jobs:
             echo "always-use-default-config is set. Using default config."
           fi
 
+          # Some forks are having issues with cloning the zizmor config file, so in the worst case
+          # we'll use the default configuration that's built in.
+
           ZIZMOR_CONFIG="${{ runner.temp }}/zizmor.yml"
-          echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
+          if [ -f "${ZIZMOR_CONFIG}" ]; then
+            echo "zizmor-config=${ZIZMOR_CONFIG}" | tee -a "${GITHUB_OUTPUT}"
+          fi
 
       - name: Setup UV
         uses: astral-sh/setup-uv@6b9c6063abd6010835644d4c2e1bef4cf5cd0fca # v6.0.1


### PR DESCRIPTION
We're finding that some forks of code cannot pull the content from this repo's zizmor config. We should ensure that zizmor runs with the default configuration if there is no configuration provided