### PR TITLE
docs(send-slack-notification): remove outdated docs, url update

### DIFF
--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -96,10 +96,10 @@ jobs:
 
 ## Inputs
 
-| Name                | Type   | Description                                                                                                                                       |
-| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `payload`           | String | JSON payload to send.                                                                             |
-| `method`            | String | The Slack API method to call.                                                                                                                     |
+| Name                | Type   | Description                                                                                                                                        |
+| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payload`           | String | JSON payload to send.                                                                                                                              |
+| `method`            | String | The Slack API method to call.                                                                                                                      |
 | `payload-templated` | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
 
 ## Outputs

--- a/actions/send-slack-message/README.md
+++ b/actions/send-slack-message/README.md
@@ -3,7 +3,7 @@
 This is a composite GitHub Action used to send Slack messages to the Grafana workspace.
 You do not need to set up Slack webhooks in order to use this action.
 
-See the docs for the [slackapi/slack-github-action workflow](https://github.com/slackapi/slack-github-action/blob/main/README.md#technique-2-slack-app) for more info. Our installation is via Slack App.
+See the docs for the [slackapi/slack-github-action workflow](https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-slack-api-method/#usage) for more info.
 
 <!-- x-release-please-start-version -->
 
@@ -96,10 +96,10 @@ jobs:
 
 ## Inputs
 
-| Name                | Type   | Description                                                                                                                                        |
-| ------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `payload`           | String | JSON payload to send. Use `payload` or `slack-message`, but not both.                                                                              |
-| `method`            | String | The Slack API method to call.                                                                                                                      |
+| Name                | Type   | Description                                                                                                                                       |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `payload`           | String | JSON payload to send.                                                                             |
+| `method`            | String | The Slack API method to call.                                                                                                                     |
 | `payload-templated` | String | To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true. |
 
 ## Outputs

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -3,7 +3,7 @@ description: Composite action to send a Slack message
 
 inputs:
   payload:
-    description: "JSON payload to send. Use `payload` or `slack-message`, but not both"
+    description: "JSON payload to send"
     required: false
   method:
     description: "The Slack API method to call"


### PR DESCRIPTION
This pull request includes updates to the `actions/send-slack-message` GitHub Action to refine documentation and input descriptions. The most important changes include updating a link in the README, correcting formatting in the inputs table, and simplifying the description of the `payload` input.

### Documentation updates:

* [`actions/send-slack-message/README.md`](diffhunk://#diff-bc36534e8c270f109c38c4bf0352ca7c49e571ced409855c162eca3977d23ee1L6-R6): Updated the link to the Slack GitHub Action documentation to point to the latest and more specific URL for sending data using the Slack API method.

### Input descriptions and formatting:

* [`actions/send-slack-message/README.md`](diffhunk://#diff-bc36534e8c270f109c38c4bf0352ca7c49e571ced409855c162eca3977d23ee1L100-R101): Fixed the formatting of the inputs table by aligning column headers and descriptions.
* [`actions/send-slack-message/action.yaml`](diffhunk://#diff-c26fdc39a7377a035e16ba9f858758015f79a873a59aa133cd21e9a98f39db0bL6-R6): Simplified the description of the `payload` input by removing redundant information about not using `payload` and `slack-message` simultaneously.