### PR TITLE
chore: add repository name as prefix to actions in the catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,7 +21,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/argo-lint/README.md
-  name: argo-lint
+  name: shared-workflows-argo-lint
   title: argo-lint
 spec:
   lifecycle: production
@@ -39,7 +39,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/aws-auth/README.md
-  name: aws-auth
+  name: shared-workflows-aws-auth
   title: aws-auth
 spec:
   lifecycle: production
@@ -57,8 +57,26 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/build-push-to-dockerhub/README.md
-  name: build-push-to-dockerhub
+  name: shared-workflows-build-push-to-dockerhub
   title: build-push-to-dockerhub
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Auto dismiss Dependabot alerts based on manifest path
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/dependabot-auto-triage/README.md
+  name: shared-workflows-dependabot-auto-triage
+  title: dependabot-auto-triage
 spec:
   lifecycle: production
   owner: group:platform-productivity
@@ -75,7 +93,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/dockerhub-login/README.md
-  name: dockerhub-login
+  name: shared-workflows-dockerhub-login
   title: dockerhub-login
 spec:
   lifecycle: production
@@ -93,7 +111,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/find-pr-for-commit/README.md
-  name: find-pr-for-commit
+  name: shared-workflows-find-pr-for-commit
   title: find-pr-for-commit
 spec:
   lifecycle: production
@@ -112,7 +130,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/generate-openapi-clients/README.md
-  name: generate-openapi-clients
+  name: shared-workflows-generate-openapi-clients
   title: generate-openapi-clients
 spec:
   lifecycle: production
@@ -130,7 +148,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/get-vault-secrets/README.md
-  name: get-vault-secrets
+  name: shared-workflows-get-vault-secrets
   title: get-vault-secrets
 spec:
   lifecycle: production
@@ -148,7 +166,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/lint-pr-title/README.md
-  name: lint-pr-title
+  name: shared-workflows-lint-pr-title
   title: lint-pr-title
 spec:
   lifecycle: production
@@ -166,7 +184,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/login-to-gar/README.md
-  name: login-to-gar
+  name: shared-workflows-login-to-gar
   title: login-to-gar
 spec:
   lifecycle: production
@@ -184,7 +202,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/login-to-gcs/README.md
-  name: login-to-gcs
+  name: shared-workflows-login-to-gcs
   title: login-to-gcs
 spec:
   lifecycle: production
@@ -202,7 +220,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/push-to-gar-docker/README.md
-  name: push-to-gar-docker
+  name: shared-workflows-push-to-gar-docker
   title: push-to-gar-docker
 spec:
   lifecycle: production
@@ -220,7 +238,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/push-to-gcs/README.md
-  name: push-to-gcs
+  name: shared-workflows-push-to-gcs
   title: push-to-gcs
 spec:
   lifecycle: production
@@ -234,10 +252,11 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: This action removes credentials stored by the actions/checkout action
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/remove-checkout-credentials/README.md
-  name: remove-checkout-credentials
+  name: shared-workflows-remove-checkout-credentials
   title: remove-checkout-credentials
 spec:
   lifecycle: production
@@ -255,7 +274,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/send-slack-message/README.md
-  name: send-slack-message
+  name: shared-workflows-send-slack-message
   title: send-slack-message
 spec:
   lifecycle: production
@@ -274,7 +293,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/setup-argo/README.md
-  name: setup-argo
+  name: shared-workflows-setup-argo
   title: setup-argo
 spec:
   lifecycle: production
@@ -293,7 +312,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/setup-conftest/README.md
-  name: setup-conftest
+  name: shared-workflows-setup-conftest
   title: setup-conftest
 spec:
   lifecycle: production
@@ -312,7 +331,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/setup-jrsonnet/README.md
-  name: setup-jrsonnet
+  name: shared-workflows-setup-jrsonnet
   title: setup-jrsonnet
 spec:
   lifecycle: production
@@ -330,7 +349,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/techdocs-rewrite-relative-links/README.md
-  name: techdocs-rewrite-relative-links
+  name: shared-workflows-techdocs-rewrite-relative-links
   title: techdocs-rewrite-relative-links
 spec:
   lifecycle: production
@@ -348,7 +367,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/trigger-argo-workflow/README.md
-  name: trigger-argo-workflow
+  name: shared-workflows-trigger-argo-workflow
   title: trigger-argo-workflow
 spec:
   lifecycle: production
@@ -366,7 +385,7 @@ metadata:
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/validate-policy-bot-config/README.md
-  name: validate-policy-bot-config
+  name: shared-workflows-validate-policy-bot-config
   title: validate-policy-bot-config
 spec:
   lifecycle: production

--- a/scripts/generate-catalog-info/go.mod
+++ b/scripts/generate-catalog-info/go.mod
@@ -4,10 +4,14 @@ go 1.24.2
 
 require (
 	github.com/hairyhenderson/go-codeowners v0.7.0
+	k8s.io/apimachinery v0.33.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
+	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
+	k8s.io/klog/v2 v2.130.1 // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 )

--- a/scripts/generate-catalog-info/go.sum
+++ b/scripts/generate-catalog-info/go.sum
@@ -1,8 +1,11 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
+github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/hairyhenderson/go-codeowners v0.7.0 h1:s0W4wF8bdsBEjTWzwzSlsatSthWtTAF2xLgo4a4RwAo=
 github.com/hairyhenderson/go-codeowners v0.7.0/go.mod h1:wUlNgQ3QjqC4z8DnM5nnCYVq/icpqXJyJOukKx5U8/Q=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -20,5 +23,11 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.33.0 h1:1a6kHrJxb2hs4t8EE5wuR/WxKDwGN1FKH3JvDtA0CIQ=
+k8s.io/apimachinery v0.33.0/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
+k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
+k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/scripts/generate-catalog-info/main.go
+++ b/scripts/generate-catalog-info/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/hairyhenderson/go-codeowners"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 )
 
@@ -147,7 +148,7 @@ func main() {
 			APIVersion: "backstage.io/v1alpha1",
 			Kind:       "Component",
 			Metadata: CatalogInfoMetadata{
-				Name:        action.Slug,
+				Name:        "shared-workflows-" + action.Slug,
 				Title:       action.Slug,
 				Description: action.Description,
 				Annotations: map[string]string{
@@ -166,6 +167,11 @@ func main() {
 				Owner:          fmt.Sprintf("group:%s", primaryOwner),
 				SubcomponentOf: "component:shared-workflows",
 			},
+		}
+
+		if errors := validation.IsQualifiedName(info.Metadata.Name); len(errors) > 0 {
+			logger.Error("entity name invalid", "entity-name", info.Metadata.Name, "errors", errors)
+			os.Exit(1)
 		}
 		err := writeYAML(&output, info)
 		if err != nil {


### PR DESCRIPTION
This should make collisions with similarly named actions in other repositories more unlikely.