### PR TITLE
docs(get-vault-secrets): update enghub link to point to new vault docs

### DIFF
--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -1,7 +1,7 @@
 # get-vault-secrets
 
 > [!NOTE]
-> If you are at Grafana Labs, follow these steps in the [internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/vault/#ci-secrets) for the paths where this workflow can read secrets from.
+> If you are at Grafana Labs, follow these steps in the [internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/#vault-storing-your-secrets) for Vault instructions and best practices.
 
 From a `grafana/` org repository, get a secret from the Grafana vault instance.
 The secret format is defined here: <https://github.com/hashicorp/vault-action>


### PR DESCRIPTION
This pull request updates the `actions/get-vault-secrets/README.md` file to provide a more accurate and helpful link for Grafana Labs engineers regarding Vault instructions and best practices.

* Documentation update:
  * Updated the internal documentation link to point to the correct section on Vault instructions and best practices for storing secrets in CI workflows. (`actions/get-vault-secrets/README.md`)

Dependent on https://github.com/grafana/deployment_tools/pull/266757 for the new link to work.