### PR TITLE
feat(build-push-to-dockerhub): enable docker mirror for buildx on self-hosted runners

### DIFF
--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -91,9 +91,11 @@ runs:
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
+      id: buildx
       with:
         driver: ${{ inputs.docker-buildx-driver }}
+        buildkitd-config: ${{ runner.environment == 'self-hosted' && '/etc/buildkitd.toml' || '' }}
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -91,8 +91,7 @@ runs:
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
-      id: buildx
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
       with:
         driver: ${{ inputs.docker-buildx-driver }}
         buildkitd-config: ${{ runner.environment == 'self-hosted' && '/etc/buildkitd.toml' || '' }}


### PR DESCRIPTION
Update the `build-push-to-dockerhub` to utilize Grafana's internal docker mirror for self-hosted runners.

Enhancements to Docker Buildx setup:

* Introduced a conditional `buildkitd-config` parameter to specify the BuildKit daemon configuration file when running in a self-hosted environment.


This requires https://github.com/grafana/deployment_tools/pull/269388 to be merged first.
Part of https://github.com/grafana/deployment_tools/issues/269366