### PR TITLE
feat(push-to-gar-docker): enable docker mirror for buildx on self-hosted runners

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -171,6 +171,7 @@ runs:
       with:
         driver: ${{ inputs.docker-buildx-driver }}
         version: latest # see https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
+        buildkitd-config: ${{ runner.environment == 'self-hosted' && '/etc/buildkitd.toml' || '' }}
 
     - name: Build the container
       uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6.16.0


### PR DESCRIPTION
Update the `push-to-gar-docker` to utilize Grafana's internal docker mirror for self-hosted runners.

Key change:

* [`actions/push-to-gar-docker/action.yaml`](diffhunk://#diff-cd7255ed249c21034dc35c5e4e4db93b4cc690ce2c0f7d4034e1be574484a8feR174): Added a conditional expression to set the `buildkitd-config` parameter to `/etc/buildkitd.toml` when the runner is self-hosted, and an empty string otherwise. This improves compatibility with self-hosted environments.


This requires https://github.com/grafana/deployment_tools/pull/269388 to be merged first.
Part of https://github.com/grafana/deployment_tools/issues/269366