### PR TITLE
fix(login-to-gar): replace hardcoded opt dir with runner temp env var

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -104,7 +104,7 @@ runs:
           echo "Installing docker-credential-gcr @ ${tag} for ${os}/${arch}"
           mkdir -p "${RUNNER_TEMP}/docker-credential-gcr"
           curl -fsL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/${tag}/docker-credential-gcr_${os}_${arch}-${tag:1}.tar.gz" | tar xzf - -C "${RUNNER_TEMP}/docker-credential-gcr" docker-credential-gcr
-          # zizmor: ignore[github-env] - docker-credential-gcr binary must be on the PATH for credHelpers in /.docker/config.json to work.
+          # Ignoring the github-env warning - docker-credential-gcr binary must be on the PATH for credHelpers in /.docker/config.json to work.
           # We are only adding a path to a binary that was just downloaded in RUNNER_TEMP (controlled by GitHub Actions).
           echo "${RUNNER_TEMP}/docker-credential-gcr" >> $GITHUB_PATH
         fi


### PR DESCRIPTION
Looks like non-root users cannot store things to `opt/` directory. It'd be better if we stored the binary in the temp dir on the runner, using `${ RUNNER_TEMP }`.

**Note**: 
(also seen as a comment in the action)
We are adding a `zizmor: ignore[github-env]` since `docker-credential-gcr` binary should be in the PATH. We are only adding a path to a binary that was just downloaded, so the risk should be minimal. credHelpers helper in the /.docker/config.json must be on the PATH. Also, RUNNER_TEMP is controlled by GitHub Actions and not accessible to attackers.

-----

Working examples:
* [Check terraform files](https://github.com/grafana/deployment_tools/actions/runs/15299827911/job/43042468555)
* [Build and push projects in docker](https://github.com/grafana/deployment_tools/actions/runs/15299828033)