### PR TITLE
docs(multiple): add docker cache notes to build-push-to-dockerhub and push-to-gar-docker

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -1,5 +1,10 @@
 # build-push-to-dockerhub
 
+> [!NOTE]
+> If you are at Grafana Labs:
+> - A docker mirror is available on our self-hosted runners, see [the internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/#docker-caching-in-github-actions) for more info.
+
+
 This is a composite GitHub Action, used to build Docker images and push them to DockerHub.
 It uses `get-vault-secrets` action to get the DockerHub username and password from Vault.
 

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -1,7 +1,9 @@
 # push-to-gar-docker
 
 > [!NOTE]
-> If you are at Grafana Labs, follow these steps in the [internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/google-artifact-registry/) to set up a repository before using this action.
+> If you are at Grafana Labs:
+> - Follow these steps in the [internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/google-artifact-registry/) to set up a repository before using this action.
+> - A docker mirror is available on our self-hosted runners, see [the internal documentation](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/#docker-caching-in-github-actions) for more info.
 
 This is a composite GitHub Action, used to push docker images to Google Artifact Registry (GAR).
 It uses [OIDC authentication](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)


### PR DESCRIPTION
This pull request updates the documentation for two GitHub Actions to include information about a Docker mirror available on Grafana Labs' self-hosted runners. The changes aim to provide clearer guidance for internal users.

Documentation updates:

* [`actions/build-push-to-dockerhub/README.md`](diffhunk://#diff-f63b08ade8c2f33b4b8d70e8dc733819a744f95418c95120c7dfdc35f7267daeR3-R7): Added a note about the availability of a Docker mirror on Grafana Labs' self-hosted runners and linked to the internal documentation for more details.
* [`actions/push-to-gar-docker/README.md`](diffhunk://#diff-508a84f0112127461c8c1801dfd39d202ecda902821a89b8b933708ec25163c3L4-R6): Updated the existing note to include information about the Docker mirror on Grafana Labs' self-hosted runners, along with a link to the relevant internal documentation.