### PR TITLE
build: replace tag separator `/` (slash) with `-` (hyphen)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -145,5 +145,6 @@
     }
   },
   "release-type": "simple",
+  "tag-separator": "/",
   "separate-pull-requests": true
 }


### PR DESCRIPTION
See issue for more information https://github.com/grafana/shared-workflows/issues/981 

Dependabot and Renovate seem to follow a "namespaced" solution when it comes to tagging versions in monorepos. We should try to follow that to make automated updates smoother.

Note that changes won't happen to tags until new changes are made to the actions themselves

--------

## Things I've tried

Have made the exact same field addition in another private repo of mine, and created two new versions:
![image](https://github.com/user-attachments/assets/8d13d0d1-0b4e-4417-9abe-9c8e5e67ffe1)
<img width="923" alt="image" src="https://github.com/user-attachments/assets/2f856521-d7d5-4249-8d27-2dc097c3b2bb" />

Then I used the test-action in a random workflow tagged as `test-action/v1.1.10` and ran dependabot manually.
This returns:

![image](https://github.com/user-attachments/assets/bf909322-b834-4680-a784-1a501f7129bd)
Along with a PR to update the actual dependency.


--------

## Resources
* [Git Documentation](https://git-scm.com/docs/git-check-ref-format#_description)
* Convo w/ GitHub support:

```
Now lets see how Dependabot handles that.
In https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_parser.rb#L117:
 
name = version_class.path_based?(ref) ? string : repo_name
 
If we look now at how the path_based is defined https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/version.rb#L34:
 
def self.path_based?(version)
        version.to_s.match?(%r{\A.+/v?([0-9])})
      end
 
This regular expression matches any string that begins with any sequence of characters, followed by a forward slash /, and immediately after the slash, there is an optional v character preceding a single digit.
 
Since it fails to match the path based one it will be treated as a single tag my-action-a-v1.0.0 and that is not a recognizable version. 
Related code:
https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/version.rb#L38
```