### PR TITLE
feat!: only allow direct workload identity federation in login-to-gar

### DIFF
--- a/.github/workflows/test-login-to-gar.yaml
+++ b/.github/workflows/test-login-to-gar.yaml
@@ -26,11 +26,6 @@ permissions:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        enviromnent:
-          - dev
-          - prod
     runs-on: ubuntu-latest
     # Don't run for forks - they don't have access to secrets
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -49,5 +44,4 @@ jobs:
         id: test-login-to-gar
         uses: ./actions/login-to-gar
         with:
-          environment: ${{ matrix.enviromnent }}
           registry: "us-docker.pkg.dev"

--- a/actions/login-to-gar/README.md
+++ b/actions/login-to-gar/README.md
@@ -23,7 +23,6 @@ jobs:
         id: login-to-gar
         with:
           registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev
-          environment: "prod" # can be either dev/prod
 ```
 
 <!-- x-release-please-end-version -->
@@ -33,7 +32,6 @@ jobs:
 | Name                      | Description                                                                                                                             | Default             |
 | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------- |
 | `registry`                | Google Artifact Registry to authenticate against.                                                                                       | `us-docker.pkg.dev` |
-| `environment`             | Environment for pushing artifacts (can be either dev or prod).                                                                          | `dev`               |
 | `delete_credentials_file` | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false. | `false`             |
 
 > [!WARNING]

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -5,10 +5,6 @@ inputs:
     description: |
       Google Artifact Registry to authenticate against.
     default: "us-docker.pkg.dev"
-  environment:
-    description: |
-      Environment for pushing artifacts (can be either dev or prod).
-    default: dev
   delete_credentials_file:
     description: |
       Delete the credentials file after the action is finished. 
@@ -18,42 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Construct service account
-      id: construct-service-account
-      shell: sh
-      env:
-        ENVIRONMENT: ${{ inputs.environment }}
-      run: |
-        SERVICE_ACCOUNT="github-${{ github.repository_id }}-${ENVIRONMENT}@grafanalabs-workload-identity.iam.gserviceaccount.com"
-        echo "service_account=${SERVICE_ACCOUNT}" | tee -a "${GITHUB_OUTPUT}"
-    # if service account exists, then authenticate using the service account
     - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      name: Auth with service account
-      id: auth_with_service_account
-      with:
-        token_format: access_token
-        workload_identity_provider: "projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider"
-        service_account: ${{ steps.construct-service-account.outputs.service_account }}
-      continue-on-error: true
-    - name: Service account deprecation warning
-      if: ${{ steps.auth_with_service_account.outputs.access_token != '' }}
-      shell: sh
-      run: |
-        echo "::warning::Warning: Authenticating with a Service Account is going to be deprecated on April 30. \
-        If you don't want to be affected by this change, either pin your action according to \
-        https://github.com/grafana/shared-workflows/blob/main/actions/login-to-gar/README.md or go to your repository config \
-        and stop using Service Accounts."
-    # authenticate using the access_token from the auth_with_service_account step
-    - name: Login to GAR
-      if: ${{ steps.auth_with_service_account.outputs.access_token != '' }}
-      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-      with:
-        registry: ${{ inputs.registry }}
-        username: oauth2accesstoken
-        password: ${{ steps.auth_with_service_account.outputs.access_token }}
-    # if service account doesn't exist, then authenticate using direct workload identity federation
-    - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
-      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       name: Auth with direct WIF
       id: auth_with_direct_wif
       with:
@@ -109,14 +70,12 @@ runs:
           echo "${RUNNER_TEMP}/docker-credential-gcr" >> $GITHUB_PATH
         fi
     - name: "Configure GCP Artifact Registry"
-      if: ${{ steps.auth_with_service_account.outputs.access_token == '' }}
       id: configure-docker
       shell: sh
       env:
         REGISTRY: ${{ inputs.registry }}
       run: docker-credential-gcr configure-docker --registries="${REGISTRY}"
     - name: Delete Google Application Credentials file
-      if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}
       shell: sh
       run: |
         if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then


### PR DESCRIPTION
Removes old deprecated authentication after all GAR ops have moved to Direct WIF.

Part of: https://github.com/issues/assigned?issue=grafana%7Cdeployment_tools%7C259653