### PR TITLE
fix: change url of the github-action.json

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -107,7 +107,7 @@ jobs:
             --time-cond github-action.json \
             --etag-save github-action.json-etag \
             --etag-compare github-action.json-etag \
-            https://json.schemastore.org/github-action.json);
+            https://www.schemastore.org/github-action.json);
 
           curl_exit_code="${?}";
 


### PR DESCRIPTION
`Validate action definitions` step is failing on every PR.

By running:

```bash
curl \
    --verbose \
    --retry 5 \
    --remote-time \
    --remote-name \
    --time-cond github-action.json \
    --etag-save github-action.json-etag \
    --etag-compare github-action.json-etag \
    https://json.schemastore.org/github-action.json
```

and trying to `cat` the result `github-actions.json` file, I got:

```bash
<head><title>Document Moved</title></head>
<body><h1>Object Moved</h1>This document may be found <a HREF="https://www.schemastore.org/github-action.json">here</a></body>%   
```

This PR makes this change.