### PR TITLE
fix(login-to-gar): check if delete_credentials_file is set

### DIFF
--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -78,9 +78,12 @@ runs:
     - name: Delete Google Application Credentials file
       shell: sh
       run: |
-        if [ "${{ inputs.delete_credentials_file }}" = 'true' ] && [ -n "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
-          rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+        if [ "${INPUTS_DELETE_CREDENTIALS_FILE}" = "true" ] && [ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+          rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
           echo "::notice::Successfully deleted credentials file"
         else
-          echo "::warning::Credentials file not found at ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
+          echo "::warning::Credentials file not found at ${GOOGLE_APPLICATION_CREDENTIALS}"
         fi
+      env:
+        INPUTS_DELETE_CREDENTIALS_FILE: ${{ inputs.delete_credentials_file }}
+        GOOGLE_APPLICATION_CREDENTIALS: ${{ env.GOOGLE_APPLICATION_CREDENTIALS }}

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -78,7 +78,7 @@ runs:
     - name: Delete Google Application Credentials file
       shell: sh
       run: |
-        if [ -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
+        if [ "${{ inputs.delete_credentials_file }}" = 'true' ] && [ -n "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}" ]; then
           rm -f "${{ env.GOOGLE_APPLICATION_CREDENTIALS }}"
           echo "::notice::Successfully deleted credentials file"
         else


### PR DESCRIPTION
After https://github.com/grafana/shared-workflows/pull/1009, there was a condition which checked for credentials path and the actual input flag which was accidentally removed. This PR adds it back.