### PR TITLE
fix(renovate): fix runs from non-forks

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,7 +44,7 @@ jobs:
 
     # We need a secret for the GitHub app, which isn't available for a fork, so
     # don't run there.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
In c0944351c68e107649cb9c9a86204b400b607564 we fixed the Renovate job to be skipped for PRs from forks. But at the same time we broke non-fork runs. The `if` condition was looking for `github.event.pull_request`, and of course that's not set for any other event.

Fix it so that we always run for non-PR events. The `on:` conditions take care of us there.
