### PR TITLE
fix(aws-auth): fix reference to the action's own path

### DIFF
--- a/actions/aws-auth/action.yaml
+++ b/actions/aws-auth/action.yaml
@@ -69,6 +69,6 @@ runs:
         if [[ ! -z "${REPOSITORY_PATH}" ]]; then
           cd ${REPOSITORY_PATH}/actions/aws-auth
         else
-          cd "${{ github.action_path }}"
+          cd "${GITHUB_ACTION_PATH}"
         fi
         ./resolve-aws-region.sh


### PR DESCRIPTION
This is a workaround for https://github.com/actions/runner/issues/716 (closed but not fixed): use `${GITHUB_ACTION_PATH}` instead of `${{ github.action_path }}`.
