### PR TITLE
ci: run the `pre-commit` workflow for the merge queue

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,7 @@ name: pre-commit
 
 on:
   pull_request:
+  merge_group:
 
 permissions: {}
 


### PR DESCRIPTION
This is a required check - it needs to run!
