### PR TITLE
fix(renovate): use a dry-run when run from the merge group

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -83,13 +83,13 @@ jobs:
           renovate-version: 39.252.0@sha256:f244c095f6f698e1ced593a8521dd2cc78d22beeaf4fb009450fbc977a2c5b36
           token: ${{ steps.generate-token.outputs.token }}
         env:
-          LOG_LEVEL: ${{ github.event_name == 'pull_request' && 'debug' || 'info' }}
+          LOG_LEVEL: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group') && 'debug' || 'info' }}
           # For pull requests, this means we'll get the dependencies of the PR's
           # branch, so you can fix/change things and see the results in the PR's
           # run. By default, Renovate will clone the main/default branch.
           RENOVATE_BASE_BRANCHES: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || null }}
           # Dry run if the event is pull_request, or workflow_dispatch AND the dry-run input is true
-          RENOVATE_DRY_RUN: ${{ (github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && 'full' || null }}
+          RENOVATE_DRY_RUN: ${{ (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry-run == 'true')) && 'full' || null }}
           RENOVATE_PLATFORM: github
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           RENOVATE_USERNAME: GrafanaRenovateBot


### PR DESCRIPTION
We've currently re-running Renovate for _any_ run in the merge group, which is making it push branches whenever anything is queued to be merged. This is causing way too many runs and unnecessary rebases and CI runs. We should only run in write mode on a schedule, on an explicit manual request, or from the main branch if Renovate's config itself changes
