### PR TITLE
feat(get-latest-workflow-artifact): consider runs triggered by comments

### DIFF
--- a/actions/get-latest-workflow-artifact/README.md
+++ b/actions/get-latest-workflow-artifact/README.md
@@ -17,6 +17,7 @@ Required permissions:
 | `path`                | Directory to store the artifact in                             | no       | `${{ github.workspace }}`                 |
 | `github-token`        | GitHub token                                                   | no       | `${{ github.token }}`                     |
 | `consider-inprogress` | Not only consider completed but also in-progress workflow runs | no       | `false`                                   |
+| `consider-comments`   | Also look for workflow runs triggered by comments              | no       | `false`                                   |
 
 | Output                   | Description                                            |
 | ------------------------ | ------------------------------------------------------ |

--- a/actions/get-latest-workflow-artifact/action.yml
+++ b/actions/get-latest-workflow-artifact/action.yml
@@ -10,6 +10,9 @@ inputs:
   consider-inprogress:
     description: Allow to also return artifacts from in-progress runs
     required: false
+  consider-comments:
+    description: Also look for workflow runs triggered by comments
+    required: false
   repository:
     description: Repository of the target workflow (e.g. `grafana/grafana`)
     required: false
@@ -64,6 +67,7 @@ runs:
         INPUT_ARTIFACT-NAME: ${{ inputs.artifact-name }}
         INPUT_WORKFLOW-ID: ${{ inputs.workflow-id }}
         INPUT_CONSIDER-INPROGRESS: ${{ inputs.consider-inprogress }}
+        INPUT_CONSIDER-COMMENTS: ${{ inputs.consider-comments }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
         INPUT_PR-NUMBER: ${{ inputs.pr-number }}
         INPUT_PATH: ${{ inputs.path }}

--- a/actions/get-latest-workflow-artifact/package.json
+++ b/actions/get-latest-workflow-artifact/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@actions/artifact": "2.3.2",
     "@actions/core": "1.11.1",
-    "@actions/github": "6.0.1"
+    "@actions/github": "6.0.1",
+    "@js-temporal/polyfill": "0.5.1"
   },
   "devDependencies": {
     "@octokit/openapi-types": "25.1.0",

--- a/actions/get-latest-workflow-artifact/src/main.ts
+++ b/actions/get-latest-workflow-artifact/src/main.ts
@@ -1,3 +1,6 @@
+import { Temporal, toTemporalInstant } from "@js-temporal/polyfill";
+Date.prototype.toTemporalInstant = toTemporalInstant;
+
 import * as core from "@actions/core";
 import { getOctokit } from "@actions/github";
 import { DefaultArtifactClient } from "@actions/artifact";
@@ -9,10 +12,12 @@ type WorkflowRunStatus = "in_progress" | "completed";
 type Artifact = components["schemas"]["artifact"];
 type GitHubClient = ReturnType<typeof getOctokit>;
 type WorkflowRun = components["schemas"]["workflow-run"];
+type IssueComment = components["schemas"]["issue-comment"];
+type PullRequest = components["schemas"]["pull-request-simple"];
 type GetLatestArtifactResponse = {
   artifact: Artifact;
   run: WorkflowRun;
-} | null;
+};
 
 async function main() {
   const ghToken = core.getInput("github-token", { required: true });
@@ -23,6 +28,7 @@ async function main() {
   const prNumber = parseInt(core.getInput("pr-number", { required: true }), 10);
   const artifactName = core.getInput("artifact-name", { required: true });
   const considerInProgress = core.getInput("consider-inprogress") === "true";
+  const considerComments = core.getInput("consider-comments") === "true";
   let path = core.getInput("path", { required: false });
 
   if (!path) {
@@ -47,7 +53,55 @@ async function main() {
 
   // Now let's get all workflows associated with this sha:
   // We start with in-progress ones if those are to be considered.
-  let found: GetLatestArtifactResponse = null;
+  let found: GetLatestArtifactResponse | null = null;
+  let foundForComment: GetLatestArtifactResponse | null = null;
+
+  if (considerComments) {
+    // If we need to consider workflow runs triggered by comments, then we
+    // cannot filter by head_sha but need to really go through all the runs of
+    // a particular workflow and hope it's still available through paging.
+    // Otherwise, we can only fallback and potentially get an outdated
+    // artifact:
+    //
+    // First we need to get a list of all the comments inside a PR but only
+    // those that happened before the PR was merged:
+    const mergedAt = data.merged_at;
+    const comment = await getRelevantComment(
+      client,
+      repoOwner,
+      repoName,
+      prNumber,
+      mergedAt,
+    );
+    if (comment) {
+      // Now that we have a comment, we need to find workflows triggered by it.
+      // The problem is, that there is no clear association between a workflow
+      // run and a comment triggering it available through the API. For this we
+      // need to look at workflows runs with the title of the PR (ideally at the
+      // time of the comment) and filter for all workflow runs that were trigger
+      // between [comment_time, comment_time+delta]. This is based on the
+      // assumption, that the title of a PR is stable around the time the fetch
+      // is made and the comment is created
+      const workflowRun = await getWorkflowRunForComment(
+        client,
+        repoOwner,
+        repoName,
+        workflowId,
+        data,
+        comment,
+        considerInProgress,
+      );
+      if (workflowRun) {
+        foundForComment = await getWorkflowRunArtifact(
+          client,
+          repoOwner,
+          repoName,
+          workflowRun,
+          artifactName,
+        );
+      }
+    }
+  }
 
   if (considerInProgress) {
     found = await getLatestArtifact(
@@ -59,7 +113,6 @@ async function main() {
       "in_progress",
       artifactName,
     );
-    core.setOutput("workflow-run-status", "in_progress");
   }
 
   if (!found) {
@@ -72,12 +125,22 @@ async function main() {
       "completed",
       artifactName,
     );
-    core.setOutput("workflow-run-status", "completed");
+  }
+
+  if (
+    found &&
+    foundForComment &&
+    found.run.created_at < foundForComment.run.created_at
+  ) {
+    found = foundForComment;
   }
 
   if (!found) {
     throw new Error(`No artifacts found with name ${artifactName}`);
   }
+
+  core.setOutput("workflow-run-status", found.run.status);
+
   const { artifact: foundArtifact, run } = found;
   const artifact = new DefaultArtifactClient();
   const response = await artifact.downloadArtifact(foundArtifact.id, {
@@ -99,10 +162,10 @@ async function getLatestArtifact(
   repoOwner: string,
   repoName: string,
   workflowId: string,
-  headSha: string,
+  headSha?: string,
   status: WorkflowRunStatus,
   artifactName: string,
-): Promise<GetLatestArtifactResponse> {
+): Promise<GetLatestArtifactResponse | null> {
   const {
     data: { workflow_runs: workflowRuns },
   }: { data: { workflow_runs: WorkflowRun[] } } =
@@ -113,25 +176,117 @@ async function getLatestArtifact(
       workflow_id: workflowId,
       status: status,
     });
+
   if (workflowRuns.length === 0) {
     console.log(`No ${status} runs found`);
     return null;
   }
   const run = workflowRuns[0];
-  // For in-progress workflows the artifact might not be available yet. For this scenario we do a bit of retrying:
-  const maxAttempts = status === "in_progress" ? 5 : 1;
+  return getWorkflowRunArtifact(client, repoOwner, repoName, run, artifactName);
+}
+
+async function getRelevantComment(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  mergedAt: string | null,
+): Promise<IssueComment | null> {
+  const comments: IssueComment[] = await client.paginate(
+    client.rest.issues.listComments,
+    {
+      owner,
+      repo,
+      issue_number: prNumber,
+      per_page: 100,
+    },
+  );
+  comments.reverse();
+  // Now drop all that are made *after* the PR was merged
+  for (const comment of comments) {
+    if (mergedAt && comment.created_at >= mergedAt) {
+      continue;
+    }
+    return comment;
+  }
+  return null;
+}
+
+async function getWorkflowRunForComment(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  workflowId: string,
+  pr: PullRequest,
+  comment: IssueComment,
+  considerInProgress: boolean,
+): Promise<WorkflowRun | null> {
+  console.log(
+    "Searching for workflows connected to comments. This can take a while…",
+  );
+  const commentCreatedAt = Temporal.Instant.from(comment.created_at);
+  const runsIterator = client.paginate.iterator(
+    client.rest.actions.listWorkflowRuns,
+    {
+      repo,
+      owner,
+      workflow_id: workflowId,
+      per_page: 100,
+      created: `${commentCreatedAt.toString()}..${commentCreatedAt.add({ minutes: 1 }).toString()}`,
+    },
+  );
+
+  let abort = false;
+  let page = 0;
+
+  const allowedStatus = ["completed", "success"];
+  if (considerInProgress) {
+    allowedStatus.push("in_progress");
+  }
+
+  for await (const runs of runsIterator) {
+    for (const run of runs.data) {
+      if (run.event !== "issue_comment") {
+        continue;
+      }
+      if (!allowedStatus.includes(run.status)) {
+        continue;
+      }
+      if (run.display_title !== pr.title) {
+        continue;
+      }
+      return run;
+    }
+    if (++page > 100) {
+      console.log("Aborting search after 100 pages");
+      abort = true;
+    }
+    if (abort) {
+      break;
+    }
+  }
+}
+
+async function getWorkflowRunArtifact(
+  client: GitHubClient,
+  owner: string,
+  repo: string,
+  run: WorkflowRun,
+  artifactName: string,
+): Promise<GetLatestArtifactResponse | null> {
+  const maxAttempts = run.status === "in_progress" ? 5 : 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     const {
       data: { artifacts },
     }: { data: { artifacts: Artifact[] } } =
       await client.rest.actions.listWorkflowRunArtifacts({
-        owner: repoOwner,
-        repo: repoName,
+        owner,
+        repo,
         run_id: run.id,
       });
     const artifact = artifacts.find((art) => art.name == artifactName);
     if (artifact) {
-      console.log(`Found ${status} artifact`);
+      console.log(`Found ${run.status} artifact`);
       return { artifact, run };
     }
     if (attempt < maxAttempts) {
@@ -142,4 +297,5 @@ async function getLatestArtifact(
   console.log("No artifact found");
   return null;
 }
+
 await main();

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@actions/artifact": "2.3.2",
         "@actions/core": "1.11.1",
         "@actions/github": "6.0.1",
+        "@js-temporal/polyfill": "0.5.1",
       },
       "devDependencies": {
         "@octokit/openapi-types": "25.1.0",
@@ -187,6 +188,8 @@
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -503,6 +506,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+
+    "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 


### PR DESCRIPTION
If a workflow is triggered by a comment, we have no clear way to associate it with a PR through the head_sha. Instead we have to look at the time and title of the run. This is not completely reliable but should be "good enough" for most cases. Due to that it is disabled by default.