### PR TITLE
chore(trigger-argo-workflow): use cli/v3

### DIFF
--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/argo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -31,6 +32,36 @@ type App struct {
 	instance  string
 
 	retries uint64
+}
+
+type FullConfig struct {
+	ArgoToken             string
+	LogLevel              *slog.LevelVar
+	AddCILabels           bool
+	Command               string
+	ExtraArgs             []string
+	Instance              string
+	Namespace             string
+	Retries               uint64
+	WorkflowTemplate      string
+	GitHubActionsMetadata GitHubActionsMetadata
+}
+
+func (a App) PrintConfig(w io.Writer, md GitHubActionsMetadata) error {
+	cfg := FullConfig{
+		ArgoToken:             a.argoToken,
+		LogLevel:              a.levelVar,
+		Command:               a.command,
+		WorkflowTemplate:      a.workflowTemplate,
+		Instance:              a.instance,
+		Namespace:             a.namespace,
+		Retries:               a.retries,
+		ExtraArgs:             a.extraArgs,
+		GitHubActionsMetadata: md,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(cfg)
 }
 
 var instanceToHost = map[string]string{

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -9,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/lmittmann/tint"
-	cli "github.com/urfave/cli/v2"
+	cli "github.com/urfave/cli/v3"
 	"github.com/willabides/actionslog"
 	"github.com/willabides/actionslog/human"
 	"golang.org/x/term"
@@ -69,35 +70,43 @@ func main() {
 		)
 	}
 
-	app := cli.NewApp()
+	app := cli.Command{}
 	app.Name = "Runs the Argo CLI"
 
-	app.Action = func(c *cli.Context) error { return run(c, &lv, logger) }
+	app.Action = func(ctx context.Context, c *cli.Command) error { return run(ctx, c, &lv, logger) }
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
-			Name:    flagAddCILabels,
-			EnvVars: []string{"ADD_CI_LABELS"},
-			Value:   false,
-			Usage:   "If true, the `--labels` argument will be added with values from the environment. This is forced for the `submit` command",
+			Name: flagAddCILabels,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("ADD_CI_LABELS"),
+			),
+			Value: false,
+			Usage: "If true, the `--labels` argument will be added with values from the environment. This is forced for the `submit` command",
 		},
 		&cli.StringFlag{
-			Name:     flagNamespace,
-			EnvVars:  []string{"ARGO_NAMESPACE"},
+			Name: flagNamespace,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("ARGO_NAMESPACE"),
+			),
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:     flagArgoToken,
-			EnvVars:  []string{"ARGO_TOKEN"},
+			Name: flagArgoToken,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("ARGO_TOKEN"),
+			),
 			Usage:    "The Argo token to use for authentication",
 			Required: true,
 		},
 		&cli.StringFlag{
-			Name:    flagLogLevel,
-			EnvVars: []string{"LOG_LEVEL"},
-			Usage:   "Which log level to use",
-			Value:   "info",
-			Action: func(c *cli.Context, level string) error {
+			Name: flagLogLevel,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("LOG_LEVEL"),
+			),
+			Usage: "Which log level to use",
+			Value: "info",
+			Action: func(ctx context.Context, c *cli.Command, level string) error {
 				level = strings.ToLower(level)
 
 				lvl, err := parseLogLevel(level)
@@ -111,10 +120,12 @@ func main() {
 			},
 		},
 		&cli.StringFlag{
-			Name:    flagInstance,
-			EnvVars: []string{"INSTANCE"},
-			Value:   "ops",
-			Action: func(c *cli.Context, instance string) error {
+			Name: flagInstance,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("INSTANCE"),
+			),
+			Value: "ops",
+			Action: func(ctx context.Context, c *cli.Command, instance string) error {
 				// Validate it is a known instance
 				instances := slices.Collect(maps.Keys(instanceToHost))
 				if !slices.Contains(instances, instance) {
@@ -129,16 +140,20 @@ func main() {
 			Usage: "Parameters to pass to the workflow template. Given as `key=value`. Specify multiple times for multiple parameters",
 		},
 		&cli.UintFlag{
-			Name:    flagRetries,
-			EnvVars: []string{"RETRIES"},
-			Value:   3,
-			Usage:   "Number of retries to make if the command fails",
+			Name: flagRetries,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("RETRIES"),
+			),
+			Value: 3,
+			Usage: "Number of retries to make if the command fails",
 		},
 		&cli.StringFlag{
-			Name:    flagWorkflowTemplate,
-			EnvVars: []string{"WORKFLOW_TEMPLATE"},
-			Usage:   "The workflow template to use",
-			Action: func(c *cli.Context, tpl string) error {
+			Name: flagWorkflowTemplate,
+			Sources: cli.NewValueSourceChain(
+				cli.EnvVar("WORKFLOW_TEMPLATE"),
+			),
+			Usage: "The workflow template to use",
+			Action: func(ctx context.Context, c *cli.Command, tpl string) error {
 				// Required if command is `submit`
 				if c.Args().First() == "submit" && tpl == "" {
 					return fmt.Errorf("required flag: %s", flagWorkflowTemplate)
@@ -148,13 +163,13 @@ func main() {
 		},
 	}
 
-	if err := app.Run(os.Args); err != nil {
+	if err := app.Run(context.Background(), os.Args); err != nil {
 		logger.With("error", err).Error("failed to run")
 		os.Exit(1)
 	}
 }
 
-func run(c *cli.Context, level *slog.LevelVar, logger *slog.Logger) error {
+func run(ctx context.Context, c *cli.Command, level *slog.LevelVar, logger *slog.Logger) error {
 	addCILabels := c.Bool(flagAddCILabels)
 	argoToken := c.String(flagArgoToken)
 	command := c.Args().First()
@@ -212,5 +227,5 @@ func run(c *cli.Context, level *slog.LevelVar, logger *slog.Logger) error {
 		retries: retries,
 	}
 
-	return argo.Run(c.Context, md)
+	return argo.Run(ctx, md)
 }

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main.go
@@ -73,7 +73,19 @@ func main() {
 	app := cli.Command{}
 	app.Name = "Runs the Argo CLI"
 
-	app.Action = func(ctx context.Context, c *cli.Command) error { return run(ctx, c, &lv, logger) }
+	app.Action = func(ctx context.Context, c *cli.Command) error {
+		return fmt.Errorf("please specify a command")
+	}
+
+	app.Commands = []*cli.Command{
+		{
+			Name:            "submit",
+			SkipFlagParsing: true,
+			Action: func(ctx context.Context, c *cli.Command) error {
+				return run(ctx, c, &lv, logger, "submit")
+			},
+		},
+	}
 
 	app.Flags = []cli.Flag{
 		&cli.BoolFlag{
@@ -169,10 +181,9 @@ func main() {
 	}
 }
 
-func run(ctx context.Context, c *cli.Command, level *slog.LevelVar, logger *slog.Logger) error {
+func run(ctx context.Context, c *cli.Command, level *slog.LevelVar, logger *slog.Logger, command string) error {
 	addCILabels := c.Bool(flagAddCILabels)
 	argoToken := c.String(flagArgoToken)
-	command := c.Args().First()
 	instance := c.String(flagInstance)
 	namespace := c.String(flagNamespace)
 	parameters := c.StringSlice(flagParameter)
@@ -188,7 +199,7 @@ func run(ctx context.Context, c *cli.Command, level *slog.LevelVar, logger *slog
 		extraArgs = append(extraArgs, "--parameter", param)
 	}
 
-	extraArgs = append(extraArgs, c.Args().Tail()...)
+	extraArgs = append(extraArgs, c.Args().Slice()...)
 
 	md, err := NewGitHubActionsMetadata()
 	if err != nil {

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main_test.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMainConfiguration(t *testing.T) {
+	tests := map[string]struct {
+		args  []string
+		env   map[string]string
+		check func(t *testing.T, cfg FullConfig)
+	}{
+		"with-extras": {
+			env: map[string]string{
+				"ARGO_TOKEN": "my-token",
+			},
+			args: []string{
+				"root",
+				"--print-config",
+				"--namespace", "my-namespace",
+				"--log-level", "debug",
+				"--instance", "ops",
+				"submit",
+				"--name", "something", "--param", "whatever",
+			},
+			check: func(t *testing.T, cfg FullConfig) {
+				require.Equal(t, []string{"--name", "something", "--param", "whatever"}, cfg.ExtraArgs)
+				require.Equal(t, slog.LevelDebug, cfg.LogLevel.Level())
+
+			},
+		},
+		"argo-token-as-flag": {
+			args: []string{
+				"root",
+				"--print-config",
+				"--argo-token", "my-token",
+				"--namespace", "my-namespace",
+				"--log-level", "warn",
+				"--instance", "ops",
+				"submit",
+			},
+			check: func(t *testing.T, cfg FullConfig) {
+				require.Equal(t, "my-token", cfg.ArgoToken)
+			},
+		},
+	}
+	for testName, test := range tests {
+		t.Run(testName, func(t *testing.T) {
+			for envName, envValue := range test.env {
+				t.Setenv(envName, envValue)
+			}
+			writer := &bytes.Buffer{}
+			runMain(test.args, writer, os.Stderr)
+			if test.check != nil {
+				cfg := FullConfig{}
+				require.NoError(t, json.NewDecoder(writer).Decode(&cfg))
+				test.check(t, cfg)
+				return
+			}
+			t.Log(writer.String())
+		})
+	}
+}

--- a/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main_test.go
+++ b/actions/trigger-argo-workflow/cmd/trigger-argo-workflow/main_test.go
@@ -57,13 +57,9 @@ func TestMainConfiguration(t *testing.T) {
 			}
 			writer := &bytes.Buffer{}
 			runMain(test.args, writer, os.Stderr)
-			if test.check != nil {
-				cfg := FullConfig{}
-				require.NoError(t, json.NewDecoder(writer).Decode(&cfg))
-				test.check(t, cfg)
-				return
-			}
-			t.Log(writer.String())
+			cfg := FullConfig{}
+			require.NoError(t, json.NewDecoder(writer).Decode(&cfg))
+			test.check(t, cfg)
 		})
 	}
 }

--- a/actions/trigger-argo-workflow/go.mod
+++ b/actions/trigger-argo-workflow/go.mod
@@ -7,21 +7,18 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lmittmann/tint v1.1.2
 	github.com/stretchr/testify v1.10.0
-	github.com/urfave/cli/v2 v2.27.7
+	github.com/urfave/cli/v3 v3.3.8
 	github.com/willabides/actionslog v0.5.1
 	golang.org/x/term v0.32.0
 )
 
 require (
-	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.10.0 // indirect
 	github.com/goccy/go-yaml v1.11.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/russross/blackfriday/v2 v2.1.0 // indirect
-	github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/actions/trigger-argo-workflow/go.sum
+++ b/actions/trigger-argo-workflow/go.sum
@@ -1,7 +1,5 @@
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
-github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
-github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
@@ -28,16 +26,12 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
-github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
-github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
+github.com/urfave/cli/v3 v3.3.8 h1:BzolUExliMdet9NlJ/u4m5vHSotJ3PzEqSAZ1oPMa/E=
+github.com/urfave/cli/v3 v3.3.8/go.mod h1:FJSKtM/9AiiTOJL4fJ6TbMUkxBXn7GO9guZqoZtpYpo=
 github.com/willabides/actionslog v0.5.1 h1:dJ/Cxg8vO1pEohgC2O4CW1tCWFKJrYJXTZDWYJQK0+E=
 github.com/willabides/actionslog v0.5.1/go.mod h1:WDufDP3XZUMBOmau2BvfVCGYuUcVRZI6Eqy8ZRw4pJ8=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
-github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=


### PR DESCRIPTION
Besides the "normal" updates this also moves the "submit" command into a proper subcommand which is necessary because otherwise the extraArgs would interfere with the rest of the argument parsing. Despite that, this change should not
be breaking since the `submit` command was also necessary in the previous implementation.