### PR TITLE
feat(dependabot-auto-triage): close PRs related to dismissed alerts

### DIFF
--- a/actions/dependabot-auto-triage/README.md
+++ b/actions/dependabot-auto-triage/README.md
@@ -60,6 +60,7 @@ jobs:
             ksonnet/lib/argo-workflows/charts/**/*.json
           dismissal-reason: "not_used"
           dismissal-comment: "These dependencies are not used in production and pose no risk"
+          close-prs: "true"  # Optional: close associated Dependabot PRs
 ```
 
 <!-- x-release-please-end-version -->
@@ -73,12 +74,15 @@ jobs:
 | `paths`             | Multi-line list of glob patterns to match manifest paths to dismiss                                               | Yes      | N/A                                                   |
 | `dismissal-comment` | Default comment to add when dismissing alerts                                                                     | No       | `Auto-dismissed based on manifest path configuration` |
 | `dismissal-reason`  | Default reason for dismissal (options: `fix_started`, `inaccurate`, `no_bandwidth`, `not_used`, `tolerable_risk`) | No       | `not_used`                                            |
+| `close-prs`         | Whether to close associated Dependabot pull requests before dismissing alerts                                     | No       | `false`                                               |
 
 ### How It Works
 
 1. The action fetches all open Dependabot alerts for the repository
 2. For each alert, it checks if the manifest path matches any of the provided glob patterns
-3. If the path matches a pattern, it dismisses the alert with the specified reason and comment
+3. If `close-prs` is enabled, it fetches associated pull requests for matching alerts
+4. For each matching alert, it optionally closes the associated pull request first (if `close-prs` is true)
+5. It then dismisses the alert with the specified reason and comment
 
 ### Glob Pattern Syntax
 
@@ -100,6 +104,7 @@ To use this action, you need:
 1. A GitHub App with the following permissions:
    - Repository permissions:
      - **Dependabot alerts**: Read & Write
+     - **Pull requests**: Read & Write (only required if `close-prs` is set to `true`)
 
 2. The GitHub App needs to be installed on your repository or organization
 

--- a/actions/dependabot-auto-triage/action.yml
+++ b/actions/dependabot-auto-triage/action.yml
@@ -23,6 +23,10 @@ inputs:
     required: false
     default: "not_used"
     # Options: 'fix_started', 'inaccurate', 'no_bandwidth', 'not_used', 'tolerable_risk'
+  close-prs:
+    description: "Whether to close associated pull requests when dismissing alerts"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -47,6 +51,7 @@ runs:
         INPUT_PATHS: ${{ inputs.paths }}
         INPUT_DISMISSAL_COMMENT: ${{ inputs.dismissal-comment }}
         INPUT_DISMISSAL_REASON: ${{ inputs.dismissal-reason }}
+        INPUT_CLOSE_PRS: ${{ inputs.close-prs }}
         NODE_ENV: "production"
       run: |
         bun run src/index.ts

--- a/actions/dependabot-auto-triage/package.json
+++ b/actions/dependabot-auto-triage/package.json
@@ -11,6 +11,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@octokit/graphql": "^9.0.1",
     "@octokit/request-error": "7.0.0",
     "@octokit/rest": "22.0.0",
     "minimatch": "10.0.3"

--- a/actions/dependabot-auto-triage/src/index.test.ts
+++ b/actions/dependabot-auto-triage/src/index.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   matchesAnyPattern,
   fetchAllAlerts,
+  fetchSpecificAlertsWithPRs,
   run,
   DependabotAlert,
 } from "./index";
@@ -22,7 +23,20 @@ import * as minimatchModule from "minimatch"; // Import for spying
 const mockOctokit = {
   request: mock(),
   paginate: mock(),
+  rest: {
+    pulls: {
+      update: mock(),
+    },
+  },
 };
+
+// Mock the graphql module
+const mockGraphql = mock();
+await mock.module("@octokit/graphql", () => ({
+  graphql: {
+    defaults: mock(() => mockGraphql),
+  },
+}));
 
 await mock.module("@octokit/rest", () => ({
   Octokit: mock(() => mockOctokit),
@@ -37,12 +51,15 @@ describe("Dependabot Auto Triage Action", () => {
     // Reset mocks and environment variables
     mockOctokit.request.mockClear();
     mockOctokit.paginate.mockClear();
+    mockOctokit.rest.pulls.update.mockClear();
+    mockGraphql.mockClear();
     process.env.GITHUB_TOKEN = "test-token";
     process.env.GITHUB_REPOSITORY = "owner/repo";
     process.env.INPUT_ALERT_TYPES = "dependency";
     process.env.INPUT_PATHS = "**/package-lock.json\n**/yarn.lock";
     process.env.INPUT_DISMISSAL_COMMENT = "Test dismissal comment";
     process.env.INPUT_DISMISSAL_REASON = "tolerable_risk";
+    process.env.INPUT_CLOSE_PRS = "false";
 
     // Spy on console messages and process.exit
     consoleLogSpy = spyOn(console, "log").mockImplementation(() => {});
@@ -61,6 +78,7 @@ describe("Dependabot Auto Triage Action", () => {
     delete process.env.INPUT_PATHS;
     delete process.env.INPUT_DISMISSAL_COMMENT;
     delete process.env.INPUT_DISMISSAL_REASON;
+    delete process.env.INPUT_CLOSE_PRS;
   });
 
   describe("matchesAnyPattern", () => {
@@ -250,6 +268,113 @@ describe("Dependabot Auto Triage Action", () => {
     });
   });
 
+  describe("fetchSpecificAlertsWithPRs", () => {
+    it("should fetch alerts with associated PRs using GraphQL", async () => {
+      const alertNumbers = [1, 2, 3];
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: {
+            number: 1,
+            dependabotUpdate: {
+              pullRequest: { number: 101 },
+            },
+          },
+          alert1: {
+            number: 2,
+            dependabotUpdate: null,
+          },
+          alert2: {
+            number: 3,
+            dependabotUpdate: {
+              pullRequest: { number: 103 },
+            },
+          },
+        },
+      };
+
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      const result = await fetchSpecificAlertsWithPRs(
+        "test-token",
+        "owner",
+        "repo",
+        alertNumbers,
+      );
+
+      expect(result.size).toBe(2);
+      expect(result.get(1)).toBe(101);
+      expect(result.get(2)).toBeUndefined();
+      expect(result.get(3)).toBe(103);
+      expect(mockGraphql).toHaveBeenCalledWith(
+        expect.stringContaining("query GetSpecificVulnerabilityAlerts"),
+        { owner: "owner", repo: "repo" },
+      );
+    });
+
+    it("should return empty map for empty alert numbers", async () => {
+      const result = await fetchSpecificAlertsWithPRs(
+        "test-token",
+        "owner",
+        "repo",
+        [],
+      );
+
+      expect(result.size).toBe(0);
+      expect(mockGraphql).not.toHaveBeenCalled();
+    });
+
+    it("should handle null alerts in GraphQL response", async () => {
+      const alertNumbers = [1, 2];
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: null,
+          alert1: {
+            number: 2,
+            dependabotUpdate: {
+              pullRequest: { number: 102 },
+            },
+          },
+        },
+      };
+
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      const result = await fetchSpecificAlertsWithPRs(
+        "test-token",
+        "owner",
+        "repo",
+        alertNumbers,
+      );
+
+      expect(result.size).toBe(1);
+      expect(result.get(1)).toBeUndefined();
+      expect(result.get(2)).toBe(102);
+    });
+
+    it("should handle alerts without pull requests", async () => {
+      const alertNumbers = [1];
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: {
+            number: 1,
+            dependabotUpdate: null,
+          },
+        },
+      };
+
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      const result = await fetchSpecificAlertsWithPRs(
+        "test-token",
+        "owner",
+        "repo",
+        alertNumbers,
+      );
+
+      expect(result.size).toBe(0);
+    });
+  });
+
   // More tests for fetchAllAlerts and run will be added here
   describe("run", () => {
     const createMockAlert = (
@@ -328,7 +453,7 @@ describe("Dependabot Auto Triage Action", () => {
         "Alert #2 dismissed successfully",
       );
       expect(consoleLogSpy).toHaveBeenCalledWith(
-        "Successfully dismissed 2 alerts.",
+        "Successfully processed 2 alerts.",
       );
       expect(processExitSpy).not.toHaveBeenCalled();
     });
@@ -542,6 +667,239 @@ describe("Dependabot Auto Triage Action", () => {
         "Some other dismiss error",
       );
       expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should close PRs when INPUT_CLOSE_PRS is true", async () => {
+      const mockAlerts: DependabotAlert[] = [
+        createMockAlert(1, "high", "pkg-a", "src/package-lock.json"),
+        createMockAlert(2, "critical", "pkg-b", "other/yarn.lock"),
+      ];
+      mockOctokit.paginate.mockResolvedValue(mockAlerts);
+      mockOctokit.request.mockResolvedValue({ status: 200 }); // For dismissal
+      mockOctokit.rest.pulls.update.mockResolvedValue({ status: 200 }); // For PR closure
+
+      // Mock successful repo check
+      mockOctokit.request.mockImplementation((route: string) => {
+        if (route === "GET /repos/{owner}/{repo}") {
+          return { data: { owner: { login: "test-user" } } };
+        }
+        if (
+          route ===
+          "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+        ) {
+          return { status: 200 };
+        }
+        return {};
+      });
+
+      // Mock GraphQL response for PR mappings
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: {
+            number: 1,
+            dependabotUpdate: {
+              pullRequest: { number: 101 },
+            },
+          },
+          alert1: {
+            number: 2,
+            dependabotUpdate: {
+              pullRequest: { number: 102 },
+            },
+          },
+        },
+      };
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      process.env.INPUT_PATHS = "src/package-lock.json\nother/yarn.lock";
+      process.env.INPUT_CLOSE_PRS = "true";
+
+      await run();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Fetching PR mappings for alerts before dismissal...",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Found 2 alerts with associated PRs",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Closing PR #101 for alert #1...",
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Closing PR #102 for alert #2...",
+      );
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "repo",
+        pull_number: 101,
+        state: "closed",
+      });
+      expect(mockOctokit.rest.pulls.update).toHaveBeenCalledWith({
+        owner: "owner",
+        repo: "repo",
+        pull_number: 102,
+        state: "closed",
+      });
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Successfully processed 2 alerts.",
+      );
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+
+    it("should handle error when fetching PR mappings", async () => {
+      const mockAlerts: DependabotAlert[] = [
+        createMockAlert(1, "high", "pkg-a", "src/package-lock.json"),
+      ];
+      mockOctokit.paginate.mockResolvedValue(mockAlerts);
+
+      // Mock successful repo check
+      mockOctokit.request.mockImplementation((route: string) => {
+        if (route === "GET /repos/{owner}/{repo}") {
+          return { data: { owner: { login: "test-user" } } };
+        }
+        return {};
+      });
+
+      // Mock GraphQL error
+      mockGraphql.mockRejectedValue(new Error("GraphQL API error"));
+
+      process.env.INPUT_PATHS = "src/package-lock.json";
+      process.env.INPUT_CLOSE_PRS = "true";
+
+      await run();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error fetching alert-PR mappings. Cannot proceed with PR closure.",
+        expect.any(Error),
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle error when closing PRs", async () => {
+      const mockAlerts: DependabotAlert[] = [
+        createMockAlert(1, "high", "pkg-a", "src/package-lock.json"),
+      ];
+      mockOctokit.paginate.mockResolvedValue(mockAlerts);
+      mockOctokit.request.mockResolvedValue({ status: 200 }); // For repo check
+      mockOctokit.rest.pulls.update.mockRejectedValue(
+        new Error("PR close error"),
+      );
+
+      // Mock successful repo check
+      mockOctokit.request.mockImplementation((route: string) => {
+        if (route === "GET /repos/{owner}/{repo}") {
+          return { data: { owner: { login: "test-user" } } };
+        }
+        return {};
+      });
+
+      // Mock GraphQL response for PR mappings
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: {
+            number: 1,
+            dependabotUpdate: {
+              pullRequest: { number: 101 },
+            },
+          },
+        },
+      };
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      process.env.INPUT_PATHS = "src/package-lock.json";
+      process.env.INPUT_CLOSE_PRS = "true";
+
+      await run();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "Error closing PR #101 for alert #1:",
+        expect.any(Error),
+      );
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should skip closing PRs when no PR mappings are found", async () => {
+      const mockAlerts: DependabotAlert[] = [
+        createMockAlert(1, "high", "pkg-a", "src/package-lock.json"),
+      ];
+      mockOctokit.paginate.mockResolvedValue(mockAlerts);
+      mockOctokit.request.mockResolvedValue({ status: 200 }); // For dismissal
+
+      // Mock successful repo check
+      mockOctokit.request.mockImplementation((route: string) => {
+        if (route === "GET /repos/{owner}/{repo}") {
+          return { data: { owner: { login: "test-user" } } };
+        }
+        if (
+          route ===
+          "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+        ) {
+          return { status: 200 };
+        }
+        return {};
+      });
+
+      // Mock GraphQL response with no PR mappings
+      const mockGraphqlResponse = {
+        repository: {
+          alert0: {
+            number: 1,
+            dependabotUpdate: null,
+          },
+        },
+      };
+      mockGraphql.mockResolvedValue(mockGraphqlResponse);
+
+      process.env.INPUT_PATHS = "src/package-lock.json";
+      process.env.INPUT_CLOSE_PRS = "true";
+
+      await run();
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Found 0 alerts with associated PRs",
+      );
+      expect(mockOctokit.rest.pulls.update).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Alert #1 dismissed successfully",
+      );
+      expect(processExitSpy).not.toHaveBeenCalled();
+    });
+
+    it("should not fetch PR mappings when INPUT_CLOSE_PRS is false", async () => {
+      const mockAlerts: DependabotAlert[] = [
+        createMockAlert(1, "high", "pkg-a", "src/package-lock.json"),
+      ];
+      mockOctokit.paginate.mockResolvedValue(mockAlerts);
+      mockOctokit.request.mockResolvedValue({ status: 200 }); // For dismissal
+
+      // Mock successful repo check
+      mockOctokit.request.mockImplementation((route: string) => {
+        if (route === "GET /repos/{owner}/{repo}") {
+          return { data: { owner: { login: "test-user" } } };
+        }
+        if (
+          route ===
+          "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}"
+        ) {
+          return { status: 200 };
+        }
+        return {};
+      });
+
+      process.env.INPUT_PATHS = "src/package-lock.json";
+      process.env.INPUT_CLOSE_PRS = "false";
+
+      await run();
+
+      expect(consoleLogSpy).not.toHaveBeenCalledWith(
+        "Fetching PR mappings for alerts before dismissal...",
+      );
+      expect(mockGraphql).not.toHaveBeenCalled();
+      expect(mockOctokit.rest.pulls.update).not.toHaveBeenCalled();
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        "Alert #1 dismissed successfully",
+      );
+      expect(processExitSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/actions/dependabot-auto-triage/src/index.ts
+++ b/actions/dependabot-auto-triage/src/index.ts
@@ -45,6 +45,7 @@ export async function run() {
 
     const dismissalComment = process.env.INPUT_DISMISSAL_COMMENT;
     const dismissalReason = process.env.INPUT_DISMISSAL_REASON;
+    const closePRs = process.env.INPUT_CLOSE_PRS === "true";
 
     const allowedDismissalReasons = [
       "fix_started",
@@ -136,20 +137,22 @@ export async function run() {
         return;
       }
 
-      // Fetch alert-PR mappings
-      console.log("Fetching PR mappings for alerts before dismissal...");
+      // Fetch alert-PR mappings only if we need to close PRs
       let alertPRMappings = new Map<number, number>();
-      try {
-        alertPRMappings = await fetchSpecificAlertsWithPRs(
-          token,
-          owner,
-          repo,
-          alertsToProcess,
-        );
-        console.log(`Found ${alertPRMappings.size} alerts with associated PRs`);
-      } catch (error) {
-        console.error("Error fetching alert-PR mappings. Cannot proceed with PR closure.", error);
-        process.exit(1);
+      if (closePRs) {
+        console.log("Fetching PR mappings for alerts before dismissal...");
+        try {
+          alertPRMappings = await fetchSpecificAlertsWithPRs(
+            token,
+            owner,
+            repo,
+            alertsToProcess,
+          );
+          console.log(`Found ${alertPRMappings.size} alerts with associated PRs`);
+        } catch (error) {
+          console.error("Error fetching alert-PR mappings. Cannot proceed with PR closure.", error);
+          process.exit(1);
+        }
       }
 
       console.log(`Dismissing ${alertsToProcess.length} alerts...`);

--- a/bun.lock
+++ b/bun.lock
@@ -21,6 +21,7 @@
       "name": "auto-dismiss-dependabot-alerts",
       "version": "0.1.0",
       "dependencies": {
+        "@octokit/graphql": "^9.0.1",
         "@octokit/request-error": "7.0.0",
         "@octokit/rest": "22.0.0",
         "minimatch": "10.0.3",
@@ -201,7 +202,7 @@
 
     "@octokit/core": ["@octokit/core@7.0.3", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.1", "@octokit/request": "^10.0.2", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ=="],
 
-    "@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+    "@octokit/endpoint": ["@octokit/endpoint@11.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ=="],
 
     "@octokit/graphql": ["@octokit/graphql@9.0.1", "", { "dependencies": { "@octokit/request": "^10.0.2", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-j1nQNU1ZxNFx2ZtKmL4sMrs4egy5h65OMDmSbVyuCzjOcwsHq6EaYjOTGXPQxgfiN8dJ4CriYHk6zF050WEULg=="],
 
@@ -215,7 +216,7 @@
 
     "@octokit/plugin-retry": ["@octokit/plugin-retry@3.0.9", "", { "dependencies": { "@octokit/types": "^6.0.3", "bottleneck": "^2.15.3" } }, "sha512-r+fArdP5+TG6l1Rv/C9hVoty6tldw6cE2pRHNGmFPdyfrc696R6JjrQ3d7HdVqGwuzfyrcaLAKD7K8TX8aehUQ=="],
 
-    "@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+    "@octokit/request": ["@octokit/request@10.0.3", "", { "dependencies": { "@octokit/endpoint": "^11.0.0", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA=="],
 
     "@octokit/request-error": ["@octokit/request-error@7.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0" } }, "sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg=="],
 
@@ -731,6 +732,8 @@
 
     "@actions/github/@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@10.4.1", "", { "dependencies": { "@octokit/types": "^12.6.0" }, "peerDependencies": { "@octokit/core": "5" } }, "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg=="],
 
+    "@actions/github/@octokit/request": ["@octokit/request@8.4.1", "", { "dependencies": { "@octokit/endpoint": "^9.0.6", "@octokit/request-error": "^5.1.1", "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw=="],
+
     "@actions/github/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
 
     "@bufbuild/protoplugin/typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
@@ -751,21 +754,7 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
-    "@octokit/core/@octokit/request": ["@octokit/request@10.0.3", "", { "dependencies": { "@octokit/endpoint": "^11.0.0", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA=="],
-
-    "@octokit/endpoint/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
-
-    "@octokit/endpoint/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
-
-    "@octokit/graphql/@octokit/request": ["@octokit/request@10.0.3", "", { "dependencies": { "@octokit/endpoint": "^11.0.0", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA=="],
-
     "@octokit/plugin-retry/@octokit/types": ["@octokit/types@6.41.0", "", { "dependencies": { "@octokit/openapi-types": "^12.11.0" } }, "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg=="],
-
-    "@octokit/request/@octokit/request-error": ["@octokit/request-error@5.1.1", "", { "dependencies": { "@octokit/types": "^13.1.0", "deprecation": "^2.0.0", "once": "^1.4.0" } }, "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g=="],
-
-    "@octokit/request/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
-
-    "@octokit/request/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
 
     "@octokit/rest/@octokit/core": ["@octokit/core@7.0.2", "", { "dependencies": { "@octokit/auth-token": "^6.0.0", "@octokit/graphql": "^9.0.1", "@octokit/request": "^10.0.2", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "before-after-hook": "^4.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-ODsoD39Lq6vR6aBgvjTnA3nZGliknKboc9Gtxr7E4WDNqY24MxANKcuDQSF0jzapvGb3KWOEDrKfve4HoWGK+g=="],
 
@@ -865,21 +854,17 @@
 
     "@actions/github/@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@12.6.0", "", { "dependencies": { "@octokit/openapi-types": "^20.0.0" } }, "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw=="],
 
+    "@actions/github/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@9.0.6", "", { "dependencies": { "@octokit/types": "^13.1.0", "universal-user-agent": "^6.0.0" } }, "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw=="],
+
+    "@actions/github/@octokit/request/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@actions/github/@octokit/request/universal-user-agent": ["universal-user-agent@6.0.1", "", {}, "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="],
+
     "@actions/github/@octokit/request-error/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "@commitlint/config-validator/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ=="],
-
-    "@octokit/endpoint/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
-
-    "@octokit/graphql/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ=="],
-
     "@octokit/plugin-retry/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@12.11.0", "", {}, "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="],
-
-    "@octokit/request/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
-
-    "@octokit/rest/@octokit/core/@octokit/request": ["@octokit/request@10.0.3", "", { "dependencies": { "@octokit/endpoint": "^11.0.0", "@octokit/request-error": "^7.0.0", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^3.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.35.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.35.0", "@typescript-eslint/types": "^8.35.0", "debug": "^4.3.4" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ=="],
 
@@ -945,7 +930,7 @@
 
     "@actions/github/@octokit/request-error/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
-    "@octokit/rest/@octokit/core/@octokit/request/@octokit/endpoint": ["@octokit/endpoint@11.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ=="],
+    "@actions/github/@octokit/request/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
     "@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 


### PR DESCRIPTION
Apparently when you dismiss an alert the PR is not automatically closed, this give the option of turning `close-prs` to `true` and giving the bot extra permissions so PRs are closed as alerts are dismissed.