### PR TITLE
fix(codeowners): update ownership of generate-openapi-clients action

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,8 +8,8 @@
 .github/workflows/build-lint-pr.yml  @grafana/infra-o11y-frontend
 /actions/lint-pr-title/              @grafana/infra-o11y-frontend @grafana/platform-productivity
 
-# Platform CAT
-/actions/generate-openapi-clients @grafana/platform-cat
+# Grafana App Platform
+/actions/generate-openapi-clients @grafana/grafana-app-platform-squad
 
 # Platform productivity
 /.github/workflows/publish-techdocs.yaml @grafana/platform-productivity


### PR DESCRIPTION
CODEOWNERS currently attributes ownership to Platform CAT. The new owners should be @grafana/grafana-app-platform-squad .

- Added @grafana/grafana-app-platform-squad to teams for this repo
- Updated ownership of `actions/generate-openapi-clients` action