### PR TITLE
feat: add support for ignoring missing secrets to get-vault-secrets action

### DIFF
--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -31,11 +31,11 @@ inputs:
     description: |
       Whether to export secrets as environment variables, making them available to all subsequent steps. Defaults to `true`.
     default: "true"
-  
+
   ignore_missing:
     description: |
       When set to true, prevents the action from failing when a secret does not exist.
-    default: "false"    
+    default: "false"
 
 outputs:
   secrets:


### PR DESCRIPTION
This will let creating workflows that could fetch secrets and fallback to something else if they're missing.