### PR TITLE
fix(ci): add `ready_for_review` type to pull request triggers for `pre-commit` workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -2,6 +2,11 @@ name: pre-commit
 
 on:
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
   merge_group:
 
 permissions: {}


### PR DESCRIPTION
Currently, `release-please` PRs (and other PRs triggered by bots) are getting blocked by certain checks that aren't getting triggered, namely `pre-commit`, which lacks a `ready_for_review` pull request trigger type, meaning it never gets ran on bot PRs, as the other trigger types don't get activated. This PR should resolve that.

<details><summary>Old description</summary>

#1036 is currently stuck on some CI jobs as a result of CodeQL, pre-commit, and Zizmor not working when the PR author is `github-actions[bot]`. This PR allows them to be skipped in that case, but adds `policy-bot` to enforce that.

One question is if any work needs to be done to apply the same restrictions laid out in [this part of our terraform config for this repository](https://github.com/grafana/deployment_tools/blob/6edab68ece5e841aa5558b2c6a1dd89800330100/terraform/repositories/shared-workflows/main.tf#L103-L109).

</details>