### PR TITLE
fix(run-capslock): checkout with credentials needed

### DIFF
--- a/actions/run-capslock/action.yaml
+++ b/actions/run-capslock/action.yaml
@@ -27,6 +27,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      with:
+        persist-credentials: true
     - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
       with:
         go-version: "${{ inputs.go-version }}"


### PR DESCRIPTION
For make it work the run-capslock action git persist credentials is needed. Added clean checkout credentials after capslock step run.