### PR TITLE
chore: disable major version updates for .NET SDK

### DIFF
--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -44,6 +44,12 @@
       matchUpdateTypes: ["digest"],
     },
     {
+      extends: ["monorepo:dotnet"],
+      description: ["Disable major version updates for .NET"],
+      matchUpdateTypes: ["major"],
+      enabled: false
+    },
+    {
       // Run the custom matcher on early Monday mornings (UTC)
       schedule: "* 0-4 * * 1",
       matchPackageNames: ["ghcr.io/renovatebot/renovate"],

--- a/.github/renovate-config.json5
+++ b/.github/renovate-config.json5
@@ -47,7 +47,7 @@
       extends: ["monorepo:dotnet"],
       description: ["Disable major version updates for .NET"],
       matchUpdateTypes: ["major"],
-      enabled: false
+      enabled: false,
     },
     {
       // Run the custom matcher on early Monday mornings (UTC)


### PR DESCRIPTION
Disable major version updates for .NET in the Renovate config.

https://github.com/grafana/shared-workflows/pull/1305#pullrequestreview-3189208284
