### PR TITLE
feat: add cleanup-branches action

### DIFF
--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -1,0 +1,37 @@
+# cleanup-branches
+
+Composite action (step) to get create github app token using vault. This action will query for for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'. Protected branches are excluded as well.
+
+## Inputs
+
+| Name             | Type   | Description                                                                                                                                                                    | Default Value         | Required |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | -------- |
+| `token`          | string | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read) | `${{ github.token }}` | true     |
+| `dry-run`        | bool   | If 'dry-run' is not 'true', then the action will print branches to be deleted, but will not delete them                                                                        | `"true"`              | true     |
+
+## Examples
+
+### Clean up branches on a weekly cron schedule
+
+<!-- x-release-please-start-version -->
+
+```yaml
+name: Clean up orphaned branches
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v5
+        uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v1.0.0
+        with:
+          dry-run: false
+```
+
+<!-- x-release-please-end-version -->

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -1,13 +1,13 @@
 # cleanup-branches
 
-Composite action (step) to get create github app token using vault. This action will query for for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'. Protected branches are excluded as well.
+Composite action (step) to query for for branches that are not in an open PR, and delete them if 'dry-run' is 'false'. Protected branches are excluded as well.
 
 ## Inputs
 
-| Name             | Type   | Description                                                                                                                                                                    | Default Value         | Required |
-| ---------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | -------- |
-| `token`          | string | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read) | `${{ github.token }}` | true     |
-| `dry-run`        | bool   | If 'dry-run' is not 'true', then the action will print branches to be deleted, but will not delete them                                                                        | `"true"`              | true     |
+| Name             | Type     | Description                                                                                                                                                                          | Default Value         | Required |
+| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | -------- |
+| `token`          | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`)   | `${{ github.token }}` | true     |
+| `dry-run`        | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                             | `'true'`              | true     |
 
 ## Examples
 
@@ -22,14 +22,14 @@ on:
     - cron: '0 9 * * 1'
 
 jobs:
-  main:
+  cleanup-branches::
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
     steps:
       - uses: actions/checkout@v5
-        uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v1.0.0
+      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v1.0.0
         with:
           dry-run: false
 ```

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -1,6 +1,6 @@
 # cleanup-branches
 
-Composite action (step) to query for for branches that are not in an open PR, and delete them if 'dry-run' is 'false'. Protected branches are excluded as well.
+Composite action (step) to query for branches that are not in an open PR, and delete them if 'dry-run' is 'false'. Protected branches are excluded as well.
 
 ## Inputs
 

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -8,6 +8,7 @@ Composite action (step) to query for for branches that are not in an open PR, an
 | ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | -------- |
 | `token`          | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`)   | `${{ github.token }}` | true     |
 | `dry-run`        | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                             | `'true'`              | true     |
+| `max-date`       | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                            | `"2 weeks ago"`       | false    |
 
 ## Examples
 

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -4,11 +4,11 @@ Composite action (step) to query for for branches that are not in an open PR, an
 
 ## Inputs
 
-| Name             | Type     | Description                                                                                                                                                                          | Default Value         | Required |
-| ---------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------- | -------- |
-| `token`          | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`)   | `${{ github.token }}` | true     |
-| `dry-run`        | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                             | `'true'`              | true     |
-| `max-date`       | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                            | `"2 weeks ago"`       | false    |
+| Name       | Type     | Description                                                                                                                                                                        | Default Value         | Required |
+| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
+| `token`    | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`) | `${{ github.token }}` | true     |
+| `dry-run`  | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                           | `'true'`              | true     |
+| `max-date` | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                          | `"2 weeks ago"`       | false    |
 
 ## Examples
 
@@ -20,7 +20,7 @@ Composite action (step) to query for for branches that are not in an open PR, an
 name: Clean up orphaned branches
 on:
   schedule:
-    - cron: '0 9 * * 1'
+    - cron: "0 9 * * 1"
 
 jobs:
   cleanup-branches::

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -29,6 +29,8 @@ runs:
         MAX_DATE: ${{ inputs.max-date }}
       run: |
         #!/usr/bin/env bash
+        # Fetch all branches from remote. This is basically `git fetch --unshallow` but also fetches branches.
+        git fetch origin "+refs/heads/*:refs/remotes/origin/*"
 
         # A limit of 1,000 open PRs is far beyond any repository that is in the grafana org
         readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -26,7 +26,7 @@ runs:
         readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')
 
         # For repositories that have exceeded 2,000+ branches, this could fail.
-        readarray -t protected_branches < <(gh api --paginate '/repos/${ORG}/${REPO}/branches?protected=true' | jq -cr '.[].name')
+        readarray -t protected_branches < <(gh api --paginate "/repos/${ORG}/${REPO}/branches?protected=true" | jq -cr '.[].name')
 
         branches=()
         while IFS= read -r line; do
@@ -56,7 +56,7 @@ runs:
         done
 
         for branch in "${to_delete[@]}"; do
-          echo $branch >> branches.txt
+          echo "$branch" >> branches.txt
         done
     - name: Delete branches (dry run)
       shell: bash

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -1,16 +1,15 @@
 name: Clean up orphaned git branches
 description: |
-  Composite action (step) to get create github app token using vault.
-  This action will query for for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'.
+  This action will query for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'.
   Protected branches are excluded as well.
 inputs:
   dry-run:
     default: "true"
     required: true
-    description: "If 'dry-run' is not 'true', then the action will print branches to be deleted, but will not delete them"
+    description: "If 'true', then the action will print branches to be deleted, but will not delete them"
   token:
     default: ${{ github.token }}
-    required: false
+    required: true
     description: "GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read)"
 runs:
   using: composite
@@ -18,20 +17,23 @@ runs:
     - name: List branches
       shell: bash
       env:
-        GITHUB_TOKEN: ${{ inputs.github_token }}
-        ORG: ${{ github.repository_owner }}
-        REPO: ${{ github.repository }}
+        GH_TOKEN: ${{ inputs.token }}
+        DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       run: |
         # A limit of 1,000 open PRs is far beyond any repository that is in the grafana org
         readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')
 
         # For repositories that have exceeded 2,000+ branches, this could fail.
-        readarray -t protected_branches < <(gh api --paginate "/repos/${ORG}/${REPO}/branches?protected=true" | jq -cr '.[].name')
+        readarray -t protected_branches < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/branches?protected=true" | jq -cr '.[].name')
 
+        # git remote show origin
+        # ...
+        # HEAD branch: main
+        # ...
         branches=()
         while IFS= read -r line; do
           branches+=("$line")
-        done < <(git branch -r | sed 's/^[[:space:]]*//' | grep -Ev '^(origin/)?(main|master)$' | grep -v 'HEAD' | sed 's|origin/||g')
+        done < <(git branch -r | sed 's/^[[:space:]]*//' | grep -Ev "^(origin/)?(${DEFAULT_BRANCH})$" | grep -v 'HEAD' | sed 's|origin/||g')
 
         to_delete=()
         for branch in "${branches[@]}"; do

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -11,6 +11,13 @@ inputs:
     default: ${{ github.token }}
     required: true
     description: "GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read)"
+  max-date:
+    default: "2 weeks ago"
+    required: false
+    description: |
+      Value provided to `date -d={}. From `man date`: "The --date=STRING is a mostly free format human readable date string such as "Sun, 29 Feb 2004 16:21:42 -0800" or "2004-02-29 16:21:42" or even "next Thursday".  A date string may
+       contain items indicating calendar date, time of day, time zone, day of week, relative time, relative date, and numbers.  An empty string indicates the beginning of the day.  The
+       date string format is more complex than is easily documented here but is fully described in the info documentation."
 runs:
   using: composite
   steps:
@@ -19,17 +26,16 @@ runs:
       env:
         GH_TOKEN: ${{ inputs.token }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        MAX_DATE: ${{ inputs.max-date }}
       run: |
+        #!/usr/bin/env bash
+
         # A limit of 1,000 open PRs is far beyond any repository that is in the grafana org
         readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')
 
         # For repositories that have exceeded 2,000+ branches, this could fail.
-        readarray -t protected_branches < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/branches?protected=true" | jq -cr '.[].name')
+        readarray -t protected_branches < protected_branches.txt
 
-        # git remote show origin
-        # ...
-        # HEAD branch: main
-        # ...
         branches=()
         while IFS= read -r line; do
           branches+=("$line")
@@ -56,9 +62,12 @@ runs:
             to_delete+=("$branch")
           fi
         done
-
+        max_date=$(TZ=utc date -d "$MAX_DATE" +%s)
         for branch in "${to_delete[@]}"; do
-          echo "$branch" >> branches.txt
+          branch_date=$(git log --pretty=format:"%ad" --date=unix "origin/${branch}" | head -n 1)
+          if [[ "$branch_date" -lt "$max_date" ]]; then
+            echo "$branch" >> branches.txt
+          fi
         done
     - name: Delete branches (dry run)
       shell: bash

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -1,0 +1,70 @@
+name: Clean up orphaned git branches
+description: |
+  Composite action (step) to get create github app token using vault.
+  This action will query for for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'.
+  Protected branches are excluded as well.
+inputs:
+  dry-run:
+    default: "true"
+    required: true
+    description: "If 'dry-run' is not 'true', then the action will print branches to be deleted, but will not delete them"
+  token:
+    default: ${{ github.token }}
+    required: false
+    description: "GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read)"
+runs:
+  using: composite
+  steps:
+    - name: List branches
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        ORG: ${{ github.repository_owner }}
+        REPO: ${{ github.repository }}
+      run: |
+        # A limit of 1,000 open PRs is far beyond any repository that is in the grafana org
+        readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')
+
+        # For repositories that have exceeded 2,000+ branches, this could fail.
+        readarray -t protected_branches < <(gh api --paginate '/repos/${ORG}/${REPO}/branches?protected=true' | jq -cr '.[].name')
+
+        branches=()
+        while IFS= read -r line; do
+          branches+=("$line")
+        done < <(git branch -r | sed 's/^[[:space:]]*//' | grep -Ev '^(origin/)?(main|master)$' | grep -v 'HEAD' | sed 's|origin/||g')
+
+        to_delete=()
+        for branch in "${branches[@]}"; do
+          found=0
+          for pr_branch in "${open_pr_branches[@]}"; do
+            if [[ "$branch" == "$pr_branch" ]]; then
+              found=1
+              break
+            fi
+          done
+          if [ "$found" != 1 ]; then
+            for protected_branch in "${protected_branches[@]}"; do
+              if [[ "$branch" == "$protected_branch" ]]; then
+                found=1
+                break
+              fi
+            done
+          fi
+          if [ "$found" != 1 ]; then
+            to_delete+=("$branch")
+          fi
+        done
+
+        for branch in "${to_delete[@]}"; do
+          echo $branch >> branches.txt
+        done
+    - name: Delete branches (dry run)
+      shell: bash
+      if: ${{ inputs.dry-run == "true" }}
+      run: |
+        cat branches.txt | xargs -I {} echo git push origin --delete "{}"
+    - name: Delete branches
+      shell: bash
+      if: ${{ inputs.dry-run != "true" }}
+      run: |
+        cat branches.txt | xargs -I {} git push origin --delete "{}"

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -39,7 +39,7 @@ runs:
         branches=()
         while IFS= read -r line; do
           branches+=("$line")
-        done < <(git branch -r | sed 's/^[[:space:]]*//' | grep -Ev "^(origin/)?(${DEFAULT_BRANCH})$" | grep -v 'HEAD' | sed 's|origin/||g')
+        done < <(git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||' | grep -Ev "^(origin/)?(${DEFAULT_BRANCH})$")
 
         to_delete=()
         for branch in "${branches[@]}"; do

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -34,7 +34,7 @@ runs:
         readarray -t open_pr_branches < <(gh pr list --state open -L 1000 --json headRefName | jq -cr '.[].headRefName')
 
         # For repositories that have exceeded 2,000+ branches, this could fail.
-        readarray -t protected_branches < protected_branches.txt
+        readarray -t protected_branches < <(gh api --paginate "/repos/${GITHUB_REPOSITORY}/branches?protected=true" | jq -cr '.[].name')
 
         branches=()
         while IFS= read -r line; do


### PR DESCRIPTION
Add a new action that will delete branches that meet the following requirements:
1. Not the `head` ref of an open PR.
2. Not a protected branch.
3. `HEAD` commit created before `max-date`.

Some things I wanted to achieve with this where I feel like other community actions fall short:
1. Avoid using the GitHub API where `git` is sufficient.
2. Avoid unnecessary third party dependencies.