### PR TITLE
Update techdocs-cli version to 1.9.7

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -124,9 +124,8 @@ jobs:
           role-arn: ${{ steps.instance-settings.outputs.aws-role-arn }}
           set-creds-in-environment: true
 
-      # Pinning until resolved https://github.com/backstage/backstage/issues/25303
       - name: Install techdocs-cli
-        run: sudo npm install -g @techdocs/cli@1.8.11
+        run: sudo npm install -g @techdocs/cli@1.9.7
 
       - name: setup python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0


### PR DESCRIPTION
Installing the current version is broken:
```
Run sudo npm install -g @techdocs/cli@1.8.11
  sudo npm install -g @techdocs/cli@1.8.11
  shell: /usr/bin/bash -e {0}
  env:
    GOTOOLCHAIN: local
npm error code ETARGET
npm error notarget No matching version found for @backstage/plugin-permission-node@^0.10.4.
npm error notarget In most cases you or one of your dependencies are requesting
npm error notarget a package version that doesn't exist.
npm notice
npm notice New major version of npm available! 10.8.2 -> 11.6.0
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.0
npm notice To update run: npm install -g npm@11.6.0
npm notice
npm error A complete log of this run can be found in: /root/.npm/_logs/2025-09-16T14_56_34_121Z-debug-0.log
```