### PR TITLE
ci: create new shared action to run e2e tests against pre-selected stack

### DIFF
--- a/actions/plugins-e2e-tests/.gitignore
+++ b/actions/plugins-e2e-tests/.gitignore
@@ -1,0 +1,17 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+node_modules/
+
+coverage/
+dist/
+
+.*.bun-build
+
+# Editor
+.idea

--- a/actions/plugins-e2e-tests/CHANGELOG.md
+++ b/actions/plugins-e2e-tests/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.0.1
+
+- Create new action plugins-e2e-tests to run tests aginst pre-selected stack.

--- a/actions/plugins-e2e-tests/README.md
+++ b/actions/plugins-e2e-tests/README.md
@@ -1,0 +1,57 @@
+# Run e2e tests from plugins against specific stack
+
+This is a [GitHub Action][github-action] that help the execution of e2e tests on any plugin against specific selected stacks.
+This action use the following input parameters to run:
+
+| Name                 | Description                                                                                     | Default            | Required |
+|----------------------|-------------------------------------------------------------------------------------------------|--------------------|----------|
+| `plugin_id`          | Name of the plugin running the tests                                                            |                    | Yes      |
+| `stack_slug`         | Name of the stack where you want to run the tests                                               |                    | Yes      |
+| `env`                | Region of the stack where you want to run the tests                                             |                    | Yes      |
+| `other_plugins`      | List of other plugins that you want to enable separated by comma                                |                    | No       |
+| `datasource_ids`     | List of data sources that you want to enable separated by comma                                 |                    | No       |
+| `upload_report_path `| Name of the folder where you want to store the test report                                      | playwright-report  | No       |
+| `upload_videos_path` | Name of the folder where you want to store the test videos                                      | playwright-videos  | No       |
+| `plugin-secrets`     | A JSON string containing key-value pairs of specific plugin secrets necessary to run the tests. |                    | No       |
+
+## Example workflows
+This is an example of how you could use this action.
+
+```yml
+name: Build and Test PR
+
+on:
+  pull_request:
+
+jobs:
+  e2e-tests:
+    permissions:
+      contents: write
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Get plugin specific secrets
+        id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+        with:
+          repo_secrets: |
+            MY_SECRET1=test:token1
+            MY_SECRET2=test:token2
+
+      - name: Run e2e cross app tests
+        id: e2e-cross-apps-tests
+        uses: grafana/shared-workflows/actions/plugins-e2e-tests@main
+        with:
+          stack_slug: 'awsintegrationrevamp'
+          env: 'dev-central'
+          plugin_id: 'grafana-csp-app'
+          other_plugins: 'grafana-k8s-app,grafana-asserts-app'
+          datasource_ids: 'grafanacloud-awsintegrationrevamp-prom,grafanacloud-awsintegrationrevamp-logs'
+          upload_report_path: 'playwright-cross-apps-report'
+          upload_videos_path: 'playwright-cross-apps-videos'
+          plugin-secrets: ${{ ${{ steps.get-secrets.outputs.vault_secrets }} }}
+```

--- a/actions/plugins-e2e-tests/action.yml
+++ b/actions/plugins-e2e-tests/action.yml
@@ -1,0 +1,171 @@
+name: Run e2e tests
+description: Run e2e tests against specific stack and environment
+inputs:
+  plugin_id:
+    description: 'Name of the plugin running the tests'
+    required: true
+    type: string
+  stack_slug:
+    description: 'Name of the stack where you want to run the tests'
+    required: true
+    type: string
+  env:
+    description: 'Region of the stack where you want to run the tests'
+    required: true
+    type: string
+  other_plugins:
+    description: 'List of other plugins that you want to enable separated by comma'
+    required: false
+    type: string
+  datasource_ids:
+    description: 'List of data sources that you want to enable separated by comma'
+    required: false
+    type: string
+  upload_report_path:
+    description: 'Name of the artifact where you want to store the test report'
+    required: false
+    type: string
+    default: 'playwright-report'
+  upload_videos_path:
+    description: 'Name of the artifact where you want to store the test videos'
+    required: false
+    type: string
+    default: 'playwright-videos'
+  plugin-secrets:
+    description: 'A JSON string containing key-value paris of specific plugin secrets necessary to run the tests.'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
+
+    - name: Setup Node.js environment
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: '20'
+        cache: 'yarn'
+
+    - name: Install e2e action dependencies
+      run: yarn install
+      shell: bash
+
+    - uses: google-github-actions/auth@8254fb75a33b976a221574d287e93919e6a36f70 # v2.1.6
+      id: gcloud-auth
+      working-directory: ${{ github.workspace }}
+      with:
+        token_format: access_token
+        workload_identity_provider: 'projects/304398677251/locations/global/workloadIdentityPools/github/providers/github-provider'
+        service_account: 'github-cloud-npm-dev-pkgs@grafanalabs-workload-identity.iam.gserviceaccount.com'
+
+    - name: NPM registry auth
+      working-directory: ${{ github.workspace }}
+      run: npx google-artifactregistry-auth --credential-config
+      shell: bash
+
+    - name: Install plugin dependencies
+      working-directory: ${{ github.workspace }}
+      run: yarn install --immutable --prefer-offline
+      shell: bash
+
+    - name: Build frontend
+      working-directory: ${{ github.workspace }}
+      run: yarn run build
+      shell: bash
+
+    - name: setup e2e env
+      id: get-secrets
+      working-directory: ${{ github.workspace }}
+      uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # v1.2.0
+      with:
+        repo_secrets: |
+          HG_TOKEN=hg-ci:token
+
+    - name: Set plugin secrets as environment variables
+      id: set-env-vars
+      if: ${{ inputs.plugin-secrets != '' }}
+      shell: bash
+      env:
+        SECRETS_JSON: '${{ inputs.plugin-secrets }}'
+      run: |
+        echo "Parsing and setting plugin environment variables..."
+        echo "$SECRETS_JSON" | jq -r 'to_entries[] | "echo \"\(.key)=\(.value)\" >> $GITHUB_ENV"'
+        echo "Plugin environment variables set."
+
+    - name: Generate provisioning
+      shell: bash
+      run: npx plop e2e-testing-provisioning
+      working-directory: ${{ github.workspace }}
+      env:
+        E2E_STACK_SLUG: ${{ inputs.stack_slug }}
+        E2E_ENV: ${{ inputs.env }}
+        HG_TOKEN: ${{ env.HG_TOKEN }}
+        E2E_PLUGIN_ID: ${{ inputs.plugin_id }}
+        E2E_OTHER_PLUGINS: ${{ inputs.other_plugins }}
+        E2E_DATASOURCE_IDS: ${{ inputs.datasource_ids }}
+
+    - name: Start server
+      working-directory: ${{ github.workspace }}
+      run: docker compose up -d --build --quiet-pull --timestamps
+      shell: bash
+
+    - name: Install Playwright Browsers
+      working-directory: ${{ github.workspace }}
+      run: npx playwright install chromium --with-deps
+      shell: bash
+
+    - name: Run Playwright tests
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        NODE_ENV: production
+      run: |
+        echo "Waiting for Grafana to be available..."
+        timeout=300  # 5 minutes timeout
+        start_time=$(date +%s)
+
+        while ! docker logs grafana-csp-app 2>&1 | grep "Usage stats are ready to report" > /dev/null; do
+          current_time=$(date +%s)
+          elapsed=$((current_time - start_time))
+
+          if [ $elapsed -ge $timeout ]; then
+            echo "Timeout reached: Grafana did not become ready within 5 minutes."
+            exit 1
+          fi
+
+          echo "Waiting for Grafana..."
+          sleep 5 # Wait for 5 seconds before checking again
+        done
+
+        echo "Grafana is ready!"
+        npx playwright test
+
+    - name: Stop grafana docker
+      working-directory: ${{ github.workspace }}
+      run: docker compose down
+      shell: bash
+
+    - name: Upload E2E report
+      working-directory: ${{ github.workspace }}
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ${{ inputs.upload_report_path }}
+        path: playwright-report/
+        retention-days: 30
+
+    - name: Upload E2E videos
+      working-directory: ${{ github.workspace }}
+      uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: ${{ inputs.upload_videos_path }}
+        path: test-results/
+        retention-days: 30
+
+branding:
+  icon: "shield"
+  color: "green"

--- a/actions/plugins-e2e-tests/package.json
+++ b/actions/plugins-e2e-tests/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "plugins-e2e-tests",
+  "version": "0.0.1",
+  "description": "Run e2e tests from plugins against specific stack and environment.",
+  "private": true,
+  "scripts": {},
+  "keywords": [
+    "e2e",
+    "github-action",
+    "playwright"
+  ],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "js-yaml": "^4.1.0",
+    "plop": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/bun": "1.2.22",
+    "@eslint/js": "9.35.0",
+    "@types/eslint__js": "9.14.0",
+    "eslint": "9.35.0",
+    "eslint-config-prettier": "10.1.8",
+    "eslint-plugin-jest": "29.0.1",
+    "eslint-plugin-prettier": "5.5.4",
+    "prettier": "3.6.2",
+    "typescript": "5.9.2",
+    "typescript-eslint": "8.44.0"
+  }
+}

--- a/actions/plugins-e2e-tests/plopfile.mjs
+++ b/actions/plugins-e2e-tests/plopfile.mjs
@@ -1,0 +1,298 @@
+import fs from "fs";
+import yaml from "js-yaml";
+import * as path from "path";
+
+const HG_TOKEN = process.env.HG_TOKEN;
+const APPS_YAML_FILE = path.join(process.cwd(), "./provisioning/plugins/apps.yaml");
+const DATASOURCES_YAML_FILE = path.join(process.cwd(), "./provisioning/datasources/default.yaml");
+
+function formatDataSource(dataSource) {
+  if (dataSource) {
+    return {
+      name: dataSource.name,
+      type: dataSource.type,
+      url: dataSource.url,
+      basicAuth: dataSource.basicAuth === 1 || dataSource.basicAuth === true,
+      basicAuthUser: dataSource.basicAuthUser ? Number(dataSource.basicAuthUser) : undefined,
+      isDefault: dataSource.isDefault === 1 || dataSource.isDefault === true,
+      jsonData: dataSource.jsonData,
+      secureJsonData: {
+        basicAuthPassword: dataSource.basicAuthPassword,
+      },
+    };
+  }
+  return dataSource;
+}
+
+function removeEmptyProperties(obj) {
+  // Check if the input is an object or an array
+  if (Array.isArray(obj)) {
+    // If it's an array, recursively clean each element
+    return obj
+      .map((item) => removeEmptyProperties(item))
+      .filter((item) => item !== null && typeof item !== "undefined");
+  }
+
+  // Check if the input is a plain object
+  if (typeof obj === "object" && obj !== null) {
+    const newObj = {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        const value = obj[key];
+
+        // Recursively clean nested objects/arrays
+        const cleanedValue = removeEmptyProperties(value);
+
+        // Check for empty values and skip them
+        if (
+          cleanedValue !== "" &&
+          cleanedValue !== null &&
+          cleanedValue !== undefined &&
+          !(Array.isArray(cleanedValue) && cleanedValue.length === 0) &&
+          !(typeof cleanedValue === "object" && Object.keys(cleanedValue).length === 0)
+        ) {
+          newObj[key] = cleanedValue;
+        }
+      }
+    }
+    return newObj;
+  }
+
+  // If the value is not an object or array, return it as is
+  return obj;
+}
+
+function getBaseUrlByEnv(env) {
+  switch (env) {
+    case "prod-us-east":
+      return "https://hg-api-prod-us-east-0.grafana.net";
+    case "prod":
+      return "https://hg-api-prod-us-central-0.grafana.net";
+    case "ops":
+      return "https://hg-api-ops-eu-south-0.grafana-ops.net";
+    case "dev-east":
+      return "https://hg-api-dev-us-east-0.grafana-dev.net";
+    case "dev-central":
+    default:
+      return "https://hg-api-dev-us-central-0.grafana-dev.net";
+  }
+}
+
+async function fetchMultipleAppConfigs(stackSlug, env, pluginIds) {
+  try {
+    const fetchPromises = pluginIds.map((pluginId) => fetchAppConfig(stackSlug, env, pluginId));
+    return await Promise.all(fetchPromises);
+  } catch (error) {
+    console.error("Error fetching multiple app configs:", error.message);
+    throw error;
+  }
+}
+
+async function fetchAppConfig(stackSlug, env, pluginId) {
+  try {
+    const baseUrl = getBaseUrlByEnv(env);
+    const url = `${baseUrl}/instances/${stackSlug}/provisioned-plugins/${pluginId}`;
+
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": `plop/${pluginId}-provisioning`,
+        Authorization: `Bearer ${HG_TOKEN}`,
+      },
+    });
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching app config", pluginId, ":", error.message);
+    throw error;
+  }
+}
+
+async function fetchMultipleDatasources(stackSlug, env, datasourceNames) {
+  try {
+    const fetchPromises = datasourceNames.map((dsName) => fetchDataSource(stackSlug, env, dsName));
+    if (fetchPromises.length > 0) {
+      return Promise.all(fetchPromises);
+    }
+    return Promise.all([]);
+  } catch (error) {
+    console.error("Error fetching multiple data sources:", error.message);
+    throw error;
+  }
+}
+
+async function fetchDataSource(stackSlug, env, datasourceName) {
+  try {
+    const baseUrl = getBaseUrlByEnv(env);
+    const url = `${baseUrl}/instances/${stackSlug}/datasources/${datasourceName}`;
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": `plop/${datasourceName}-provisioning`,
+        Authorization: `Bearer ${HG_TOKEN}`,
+      },
+    });
+    const dataSourceWithToken = await response.json();
+    const dataSourceWithNoEmptyField = removeEmptyProperties(dataSourceWithToken);
+    return formatDataSource(dataSourceWithNoEmptyField);
+  } catch (error) {
+    console.error("Error fetching datasource", datasourceName, ":", error.message);
+    throw error;
+  }
+}
+
+function createDataSourcesYamlFile() {
+  const dir = path.dirname(DATASOURCES_YAML_FILE);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const initialContent = {
+    apiVersion: 1,
+    prune: true,
+
+    datasources: [],
+  };
+  fs.writeFileSync(DATASOURCES_YAML_FILE, yaml.dump(initialContent));
+  return initialContent;
+}
+
+async function fetchGrafanaConfig(stackSlug, env, pluginId) {
+  try {
+    const baseUrl = getBaseUrlByEnv(env);
+    const url = `${baseUrl}/instances/${stackSlug}/config`;
+    const response = await fetch(url, {
+      headers: {
+        "User-Agent": `plop/${pluginId}-provisioning`,
+        Authorization: `Bearer ${HG_TOKEN}`,
+      },
+    });
+    return response.json();
+  } catch (error) {
+    console.error("Error fetching gcom token:", error.message);
+    throw error;
+  }
+}
+
+function createAppsYamlFile() {
+  const dir = path.dirname(APPS_YAML_FILE);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  const initialContent = {
+    apiVersion: 1,
+
+    apps: [],
+  };
+  fs.writeFileSync(APPS_YAML_FILE, yaml.dump(initialContent));
+  return initialContent;
+}
+
+function addAppConfigs(yamlData, appConfigs) {
+  appConfigs.forEach((appConfig) => {
+    if (appConfig.type === "grafana-asserts-app") {
+      appConfig.jsonData.instanceUrl = "http://localhost:3000";
+    }
+    yamlData.apps.push(appConfig);
+    console.log(`App with type '${appConfig.type}' has been added`);
+  });
+}
+
+function addDataSourceConfigs(yamlData, dataSourceConfigs = []) {
+  dataSourceConfigs.forEach((dsConfig, i) => {
+    yamlData.datasources.push(dsConfig);
+    console.log(`Data source with type '${dsConfig.type}' and name '${dsConfig.name}' has been added`);
+  });
+}
+
+function writeDataSourcesYamlFile(yamlData) {
+  const yamlString = yaml.dump(yamlData);
+  fs.writeFileSync(DATASOURCES_YAML_FILE, yamlString);
+  console.log("default.yaml data source file has been updated.");
+}
+
+function writeAppsYamlFile(yamlData) {
+  const yamlString = yaml.dump(yamlData);
+
+  // just for asserts
+  const fixed = yamlString.replace("enableGrafanaManagedLLM: true", "enableGrafanaManagedLLM: false");
+  fs.writeFileSync(APPS_YAML_FILE, fixed);
+  console.log("apps.yaml plugins file has been updated. Asserts prop enableGrafanaManagedLLM was disabled");
+}
+
+async function fillAnswers(answers) {
+  const appConfigs = await fetchMultipleAppConfigs(answers.STACK_SLUG, answers.ENV, answers.PLUGIN_IDS);
+  const yamlAppsData = createAppsYamlFile();
+  addAppConfigs(yamlAppsData, appConfigs);
+  writeAppsYamlFile(yamlAppsData);
+
+  const dataSourceConfigs = await fetchMultipleDatasources(answers.STACK_SLUG, answers.ENV, answers.DATASOURCE_IDS);
+  const yamlDataSourcesData = createDataSourcesYamlFile();
+  addDataSourceConfigs(yamlDataSourcesData, dataSourceConfigs);
+  writeDataSourcesYamlFile(yamlDataSourcesData);
+
+  const grafanaConfig = await fetchGrafanaConfig(answers.STACK_SLUG, answers.ENV, answers.GF_PLUGIN_ID);
+  answers.GF_GRAFANA_COM_SSO_API_TOKEN = grafanaConfig.hosted_grafana.hg_auth_token;
+
+  // Use hardcoded URL for ops stack when grafana_net.url is missing
+  const grafanaNetUrl =
+    answers.STACK_SLUG === "ops" && !grafanaConfig.grafana_net?.url
+      ? "https://grafana-ops.com"
+      : grafanaConfig.grafana_net.url;
+
+  answers.GF_GRAFANA_COM_URL = grafanaNetUrl;
+  answers.GF_GRAFANA_COM_API_URL = `${grafanaNetUrl}/api`;
+  answers.GF_PLUGINS_PREINSTALL_SYNC = answers.PLUGIN_IDS.filter((p) => p !== answers.GF_PLUGIN_ID).join(",");
+}
+
+export default function(plop) {
+  plop.setHelper("env", (text) => process.env[text]);
+
+  plop.setGenerator("e2e-testing-provisioning", {
+    prompts: [],
+    actions: [
+      async function loadRemoteProvisioning(answers) {
+        try {
+          if (!HG_TOKEN) {
+            console.error("HG_TOKEN environment variable is not set.");
+            process.exit(1);
+          }
+
+          if (!process.env.E2E_STACK_SLUG) {
+            console.error("E2E_STACK_SLUG environment variable is not set.");
+            process.exit(1);
+          }
+
+          if (!process.env.E2E_PLUGIN_ID) {
+            console.error("E2E_PLUGIN_ID environment variable is not set.");
+            process.exit(1);
+          }
+          answers.STACK_SLUG = process.env.E2E_STACK_SLUG;
+          answers.ENV = process.env.E2E_ENV;
+
+          answers.GF_PLUGIN_ID = process.env.E2E_PLUGIN_ID;
+          const otherPlugins = process.env.E2E_OTHER_PLUGINS ? process.env.E2E_OTHER_PLUGINS.split(",").map((i) => i.trim()) : [];
+          answers.PLUGIN_IDS = [process.env.E2E_PLUGIN_ID].concat(otherPlugins);
+
+          answers.DATASOURCE_IDS = process.env.E2E_DATASOURCE_IDS
+            ? process.env.E2E_DATASOURCE_IDS.split(",").map((i) => i.trim())
+            : [];
+          answers.GF_PLUGINS_PREINSTALL_SYNC = otherPlugins.join(",");
+
+          await fillAnswers(answers);
+
+          return "Remote Provisioning data loaded successfully for e2e tests.";
+        } catch (error) {
+          console.error("Failed to load Remote Provisioning:", error.message);
+          return "Failed to load Remote Provisioning data";
+        }
+      },
+      {
+        type: "add",
+        path: "./docker-compose.yaml",
+        templateFile: "plop-templates/docker-compose.hbs.yaml",
+        force: true,
+      },
+    ],
+  });
+}


### PR DESCRIPTION
create new shared action to run e2e tests against pre-selected stack. You define in which region the selected stack belong, the plugin from where are executed the tests and optionally which other plugins and datasources you want to provision in that stack when starting a Grafana instance. You need to have the playwright configuration and the test specifications in the plugin that run the tests.