### PR TITLE
feat: docker multi-arch reusable workflow

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.md
+++ b/.github/workflows/docker-build-push-multiarch.md
@@ -1,0 +1,86 @@
+# docker-build-push-multiaarch
+
+This is a reusable workflow, that uses Grafana's hosted runner to natively build and push multi-architecture docker
+images.
+
+This is effectively a wrapper around [docker-build-push-image](), [docker-export-digest](),
+and [docker-import-digests-push-manifest](), with a [matrix strategy]()k to determine which instance types to launch.
+
+# TODO: do we need QEMU?
+
+<!-- x-release-please-start-version -->
+
+```yaml
+name: Build a Docker Image
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-push-image:
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: grafana/shared-workflows/actions/docker-build-push-image@main # TODO: Fix version once released
+        with:
+          platforms: linux/arm64,linux/amd64
+          tags: |
+            ${{ github.sha }}
+            main
+          push: true
+          registries: "gar,dockerhub"
+```
+
+<!-- x-release-please-end-version -->
+
+## Inputs
+
+| Name                      | Type    | Description                                                                                                                                                                                                            |
+|---------------------------|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `build-args`              | String  | List of arguments necessary for the Docker image to be built.                                                                                                                                                          |
+| `build-contexts`          | String  | List of additional build contexts (e.g., name=path)                                                                                                                                                                    |
+| `buildkitd-config`        | String  | Configum buildkitium descriptium                                                                                                                                                                                       |
+| `buildkitd-config-inline` | String  | Inliumium configutorium buildkitium descriptium                                                                                                                                                                        |
+| `cache-from`              | String  | Where cache should be fetched from                                                                                                                                                                                     |
+| `cache-to`                | String  | Where cache should be stored to                                                                                                                                                                                        |
+| `context`                 | String  | Path to the Docker build context.                                                                                                                                                                                      |
+| `delete-credentials-file` | Boolean | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false.                                                                                |
+| `docker-buildx-driver`    | String  | The driver to use for Docker Buildx                                                                                                                                                                                    |
+| `dockerhub-repository`    | String  | Ipsum dockerhubium                                                                                                                                                                                                     |
+| `file`                    | String  | The dockerfile to use.                                                                                                                                                                                                 |
+| `gar-environment`         | String  | Environment for pushing artifacts (can be either dev or prod).                                                                                                                                                         |
+| `gar-image`               | String  | Name of the image to build. Default: `${GitHub Repo Name}`                                                                                                                                                             |
+| `gar-registry`            | String  | Google Artifact Registry to store docker images in.                                                                                                                                                                    |
+| `gar-repository`          | String  | Override the 'repo_name' used to construct the GAR repository name. Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name. Default: `docker-${GitHub Repo Name}-${gar-environment}` |
+| `labels`                  | String  | List of custom labels to add to the image as metadata.                                                                                                                                                                 |
+| `load`                    | Boolean | Whether to load the built image into the local docker daemon.                                                                                                                                                          |
+| `outputs`                 | String  | Ipsum factum explainum.                                                                                                                                                                                                |
+| `platforms`               | String  | List of platforms to build the image for                                                                                                                                                                               |
+| `post-build-script`       | String  | A script to run after docker build                                                                                                                                                                                     |
+| `pre-build-script`        | String  | A script to run before docker build                                                                                                                                                                                    |
+| `push`                    | String  | Whether to push the image to the configured registries.                                                                                                                                                                |
+| `registries`              | String  | List of registries to build images for.                                                                                                                                                                                |
+| `secrets`                 | String  | Secrets to expose to the build. Only needed when authenticating to private repositories outside the repository in which the image is being built.                                                                      |
+| `server-size`             | String  | Size of the hosted runner                                                                                                                                                                                              |
+| `ssh`                     | String  | List of SSH agent socket or keys to expose to the build                                                                                                                                                                |
+| `tags`                    | String  | List of Docker tags to be pushed.                                                                                                                                                                                      |
+| `target`                  | String  | Sets the target stage to build                                                                                                                                                                                         |
+
+## Outputs
+
+| Name            | Type   | Description                                                              |
+|-----------------|--------|--------------------------------------------------------------------------|
+| `annotations`   | String | Generated annotations (from docker/metadata-action)                      |
+| `digest`        | String | Image digest (from docker/build-push-action)                             |
+| `imageid`       | String | Image ID (from docker/build-push-action)                                 |
+| `images`        | String | Comma separated list of the images that were built                       |
+| `json`          | String | JSON output of tags and labels (from docker/metadata-action)             |
+| `labels`        | String | Generated Docker labels (from docker/metadata-action)                    |
+| `metadata`      | String | Build result metadata (from docker/build-push-action)                    |
+| `metadatajson`  | String | Metadata JSON (from docker/metadata)                                     |
+| `runner_arches` | String | The list of OS used to build images (for mapping to self hosted runners) |
+| `tags`          | String | Generated Docker tags (from docker/metadata-action)                      |
+| `version`       | String | Generated Docker image version (from docker/metadata-action)             |

--- a/.github/workflows/docker-build-push-multiarch.md
+++ b/.github/workflows/docker-build-push-multiarch.md
@@ -4,17 +4,26 @@ This is a reusable workflow that uses Grafana's hosted runners to natively build
 images.
 
 Right now this supports pushing images to:
+
 - Google Artifact Registry
 - DockerHub
 
 And supports building the following image types:
+
 - linux/arm64
 - linux/amd64
 
 ## How it works
 
-This generates a matrix based off of the `platforms` input, then creates a job per platform that runs the composite actions [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image) and [docker-export-digest](https://github.com/grafana/shared-workflows/tree/main/actions/docker-export-digest) to build and push docker images, and capture their digests.
-There is a then a final job that runs the composite action [docker-import-digests-push-manifest](https://github.com/grafana/shared-workflows/tree/main/actions/docker-import-digests-push-manifest) to push the final docker manifest.
+This generates a matrix based off of the `platforms` input, then creates a job per platform that runs the composite
+actions [docker-build-push-image] and [docker-export-digest] to build and push docker images, and capture their digests.
+There is a then a final job that runs the composite action [docker-import-digests-push-manifest] to push the final
+docker manifest.
+
+[docker/build-push-action]: https://github.com/docker/build-push-action
+[docker-build-push-image]: ../../docker-build-push-image/README.md
+[docker-export-digest]: ../../docker-export-digest/README.md
+[docker-import-digests-push-manifest]: ../../docker-import-digests-push-manifest/README.md
 
 <!-- x-release-please-start-version -->
 

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -266,7 +266,7 @@ jobs:
           PRE_BUILD_SCRIPT_PATH: ${{ inputs.pre-build-script }}
       - name: Build Docker Image
         id: build
-        uses: grafana/shared-workflows/actions/docker-build-push-image@rwhitaker/multi-arch-builds
+        uses: grafana/shared-workflows/actions/docker-build-push-image@rwhitaker/multi-arch-composite-actions
         with:
           # from inputs
           build-args: ${{ inputs.build-args }}
@@ -312,7 +312,7 @@ jobs:
         env:
           $POST_BUILD_SCRIPT_PATH: ${{ inputs.post-build-script }}
       - name: Export and upload digest
-        uses: grafana/shared-workflows/actions/docker-export-digest@rwhitaker/multi-arch-builds
+        uses: grafana/shared-workflows/actions/docker-export-digest@rwhitaker/multi-arch-composite-actions
         with:
           digest: ${{ steps.build.outputs.digest }}
           platform: ${{ env.PLATFORM }}
@@ -326,10 +326,8 @@ jobs:
       id-token: write
     steps:
       - name: Download Multi-Arch Digests, Construct and Upload Manifest
-        uses: grafana/shared-workflows/actions/docker-import-digests-push-manifest@rwhitaker/multi-arch-builds
+        uses: grafana/shared-workflows/actions/docker-import-digests-push-manifest@rwhitaker/multi-arch-composite-actions
         with:
           images: ${{ needs.build-and-push.outputs.images }}
           gar-environment: ${{ inputs.gar-environment }}
-          push-to-gar: true # TODO: don't hardcode these
-          push-to-dockerhub: true
           docker-metadata-json: ${{ needs.build-and-push.outputs.metadatajson }}

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -1,0 +1,321 @@
+name: Push to artifact registry MultiArch
+# description: Resuable workflow to push to Google Artifact Registry using runners of different architectures.
+
+# TODO: docker.io/grafana/cicd-test:rickytest is the correct url style for dockerhub
+
+on:
+  workflow_call:
+    inputs:
+      # THE FOLLOWING INPUTS ARE UNIQUE TO THIS WORKFLOW
+      # MULTIARCH CONFIGS
+      server-size:
+        description: "Size of the hosted runner"
+        required: false
+        default: "small"
+        type: string
+      pre-build-script:
+        description: "A script to run before docker build"
+        required: false
+        default: ""
+        type: string
+      post-build-script: # TODO: BUild this in
+        description: "A script to run after docker build"
+        required: false
+        default: ""
+        type: string
+
+      # The following inputs are identical to the inputs
+      # found in `shared-workflows/actions/docker-build-push-image`
+      # INHERITED CONFIGS
+      build-args:
+        description: |
+          List of arguments necessary for the Docker image to be built.
+        default: ""
+        type: string
+      build-contexts:
+        description: |
+          List of additional build contexts (e.g., name=path)
+        required: false
+        type: string
+      buildkitd-config:
+        description: |
+          Configum buildkitium descriptium
+        default: ""
+        type: string
+      buildkitd-config-inline:
+        description: |
+          Inliumium configutorium buildkitium descriptium
+        default: ""
+        type: string
+      cache-from:
+        description: |
+          Where cache should be fetched from
+        required: false
+        default: "type=gha"
+        type: string
+      cache-to:
+        description: |
+          Where cache should be stored to
+        required: false
+        default: "type=gha,mode=max"
+        type: string
+      context:
+        description: |
+          Path to the Docker build context.
+        default: "."
+        type: string
+      delete-credentials-file: #TODO: Expand on this
+        description: |
+          Delete the credentials file after the action is finished.
+          If you want to keep the credentials file for a later step, set this to false.
+        default: "true"
+        type: string
+      dockerhub-repository:
+        description: |
+          Ipsum dockerhubium
+        default: "${{ github.repository }}"
+        type: string
+      docker-buildx-driver:
+        description: |
+          The driver to use for Docker Buildx
+        required: false
+        default: "docker-container"
+        type: string
+      file:
+        description: |
+          The dockerfile to use.
+        required: false
+        type: string
+      gar-registry:
+        description: |
+          Google Artifact Registry to store docker images in.
+        default: "us-docker.pkg.dev"
+        type: string
+      gar-repository:
+        description: |
+          Override the 'repo_name' used to construct the GAR repository name.
+          Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.
+          Default: `docker-${GitHub Repo Name}-${gar-environment}`
+        default: ""
+        type: string
+      gar-environment:
+        description: |
+          Environment for pushing artifacts (can be either dev or prod).
+        default: "dev"
+        type: string
+      gar-image:
+        description: |
+          Name of the image to build.
+          Default: `${GitHub Repo Name}`
+        default: ""
+        type: string
+      labels:
+        description: |
+          List of custom labels to add to the image as metadata.
+        required: false
+        type: string
+      load:
+        description: |
+          Whether to load the built image into the local docker daemon.
+        required: false
+        default: "false"
+        type: string
+      outputs:
+        description: | # TODO Desc
+          Ipsum factum explainum.
+        required: false
+        default: ""
+        type: string
+      platforms:
+        description: |
+          List of platforms to build the image for
+        required: false
+        type: string
+      push:
+        description: |
+          Whether to push the image to the configured registries.
+        required: false
+        type: string
+      registries:
+        description: |
+          List of registries to build images for.
+        default: ""
+        type: string
+      secrets:
+        description: |
+          Secrets to expose to the build. Only needed when authenticating to private repositories outside the repository in which the image is being built.
+        required: false
+        type: string
+      ssh:
+        description: |
+          List of SSH agent socket or keys to expose to the build
+        type: string
+      tags:
+        description: |
+          List of Docker tags to be pushed.
+        required: true
+        type: string
+      target:
+        description: |
+          Sets the target stage to build
+        required: false
+        type: string
+      # /INHERITED CONFIGS
+    outputs:
+      annotations:
+        description: "Generated annotations (from docker/metadata-action)"
+        value: ${{ jobs.build-and-push.outputs.annotations }}
+      digest:
+        description: "Image digest (from docker/build-push-action)"
+        value: ${{ jobs.build-and-push.outputs.digest }}
+      imageid:
+        description: "Image ID (from docker/build-push-action)"
+        value: ${{ jobs.build-and-push.outputs.imageid }}
+      images:
+        description: "Comma separated list of the images that were built"
+        value: ${{ jobs.build-and-push.outputs.images }}
+      json:
+        description: "JSON output of tags and labels (from docker/metadata-action)"
+        value: ${{ jobs.build-and-push.outputs.json }}
+      labels:
+        description: "Generated Docker labels (from docker/metadata-action)"
+        value: ${{ jobs.build-and-push.outputs.labels }}
+      metadata:
+        description: "Build result metadata (from docker/build-push-action)"
+        value: ${{ jobs.build-and-push.outputs.metadata }}
+      metadatajson:
+        description: "Metadata JSON (from docker/metadata)"
+        value: ${{ jobs.build-and-push.outputs.json }}
+      tags:
+        description: "Generated Docker tags (from docker/metadata-action)"
+        value: ${{ jobs.build-and-push.outputs.tags }}
+      version:
+        description: "Generated Docker image version (from docker/metadata-action)"
+        value: ${{ jobs.build-and-push.outputs.version }}
+      runner_arches:
+        description: "The list of OS used to build images (for mapping to self hosted runners)"
+        value: ${{ jobs.prepare-matrix.outputs.runner_arches }}
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-arm64-small
+    outputs:
+      runner_arches: ${{ steps.matrix.outputs.runner_arches }}
+    steps:
+      - id: matrix
+        run: |
+          # This converts the potential list of `linux/arm64,linux/amd64` into a matrix of `arm64,x64`
+          # to match our hosted runner labels
+          MATRIX=$(echo "$PLATFORMS" | tr -d ' ' | tr ',' '\n' \
+            | jq -R 'if .=="linux/amd64" then "x64" elif .=="linux/arm64" then "arm64" else . end' \
+            | jq -s -c .)
+
+          # Set output
+          echo "runner_arches=$MATRIX" | tee -a "${GITHUB_OUTPUT}"
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
+
+  build-and-push:
+    needs: prepare-matrix
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJson(needs.prepare-matrix.outputs.runner_arches) }}
+    runs-on: ubuntu-${{ matrix.arch }}-${{ inputs.server-size }}
+    env:
+      ARCH_TO_PLATFORM_MAP: '{"arm64": "linux/arm64", "x64": "linux/amd64"}' # TODO: Document this somewhere
+    outputs:
+      annotations: ${{ steps.build.outputs.annotations }}
+      digest: ${{ steps.build.outputs.digest }}
+      imageid: ${{ steps.build.outputs.imageid }}
+      images: ${{ steps.build.outputs.images }}
+      json: ${{ steps.build.outputs.json }}
+      labels: ${{ steps.build.outputs.labels }}
+      metadata: ${{ steps.build.outputs.metadata }}
+      metadatajson: ${{ steps.build.outputs.metadatajson }}
+      tags: ${{ steps.build.outputs.tags }}
+      version: ${{ steps.build.outputs.version }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Prepare
+        run: |
+          PLATFORM=$(echo "$ARCH_TO_PLATFORM_MAP" | jq -r --arg arch "${MATRIX_ARCH}" '.[$arch]')
+          echo "PLATFORM=${PLATFORM}" | tee -a "${GITHUB_ENV}"
+          echo "PLATFORM_PAIR=${PLATFORM//\//-}" | tee -a "${GITHUB_ENV}"
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Run custom build script if it exists
+        if: ${{ inputs.pre-build-script != '' }}
+        run: |
+          set -euo pipefail
+          echo "Running $PRE_BUILD_SCRIPT_PATH"
+
+          if [ -f "$PRE_BUILD_SCRIPT_PATH" ]; then
+            chmod +x "$PRE_BUILD_SCRIPT_PATH"
+            "$PRE_BUILD_SCRIPT_PATH"
+          else
+            echo "No script found at $PRE_BUILD_SCRIPT_PATH, skipping."
+          fi
+        env:
+          PRE_BUILD_SCRIPT_PATH: ${{ inputs.pre-build-script }}
+      - name: Build Docker Image
+        id: build
+        uses: grafana/shared-workflows/actions/docker-build-push-image@rwhitaker/multi-arch-builds
+        with:
+          # from inputs
+          build-args: ${{ inputs.build-args }}
+          build-contexts: ${{ inputs.build-contexts }}
+          buildkitd-config: ${{ inputs.buildkitd-config }}
+          buildkitd-config-inline: ${{ inputs.buildkitd-config-inline }}
+          cache-from: ${{ inputs.cache-from }}
+          cache-to: ${{ inputs.cache-to }}
+          context: ${{ inputs.context }}
+          delete-credentials-file: ${{ inputs.delete-credentials-file }}
+          dockerhub-repository: ${{ inputs.dockerhub-repository }}
+          docker-buildx-driver: ${{ inputs.docker-buildx-driver }}
+          file: ${{ inputs.file }}
+          gar-registry: ${{ inputs.gar-registry }}
+          gar-repository: ${{ inputs.gar-repository }}
+          gar-environment: ${{ inputs.gar-environment }}
+          gar-image: ${{ inputs.gar-image }}
+          labels: ${{ inputs.labels }}
+          registries: ${{ inputs.registries }}
+          secrets: ${{ inputs.secrets }}
+          ssh: ${{ inputs.ssh }}
+          tags: ${{ inputs.tags }}
+          target: ${{ inputs.target }}
+          include-tags-in-push: false
+
+          # special cases
+          platforms: ${{ env.PLATFORM }}
+          outputs: "type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push == 'true' && 'true' || 'false' }}"
+          load: ${{ inputs.load == 'true' }}
+          push: ${{ inputs.push == 'true' }}
+      - name: Export and upload digest
+        uses: grafana/shared-workflows/actions/docker-export-digest@rwhitaker/multi-arch-builds
+        with:
+          digest: ${{ steps.build.outputs.digest }}
+          platform: ${{ env.PLATFORM }}
+
+  merge-digest:
+    if: ${{ inputs.push == 'true' }}
+    runs-on: ubuntu-arm64-small
+    needs: build-and-push
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download Multi-Arch Digests, Construct and Upload Manifest
+        uses: grafana/shared-workflows/actions/docker-import-digests-push-manifest@rwhitaker/multi-arch-builds
+        with:
+          images: ${{ needs.build-and-push.outputs.images }}
+          gar-environment: ${{ inputs.gar-environment }}
+          push-to-gar: true # TODO: don't hardcode these
+          push-to-dockerhub: true
+          docker-metadata-json: ${{ needs.build-and-push.outputs.metadatajson }}

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -9,17 +9,17 @@ on:
       # THE FOLLOWING INPUTS ARE UNIQUE TO THIS WORKFLOW
       # MULTIARCH CONFIGS
       server-size:
-        description: "Size of the hosted runner"
+        description: "Size of the Grafana self-hosted runner"
         required: false
         default: "small"
         type: string
       pre-build-script:
-        description: "A script to run before docker build"
+        description: "A script to run before `docker build`"
         required: false
         default: ""
         type: string
-      post-build-script: # TODO: BUild this in
-        description: "A script to run after docker build"
+      post-build-script:
+        description: "A script to run after `docker build`"
         required: false
         default: ""
         type: string
@@ -64,22 +64,22 @@ on:
           Path to the Docker build context.
         default: "."
         type: string
-      delete-credentials-file: #TODO: Expand on this
+      delete-credentials-file:
         description: |
           Delete the credentials file after the action is finished.
           If you want to keep the credentials file for a later step, set this to false.
         default: "true"
-        type: string
-      dockerhub-repository:
-        description: |
-          Ipsum dockerhubium
-        default: "${{ github.repository }}"
         type: string
       docker-buildx-driver:
         description: |
           The driver to use for Docker Buildx
         required: false
         default: "docker-container"
+        type: string
+      dockerhub-repository:
+        description: |
+          Ipsum dockerhubium
+        default: "${{ github.repository }}"
         type: string
       file:
         description: |
@@ -297,6 +297,20 @@ jobs:
           outputs: "type=image,push-by-digest=true,name-canonical=true,push=${{ inputs.push == 'true' && 'true' || 'false' }}"
           load: ${{ inputs.load == 'true' }}
           push: ${{ inputs.push == 'true' }}
+      - name: Run post build script if it exists
+        if: ${{ inputs.post-build-script != '' }}
+        run: |
+          set -euo pipefail
+          echo "Running $POST_BUILD_SCRIPT_PATH"
+
+          if [ -f "$POST_BUILD_SCRIPT_PATH" ]; then
+            chmod +x "$POST_BUILD_SCRIPT_PATH"
+            "$POST_BUILD_SCRIPT_PATH"
+          else
+            echo "No script found at $POST_BUILD_SCRIPT_PATH, skipping."
+          fi
+        env:
+          $POST_BUILD_SCRIPT_PATH: ${{ inputs.post-build-script }}
       - name: Export and upload digest
         uses: grafana/shared-workflows/actions/docker-export-digest@rwhitaker/multi-arch-builds
         with:

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -64,12 +64,6 @@ on:
           Path to the Docker build context.
         default: "."
         type: string
-      delete-credentials-file:
-        description: |
-          Delete the credentials file after the action is finished.
-          If you want to keep the credentials file for a later step, set this to false.
-        default: "true"
-        type: string
       docker-buildx-driver:
         description: |
           The driver to use for Docker Buildx
@@ -276,7 +270,6 @@ jobs:
           cache-from: ${{ inputs.cache-from }}
           cache-to: ${{ inputs.cache-to }}
           context: ${{ inputs.context }}
-          delete-credentials-file: ${{ inputs.delete-credentials-file }}
           dockerhub-repository: ${{ inputs.dockerhub-repository }}
           docker-buildx-driver: ${{ inputs.docker-buildx-driver }}
           file: ${{ inputs.file }}

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -28,55 +28,80 @@ on:
       build-args:
         description: |
           List of arguments necessary for the Docker image to be built.
-        default: ""
+          Passed to `docker/build-push-action`.
         type: string
       build-contexts:
         description: |
-          List of additional build contexts (e.g., name=path)
-        required: false
+          List of additional build contexts (e.g., name=path).
+          Passed to `docker/build-push-action`.
         type: string
       buildkitd-config:
         description: |
-          Configum buildkitium descriptium
-        default: ""
+          The buildkitd config file to use. Defaults to `/etc/buildkitd.toml` if you're using
+          Grafana's self-hosted runners.
+          Passed to `docker/setup-buildx-action`.
         type: string
       buildkitd-config-inline:
         description: |
-          Inliumium configutorium buildkitium descriptium
-        default: ""
+          The buildkitd inline config to use.
+          Passed to `docker/setup-buildx-action`.
         type: string
       cache-from:
         description: |
-          Where cache should be fetched from
-        required: false
+          Where cache should be fetched from.
+          Passed to `docker/build-push-action`.
         default: "type=gha"
         type: string
       cache-to:
         description: |
-          Where cache should be stored to
-        required: false
+          Where cache should be stored to.
+          Passed to `docker/build-push-action`.
         default: "type=gha,mode=max"
         type: string
       context:
         description: |
           Path to the Docker build context.
+          Passed to `docker/build-push-action`.
         default: "."
         type: string
       docker-buildx-driver:
         description: |
-          The driver to use for Docker Buildx
-        required: false
+          The driver to use for Docker Buildx.
+          Passed to `docker/setup-buildx-action`.
         default: "docker-container"
+        type: string
+      dockerhub-registry:
+        description: |
+          DockerHub Registry to store docker images in.
+        default: "docker.io"
         type: string
       dockerhub-repository:
         description: |
-          Ipsum dockerhubium
+          DockerHub Repository to store docker images in.
+          Default: github.repository
         default: "${{ github.repository }}"
         type: string
       file:
         description: |
           The dockerfile to use.
-        required: false
+          Passed to `docker/build-push-action`.
+        type: string
+      gar-delete-credentials-file:
+        description: |
+          Delete the Google credentials file after the action is finished.
+          If you want to keep the credentials file for a later step, set this to false.
+        default: "true"
+        type: string
+      gar-environment:
+        description: |
+          Environment for pushing artifacts (can be either dev or prod).
+          This sets the GAR Project (gar-project) to either `grafanalabs-dev` or `grafanalabs-global`.
+        default: dev
+        type: string
+      gar-image:
+        description: |
+          Name of the image to build.
+          Default: `${GitHub Repo Name}`.
         type: string
       gar-registry:
         description: |
@@ -88,69 +113,64 @@ on:
           Override the 'repo_name' used to construct the GAR repository name.
           Only necessary when the GAR includes a repo name that doesn't match the GitHub repo name.
           Default: `docker-${GitHub Repo Name}-${gar-environment}`
-        default: ""
         type: string
-      gar-environment:
+      include-tags-in-push:
         description: |
-          Environment for pushing artifacts (can be either dev or prod).
-        default: "dev"
-        type: string
-      gar-image:
-        description: |
-          Name of the image to build.
-          Default: `${GitHub Repo Name}`
-        default: ""
+          Disables the pushing of tags, and instead includes just a list of images as docker tags.
+          Used when pushing docker digests instead of docker tags.
+        default: "true"
         type: string
       labels:
         description: |
-          List of custom labels to add to the image as metadata.
-        required: false
+          List of custom labels to add to the image as metadata (passed to `docker/build-push-action`).
+          Passed to `docker/build-push-action`.
         type: string
       load:
         description: |
-          Whether to load the built image into the local docker daemon.
-        required: false
+          Whether to load the built image into the local docker daemon (passed to `docker/build-push-action`).
+          Passed to `docker/build-push-action`.
         default: "false"
         type: string
       outputs:
-        description: | # TODO Desc
-          Ipsum factum explainum.
-        required: false
-        default: ""
+        description: |
+          List of docker output destinations.
+          Passed to `docker/build-push-action`.
         type: string
       platforms:
         description: |
-          List of platforms to build the image for
-        required: false
+          List of platforms to build the image for.
+          Passed to `docker/build-push-action`.
         type: string
       push:
         description: |
           Whether to push the image to the configured registries.
-        required: false
+          Passed to `docker/build-push-action`.
         type: string
       registries:
         description: |
-          List of registries to build images for.
-        default: ""
+          CSV list of registries to build images for.
+          Accepted registries are "gar" and "dockerhub".
         type: string
       secrets:
         description: |
           Secrets to expose to the build. Only needed when authenticating to private repositories outside the repository in which the image is being built.
-        required: false
+          Passed to `docker/build-push-action`.
         type: string
       ssh:
         description: |
           List of SSH agent socket or keys to expose to the build
+          Passed to `docker/build-push-action`.
         type: string
       tags:
         description: |
           List of Docker tags to be pushed.
+          Passed to `docker/build-push-action`.
         required: true
         type: string
       target:
         description: |
-          Sets the target stage to build
-        required: false
+          Sets the target stage to build.
+          Passed to `docker/build-push-action`.
         type: string
       # /INHERITED CONFIGS
     outputs:

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -1,8 +1,6 @@
 name: Push to artifact registry MultiArch
 # description: Resuable workflow to push to Google Artifact Registry using runners of different architectures.
 
-# TODO: docker.io/grafana/cicd-test:rickytest is the correct url style for dockerhub
-
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -318,7 +318,6 @@ jobs:
           platform: ${{ env.PLATFORM }}
 
   merge-digest:
-    if: ${{ inputs.push == 'true' }}
     runs-on: ubuntu-arm64-small
     needs: build-and-push
     permissions:
@@ -331,3 +330,4 @@ jobs:
           images: ${{ needs.build-and-push.outputs.images }}
           gar-environment: ${{ inputs.gar-environment }}
           docker-metadata-json: ${{ needs.build-and-push.outputs.metadatajson }}
+          push: ${{ inputs.push }}


### PR DESCRIPTION
This pull request introduces a reusable workflow that uses a matrix strategy to perform native multi-arch docker builds for `arm64` and `amd64` builds. 

It uses the 3 new composite actions from https://github.com/grafana/shared-workflows/pull/1347.