### PR TITLE
feat(go-flaky-tests): add ignored-tests option to filter out specific test failures

### DIFF
--- a/actions/go-flaky-tests/action.yaml
+++ b/actions/go-flaky-tests/action.yaml
@@ -35,6 +35,10 @@ inputs:
     description: "Include only the top K flaky tests by distinct branches count in analysis"
     required: false
     default: "3"
+  ignored-tests:
+    description: "Comma-delimited test names to skip failures for"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -67,3 +71,4 @@ runs:
         REPOSITORY_DIRECTORY: ${{ inputs.repository-directory }}
         SKIP_POSTING_ISSUES: ${{ inputs.skip-posting-issues }}
         TOP_K: ${{ inputs.top-k }}
+        IGNORED_TESTS: ${{ inputs.ignored-tests }}

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/analyzer.go
@@ -118,6 +118,27 @@ func (t *TestFailureAnalyzer) AnalyzeFailures(config Config) (*FailuresReport, e
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse test failures: %w", err)
 	}
+
+	// Filter out ignored tests
+	if len(config.IgnoredTests) > 0 {
+		log.Printf("🚫 Filtering out %d ignored tests: %v", len(config.IgnoredTests), config.IgnoredTests)
+		var filteredTests []FlakyTest
+		for _, test := range flakyTests {
+			ignored := false
+			for _, ignoredTest := range config.IgnoredTests {
+				if test.TestName == ignoredTest {
+					ignored = true
+					break
+				}
+			}
+			if !ignored {
+				filteredTests = append(filteredTests, test)
+			}
+		}
+		log.Printf("📊 Filtered tests: %d -> %d (removed %d ignored tests)", len(flakyTests), len(filteredTests), len(flakyTests)-len(filteredTests))
+		flakyTests = filteredTests
+	}
+
 	if len(flakyTests) > config.TopK {
 		flakyTests = flakyTests[:config.TopK]
 	}

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"strings"
 )
 
 type Config struct {
@@ -14,6 +15,7 @@ type Config struct {
 	RepositoryDirectory string
 	SkipPostingIssues   bool
 	TopK                int
+	IgnoredTests        []string
 }
 
 func getConfigFromEnv() Config {
@@ -26,6 +28,7 @@ func getConfigFromEnv() Config {
 		RepositoryDirectory: getEnvWithDefault("REPOSITORY_DIRECTORY", "."),
 		SkipPostingIssues:   getBoolEnvWithDefault("SKIP_POSTING_ISSUES", true),
 		TopK:                getIntEnvWithDefault("TOP_K", 3),
+		IgnoredTests:        getStringSliceFromEnv("IGNORED_TESTS"),
 	}
 }
 
@@ -50,4 +53,20 @@ func getIntEnvWithDefault(key string, defaultValue int) int {
 		}
 	}
 	return defaultValue
+}
+
+func getStringSliceFromEnv(key string) []string {
+	value := os.Getenv(key)
+	if value == "" {
+		return []string{}
+	}
+	
+	var result []string
+	for _, item := range strings.Split(value, ",") {
+		trimmed := strings.TrimSpace(item)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
 }

--- a/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
+++ b/actions/go-flaky-tests/cmd/go-flaky-tests/config.go
@@ -60,7 +60,7 @@ func getStringSliceFromEnv(key string) []string {
 	if value == "" {
 		return []string{}
 	}
-	
+
 	var result []string
 	for _, item := range strings.Split(value, ",") {
 		trimmed := strings.TrimSpace(item)

--- a/actions/go-flaky-tests/run-local.sh
+++ b/actions/go-flaky-tests/run-local.sh
@@ -25,10 +25,11 @@ usage() {
     echo "  --repository-directory DIR    Repository directory (default: current directory)"
     echo "  --skip-posting-issues BOOL    Skip creating GitHub issues (default: ${DEFAULT_SKIP_POSTING_ISSUES})"
     echo "  --top-k NUM                   Number of top flaky tests to analyze (default: ${DEFAULT_TOP_K})"
+    echo "  --ignored-tests TESTS         Comma-delimited test names to skip failures for"
     echo ""
     echo "Environment variables:"
     echo "  LOKI_URL, LOKI_USERNAME, LOKI_PASSWORD, REPOSITORY, TIME_RANGE,"
-    echo "  REPOSITORY_DIRECTORY, GITHUB_TOKEN, SKIP_POSTING_ISSUES, TOP_K"
+    echo "  REPOSITORY_DIRECTORY, GITHUB_TOKEN, SKIP_POSTING_ISSUES, TOP_K, IGNORED_TESTS"
     echo ""
     echo "Example:"
     echo "  $0 --loki-url http://localhost:3100 --repository myorg/myrepo --time-range 7d"
@@ -77,6 +78,10 @@ while [[ $# -gt 0 ]]; do
             TOP_K="$2"
             shift 2
             ;;
+        --ignored-tests)
+            IGNORED_TESTS="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown option: $1"
             usage
@@ -111,6 +116,7 @@ export GITHUB_TOKEN
 export REPOSITORY_DIRECTORY
 export SKIP_POSTING_ISSUES
 export TOP_K
+export IGNORED_TESTS
 
 echo "🔧 Running go-flaky-tests locally..."
 echo "📊 Repository: $REPOSITORY"


### PR DESCRIPTION
Adds ability to exclude specific tests from flaky test analysis by name. Tests in the ignored list are filtered out before applying top-K limit, ensuring they don't consume analysis slots or generate GitHub issues.

continued from https://github.com/grafana/shared-workflows/pull/1276

this is the last piece in go-flaky-tests. I don't plan to work more on this apart from bug fixes or PR reviews