### PR TITLE
fix: push-to-gar-docker pin buildx to 0.28.0

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -175,7 +175,7 @@ runs:
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       with:
         driver: ${{ inputs.docker-buildx-driver }}
-        version: latest # see https://github.com/docker/build-push-action/issues/1345#issuecomment-2770572479
+        version: 0.28.0 # Latest is 0.29.1 which has an issue with pushing to some registrys https://github.com/docker/buildx/issues/3446
         buildkitd-config: ${{ runner.environment == 'self-hosted' && '/etc/buildkitd.toml' || '' }}
 
     # The `context` input is flagged by Zizmor as a [sink]. This means that with


### PR DESCRIPTION
An issue with buildx prevents pushing to some docker registries https://github.com/docker/buildx/issues/3446