### PR TITLE
chore(cleanup-branches): prep for release

### DIFF
--- a/actions/cleanup-branches/CHANGELOG.md
+++ b/actions/cleanup-branches/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -23,14 +23,14 @@ on:
     - cron: "0 9 * * 1"
 
 jobs:
-  cleanup-branches::
+  cleanup-branches:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
     steps:
       - uses: actions/checkout@v5
-      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v1.0.0
+      - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.0.0
         with:
           dry-run: false
 ```

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -159,6 +159,11 @@
       "package-name": "validate-renovate-config",
       "extra-files": ["README.md"],
       "initial-version": "0.1.0"
+    },
+    "actions/cleanup-branches": {
+      "package-name": "cleanup-branches",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
This pull request introduces initial release configuration and documentation for the new `cleanup-branches` GitHub Action. The main changes involve setting up release management, adding a changelog, and updating usage instructions.

Release management and documentation setup:

* Added a `CHANGELOG.md` file to `actions/cleanup-branches` to track changes for the action.
* Updated `release-please-config.json` to include `actions/cleanup-branches` with its initial version and relevant files for release automation.

Documentation and workflow usage:

* Updated the example workflow in `actions/cleanup-branches/README.md` to reference the correct action version and fixed a syntax issue in the job definition.