### PR TITLE
feat(cleanup-branches): input logic and error handling improvements

### DIFF
--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -73,11 +73,19 @@ runs:
         done
     - name: Delete branches (dry run)
       shell: bash
-      if: ${{ inputs.dry-run == 'true' }}
+      if: ${{ inputs.dry-run != 'false' }}
       run: |
+        if [[ ! -s branches.txt ]]; then
+          echo "🟢 No branches marked for deletion."
+          exit 0
+        fi
         cat branches.txt | xargs -I {} echo git push origin --delete "{}"
     - name: Delete branches
       shell: bash
-      if: ${{ inputs.dry-run != 'true' }}
+      if: ${{ inputs.dry-run == 'false' }}
       run: |
+        if [[ ! -s branches.txt ]]; then
+          echo "🟢 No branches marked for deletion."
+          exit 0
+        fi
         cat branches.txt | xargs -I {} git push origin --delete "{}"


### PR DESCRIPTION
This pull request updates the branch cleanup workflow to improve its handling of dry run logic and prevent failed pipelines when no branches qualify for deletion. It includes 2 changes:

#### Dry Run Logic Update

Swap the conditional logic for the "Delete branches (dry run)" and "Delete branches" steps in `action.yml` so that invalid entries will now default to `dry-run`. For example, consider the following circumstance:

```yaml
uses: grafana/shared-workflows/actions/cleanup-branches
with:
    dry-run: falses
```

Currently we would delete the branches, since `'falses' != 'true'`. The new logic sees that `'falses' != 'false'` and does a dry run.

#### Handling for No Branches

Added a check to both branch deletion steps to skip execution and print a message if no branches are marked for deletion. Currently it will fail as there is no `branches.txt` file to parse.