### PR TITLE
chore: rename docker-import-digests-push-manifest

### DIFF
--- a/actions/docker-build-push-image/README.md
+++ b/actions/docker-build-push-image/README.md
@@ -7,7 +7,7 @@ uses [docker/build-push-action] to build and push the image(s).
 This action can work 1 of 2 ways:
 
 1. It can be run on a single runner, and if multiple `platforms` are configured then buildx/QEMU emulation is used.
-2. It can be used in conjunction with [docker-export-digest] and [docker-import-digests-push-manifest] to push untagged
+2. It can be used in conjunction with [docker-export-digest] and [docker-import-digests-push-manifests] to push untagged
    images whose digests are later exported and merged into a tagged docker manifest. For true multi-arch builds.
 
 This can push to the following registries:
@@ -18,7 +18,7 @@ This can push to the following registries:
 [docker/build-push-action]: https://github.com/docker/build-push-action
 [docker-build-push-image]: ../docker-build-push-image/README.md
 [docker-export-digest]: ../docker-export-digest/README.md
-[docker-import-digests-push-manifest]: ../docker-import-digests-push-manifest/README.md
+[docker-import-digests-push-manifests]: ../docker-import-digests-push-manifests/README.md
 
 <!-- x-release-please-start-version -->
 

--- a/actions/docker-export-digest/README.md
+++ b/actions/docker-export-digest/README.md
@@ -2,13 +2,13 @@
 
 This is a composite GitHub Action used to export a docker digest as a workflow artifact.
 
-This can be used in conjunction with [docker-build-push-image] and [docker-import-digests-push-manifest] to build
+This can be used in conjunction with [docker-build-push-image] and [docker-import-digests-push-manifests] to build
 native multi-arch Docker images.
 
 [docker/build-push-action]: https://github.com/docker/build-push-action
 [docker-build-push-image]: ../docker-build-push-image/README.md
 [docker-export-digest]: ../docker-export-digest/README.md
-[docker-import-digests-push-manifest]: ../docker-import-digests-push-manifest/README.md
+[docker-import-digests-push-manifests]: ../docker-import-digests-push-manifests/README.md
 
 <!-- x-release-please-start-version -->
 

--- a/actions/docker-import-digests-push-manifests/README.md
+++ b/actions/docker-import-digests-push-manifests/README.md
@@ -9,7 +9,7 @@ native multi-arch Docker images.
 [docker/build-push-action]: https://github.com/docker/build-push-action
 [docker-build-push-image]: ../docker-build-push-image/README.md
 [docker-export-digest]: ../docker-export-digest/README.md
-[docker-import-digests-push-manifest]: ../docker-import-digests-push-manifest/README.md
+[docker-import-digests-push-manifests]: /README.md
 
 <!-- x-release-please-start-version -->
 
@@ -28,7 +28,7 @@ jobs:
       id-token: write
     steps:
       - name: Download Multi-Arch Digests, Construct and Upload Manifest
-        uses: grafana/shared-workflows/actions/docker-import-digests-push-manifest@docker-import-digests-push-manifest/v0.0.0
+        uses: grafana/shared-workflows/actions/docker-import-digests-push-manifests@docker-import-digests-push-manifest/v0.0.0
         with:
           docker-metadata-json: ${{ needs.docker-build-push-image.outputs.metadatajson }}
           gar-environment: "dev"

--- a/actions/docker-import-digests-push-manifests/action.yaml
+++ b/actions/docker-import-digests-push-manifests/action.yaml
@@ -1,5 +1,5 @@
-name: Download and Merge Docker Digests into Manifest
-description: Composite action to export and upload a docker manifest
+name: Download and Merge Docker Digests into Manifest(s)
+description: Composite action to export and upload docker manifest(s)
 
 inputs:
   docker-metadata-json:
@@ -36,7 +36,7 @@ runs:
       with:
         repository: ${{ env.action_repo }}
         ref: ${{ env.action_ref }}
-        path: _shared-workflows-docker-import-digests-push-manifest
+        path: _shared-workflows-docker-import-digests-push-manifests
         persist-credentials: false
 
     - name: Download digests
@@ -103,11 +103,11 @@ runs:
 
     - name: Login to GAR
       if: ${{ steps.prepare-vars.outputs.include-gar == 'true' }}
-      uses: ./_shared-workflows-docker-import-digests-push-manifest/actions/login-to-gar
+      uses: ./_shared-workflows-docker-import-digests-push-manifests/actions/login-to-gar
 
     - name: Login to DockerHub
       if: ${{ steps.prepare-vars.outputs.include-dockerhub == 'true' }}
-      uses: ./_shared-workflows-docker-import-digests-push-manifest/actions/dockerhub-login
+      uses: ./_shared-workflows-docker-import-digests-push-manifests/actions/dockerhub-login
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta


### PR DESCRIPTION
Rename `docker-import-digests-push-manifest` to `docker-import-digests-push-manifests` because _technically_ if we're pushing to multiple registries we're pushing manifests... plural.