### PR TITLE
chore(docker actions): prep for releases

### DIFF
--- a/actions/docker-build-push-image/CHANGELOG.md
+++ b/actions/docker-build-push-image/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/docker-export-digest/CHANGELOG.md
+++ b/actions/docker-export-digest/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/docker-import-digests-push-manifest/CHANGELOG.md
+++ b/actions/docker-import-digests-push-manifest/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -164,6 +164,21 @@
       "package-name": "cleanup-branches",
       "extra-files": ["README.md"],
       "initial-version": "0.1.0"
+    },
+    "actions/docker-build-push-image": {
+      "package-name": "docker-build-push-image",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
+    "actions/docker-export-digest": {
+      "package-name": "docker-export-digest",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
+    "actions/docker-import-digests-push-manifest": {
+      "package-name": "docker-import-digests-push-manifest",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
This pull request sets up changelog tracking and release configuration for three Docker-related GitHub Actions. The main changes are the addition of initial changelog files and updates to the release configuration to enable versioning for these actions.

Release configuration setup:

* Added entries for `docker-build-push-image`, `docker-export-digest`, and `docker-import-digests-push-manifest` actions to `release-please-config.json`, specifying their package names, extra files, and initial version (`0.1.0`).

Changelog initialization:

* Created an empty `CHANGELOG.md` file for each of the three actions: `actions/docker-build-push-image`, `actions/docker-export-digest`, and `actions/docker-import-digests-push-manifest`.