### PR TITLE
chore(cleanup-branches): modify default max-date to match GitHub's definition of stale

### DIFF
--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: ${{ github.token }}
     description: "GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (contents: write) and pull requests (pull_requests: read)"
   max-date:
-    default: "1 month ago"
+    default: "3 months ago"
     description: |
       Value provided to `date -d={}. From `man date`: "The --date=STRING is a mostly free format human readable date string such as "Sun, 29 Feb 2004 16:21:42 -0800" or "2004-02-29 16:21:42" or even "next Thursday".  A date string may
        contain items indicating calendar date, time of day, time zone, day of week, relative time, relative date, and numbers.  An empty string indicates the beginning of the day.  The


### PR DESCRIPTION
GitHub [defines stale branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/viewing-branches-in-your-repository) as branches without commits in the last 3 months. This PR updates `cleanup-branches` default expiration age to match.