### PR TITLE
chore: define cooldowns for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 0
     directory: "/actions/trigger-argo-workflow"
     schedule:
       interval: "weekly"
@@ -13,6 +18,11 @@ updates:
           - "*"
 
   - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 5
+      semver-patch-days: 0
     directory: "/actions/techdocs-rewrite-relative-links"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Patch updates should be considered immediately. This also fixes a zizmor issue I've noticed in other PRs.