### PR TITLE
feat: implement branch cleanup

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -13,5 +13,7 @@ jobs:
     runs-on: ubuntu-arm64-small
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Cleanup
         uses: grafana/shared-workflows/actions/cleanup-branches@c906affb19f070fde9dce56e0db8053c490946cc # cleanup-branches/v0.2.1


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate the cleanup of Git branches on a scheduled basis. The workflow is configured to run weekly, and will expire any branches older than 3 months.

Automation and workflow setup:

* Added `.github/workflows/cleanup-branches.yml` to schedule a weekly branch cleanup job using the `grafana/shared-workflows/actions/cleanup-branches` action.
* Configured the workflow to run on `ubuntu-arm64-small` and to use specific versions of the `actions/checkout` and `cleanup-branches` actions for stability and reproducibility.


A sample dry run from Oct 16 shows an approximation of the branches that will be purged when this action is run: https://github.com/grafana/shared-workflows/actions/runs/18574509283/job/52956480404#step:4:384

Part of https://github.com/grafana/deployment_tools/issues/278935