### PR TITLE
chore: set timeout on pre-commit workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     permissions:
       contents: read


### PR DESCRIPTION
This workflow has recently run into some issues where it just hung. To make these not unnecessarily block resources, it should be killed after 5 minutes.