### PR TITLE
feat(renovate): add custom manager to update validator renovate npm version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,9 +14,7 @@
     },
     {
       customType: "regex",
-      managerFilePatterns: [
-        "/(?:^|/)actions/.+/action\\.ya?ml$/",
-      ],
+      managerFilePatterns: ["/(?:^|/)actions/.+/action\\.ya?ml$/"],
       matchStrings: [
         "RENOVATE_VERSION:\\s*(?<depName>renovate)@(?<currentValue>[^\\s]+)",
       ],


### PR DESCRIPTION
This PR adds a new regex custom type to renovate.json5 to target the renovate npm package version used in our validation workflow

Tested this regex pattern in a personal repository and Renovate was able to create [this PR](https://github.com/grafana/phlope-test-repo/pull/1)

This change allows us to keep our validator up to date with the version running in ops so users can more accurately test their config via GH actions