### PR TITLE
docs(docker-build-push-multiarch): fix typo

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.md
+++ b/.github/workflows/docker-build-push-multiarch.md
@@ -1,4 +1,4 @@
-# docker-build-push-multiaarch
+# docker-build-push-multiarch
 
 This is a reusable workflow that uses Grafana's hosted runners to natively build and push multi-architecture docker
 images.


### PR DESCRIPTION
Small fix in docker-build-push-multiarch docs. If by "small" you include misspelling the name of the actual thing 🤦