### PR TITLE
fix(create-github-app-token): use temporary file w/ trap for token response

### DIFF
--- a/actions/create-github-app-token/create_token.sh
+++ b/actions/create-github-app-token/create_token.sh
@@ -8,22 +8,26 @@ setRandomApp() {
     echo "Randomly selected GitHub App: ${GITHUB_APP}"
 }
 
+TEMP_FILE=$(mktemp)
+echo "Using temporary file: ${TEMP_FILE}"
+trap 'rm -f "${TEMP_FILE}"' EXIT
+
 for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
     echo "Attempt ${attempt} to get GitHub token..."
     setRandomApp
-    RESPONSE=$(curl -sS -w "%{http_code}" -o response.json \
+    RESPONSE=$(curl -sS -w "%{http_code}" -o "${TEMP_FILE}" \
         "${VAULT_URL}/v1/github-app-${GITHUB_APP}/token/${REPOSITORY_NAME}-${REF_SHA}-${PERMISSION_SET}" \
         -H "X-Vault-Token: ${VAULT_TOKEN}" \
         -H "Proxy-Authorization-Token: Bearer ${GITHUB_JWT_PROXY}" || true)
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
-        TOKEN=$(jq -r '.data.token' response.json)
+        TOKEN=$(jq -r '.data.token' "${TEMP_FILE}")
         echo "github_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
         echo "Create GitHub Token done!"
         exit 0
     else
         echo "Vault request failed (HTTP ${RESPONSE})"
-        cat response.json || true
+        cat "${TEMP_FILE}" || true
         sleep $((attempt * 5))
     fi
 done


### PR DESCRIPTION
This pull request improves the handling of temporary files in the `create_token.sh` script by using a securely created temporary file for HTTP responses, ensuring proper cleanup and avoiding file conflicts.

Improvements to temporary file handling:

* Replaced the hardcoded `response.json` file with a securely generated temporary file using `mktemp`, and set up a `trap` to automatically remove the file on script exit.
* Updated all references from `response.json` to the new temporary file variable (`${TEMP_FILE}`) for writing and reading HTTP responses, improving reliability and security.