### PR TITLE
fix(create-github-app-token): use temporary file w/ trap for oidc response

### DIFF
--- a/actions/create-github-app-token/auth_vault.sh
+++ b/actions/create-github-app-token/auth_vault.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
+TEMP_FILE=$(mktemp)
+echo "Using temporary file: ${TEMP_FILE}"
+trap 'rm -f "${TEMP_FILE}"' EXIT
+
 MAX_ATTEMPTS=3
 for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
     echo "Attempt ${attempt} to authenticate with Vault..."
 
-    RESPONSE=$(curl -sS -w "%{http_code}" -o response.json \
+    RESPONSE=$(curl -sS -w "%{http_code}" -o "${TEMP_FILE}" \
         -X POST "${VAULT_URL}/v1/auth/github-actions-oidc/login" \
         -H "Content-Type: application/json" \
         -H "Proxy-Authorization-Token: Bearer ${GITHUB_JWT_PROXY}" \
@@ -15,14 +19,14 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
         }" || true)
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
-        TOKEN=$(jq -r '.auth.client_token' response.json)
+        TOKEN=$(jq -r '.auth.client_token' "${TEMP_FILE}")
         echo "::add-mask::$TOKEN"
         echo "vault_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
         echo "Vault auth done!"
         exit 0
     else
         echo "Vault auth failed (HTTP ${RESPONSE})"
-        cat response.json || true
+        cat "${TEMP_FILE}" || true
         sleep $((attempt * 5))
     fi
 done


### PR DESCRIPTION
Missed that this script also writes sensitive info to a response.json file when I landed #1474, so this does the same thing for the OIDC token as well, using a temporary file w/ a trap to clean it up.