### PR TITLE
feat(push-to-gar-docker): parse registry as input in login-to-gar

### DIFF
--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -164,6 +164,7 @@ runs:
       with:
         environment: ${{ inputs.environment }}
         delete_credentials_file: false
+        registry: ${{ inputs.registry }}
     - name: Extract metadata (tags, labels) for Docker
       id: meta
       uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0


### PR DESCRIPTION
Currently there's no way to parse the registry in `login-to-gar` from `push-to-gar-docker`. It's needed in order to set the docker credentials for different registries.