### PR TITLE
fix(docker-build-push-image): use labels from docker/metadata-action

### DIFF
--- a/actions/docker-build-push-image/action.yaml
+++ b/actions/docker-build-push-image/action.yaml
@@ -265,6 +265,7 @@ runs:
       uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
       with:
         images: ${{ steps.setup-vars.outputs.images }}
+        labels: ${{ inputs.labels }}
         tags: ${{ inputs.tags }}
 
     - name: Setup buildkitd-config
@@ -331,7 +332,7 @@ runs:
         cache-to: ${{ inputs.cache-to }}
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}
-        labels: ${{ inputs.labels }}
+        labels: ${{ steps.meta.outputs.labels }}
         load: ${{ inputs.load == 'true' }}
         platforms: ${{ inputs.platforms }}
         outputs: ${{ inputs.outputs }}


### PR DESCRIPTION
We are not correctly passing the generated docker labels from `docker/metadata-action` to `docker/build-push-action`. This PR remedies that.

**Label management improvements:**

* The `labels` input is now passed directly to the Docker metadata action, ensuring that user-provided labels are included in the metadata generation step.
* The `labels` parameter for the Docker build step now uses the output from the metadata action (`steps.meta.outputs.labels`) instead of the raw input, ensuring that all computed and standardized labels are applied during the build.