### PR TITLE
chore(docker-build-push-multiarch): update docker-build-push-action version

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -334,7 +334,7 @@ jobs:
           persist-credentials: false
       - name: Build Docker Image
         id: build
-        uses: grafana/shared-workflows/actions/docker-build-push-image@c658f0fe8393e31c39d266684ef273c6538ed0e1 # docker-build-push-image/v0.1.0
+        uses: grafana/shared-workflows/actions/docker-build-push-image@7a256e98018aba3d01643479808a7690179a1f1c # docker-build-push-image/v0.1.1
         with:
           # from inputs
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use a newer version of the Docker build and push action. This change ensures that the workflow benefits from recent improvements and bug fixes in the action.

Workflow dependency update:

* Updated the `docker-build-push-image` action in `.github/workflows/docker-build-push-multiarch.yml` from version `v0.1.0` to `v0.1.1`.