### PR TITLE
chore(renovate): add docker-build-push-multiarch for auto updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,13 @@
     },
     {
       customType: "regex",
+      managerFilePatterns: [
+        "/(?:^|/)\\.github/workflows/docker-build-push-multiarch.yml",
+      ],
+      datasourceTemplate: "github-actions",
+    },
+    {
+      customType: "regex",
       managerFilePatterns: ["/(?:^|/)actions/.+/action\\.ya?ml$/"],
       matchStrings: [
         "RENOVATE_VERSION:\\s*(?<depName>renovate)@(?<currentValue>[^\\s]+)",


### PR DESCRIPTION
This pull request updates the Renovate configuration to include `.github/workflows/docker-build-push-multiarch.yml`.

**Renovate configuration enhancements:**

* Added a new custom regex rule in `.github/renovate.json5` to enable Renovate to detect and update dependencies in the `.github/workflows/docker-build-push-multiarch.yml` GitHub Actions workflow file, using the `github-actions` datasource.