### PR TITLE
fix(renovate): add missing matchStrings config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -17,8 +17,8 @@
       managerFilePatterns: [
         "/(?:^|/)\\.github/workflows/docker-build-push-multiarch.yml",
       ],
-      "matchStrings": [
-        "uses:\\s*(?<depName>[a-zA-Z0-9_.\\-/]+)@(?<currentValue>[^\\s]+)"
+      matchStrings: [
+        "uses:\\s*(?<depName>[a-zA-Z0-9_.\\-/]+)@(?<currentValue>[^\\s]+)",
       ],
       datasourceTemplate: "github-actions",
     },


### PR DESCRIPTION
This PR fixes a broken renovate config block. It appears that the [matchStrings config is required for CustomManagers](https://docs.renovatebot.com/configuration-options/#custommanagers), so this PR adds that to the new value.

[Original breaking PR](https://github.com/grafana/shared-workflows/commit/ed7f993635148485c6225f5127f2ec8a034effaf)


The logs that show the config parsing error can be seen [here](https://ops.grafana-ops.net/explore?schemaVersion=1&panes=%7B%22hhr%22:%7B%22datasource%22:%22000000193%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bnamespace%3D%5C%22renovate-self-hosted%5C%22%7D%20%7C%3D%20%5C%22Configuration%20Error%5C%22%20%7C%20json%20%7C%20repository%3D%5C%22grafana%2Fshared-workflows%5C%22%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22000000193%22%7D,%22editorMode%22:%22code%22,%22direction%22:%22backward%22%7D%5D,%22range%22:%7B%22from%22:%221762970500547%22,%22to%22:%221762971612312%22%7D,%22compact%22:false%7D%7D&orgId=1).