### PR TITLE
chore(renovate): add docker-build-push-multiarch.yml to github-actions manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,7 +31,7 @@
   ],
   forkProcessing: "enabled",
   "github-actions": {
-    "managerFilePatterns": [".github/workflows/docker-build-push-multiarch.yml"]
+    managerFilePatterns: [".github/workflows/docker-build-push-multiarch.yml"],
   },
   globalExtends: [":pinDependencies", "config:best-practices"],
   onboarding: false,


### PR DESCRIPTION
This pull request updates the Renovate configuration to shift from a custom regex-based approach to using the built-in `github-actions` manager for the `docker-build-push-multiarch.yml` workflow file. The previous attempt did not work.

**Renovate configuration improvements:**

* Removed the custom regex manager for matching dependencies in `.github/workflows/docker-build-push-multiarch.yml`, simplifying the configuration.
* Added a configuration block to explicitly use the `github-actions` manager for `.github/workflows/docker-build-push-multiarch.yml`, ensuring dependencies in this workflow are managed using Renovate's standard approach.