### PR TITLE
chore(renovate): make renovate self-update weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,8 @@
         "RENOVATE_VERSION:\\s*(?<depName>renovate)@(?<currentValue>[^\\s]+)",
       ],
       datasourceTemplate: "npm",
+      // Run the custom matcher on early Monday mornings (UTC)
+      schedule: "* 0-4 * * 1",
     },
   ],
   dependencyDashboard: false,


### PR DESCRIPTION
Currently having renovate updating itself every 3 hours is too noisy. Basically means that there is a high chance that we may have consecutive renovate runs based on different images every day, which adds unnecessary complexity.

This PR should limit the renovate self-update PRs to weekly, specifically every early Monday morning.