### PR TITLE
feat(push-to-gcs): add process_gcloudignore input

### DIFF
--- a/actions/push-to-gcs/README.md
+++ b/actions/push-to-gcs/README.md
@@ -127,6 +127,7 @@ jobs:
 | `predefinedAcl`           | String  | Predefined ACL applied to the uploaded objects. Default is `projectPrivate`. See [Google Documentation][gcs-docs-upload-options] for a list of available options.                            |
 | `delete_credentials_file` | Boolean | Delete the credentials file after the action is finished. If you want to keep the credentials file for a later step, set this to false. (Default: `true`)                                    |
 | `use_wif_auth`            | Boolean | Use WIF authentication. Overrides the `service_account` input.                                                                                                                               |
+| `process_gcloudignore`    | Boolean | Whether to process `.gcloudignore` file. (Default: `false`)                                                                                                                                  |
 
 > [!TIP]
 > To use WIF authentication you must enable `uniform_bucket_level_access` on the destination bucket. If you are at Grafana Labs, instructions can be found [here](https://enghub.grafana-ops.net/docs/default/component/deployment-tools/platform/continuous-integration/google-artifact-registry/). More info can be found in [Google's docs](https://cloud.google.com/storage/docs/uniform-bucket-level-access).

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -50,6 +50,11 @@ inputs:
       Use WIF for authentication instead of service account.
     required: false
     default: "false"
+  process_gcloudignore:
+    description: |
+      Whether to process .gcloudignore file.
+    required: false
+    default: "false"
 
 outputs:
   uploaded:
@@ -114,7 +119,7 @@ runs:
         parent: ${{ inputs.parent }}
         predefinedAcl: ${{ inputs.use_wif_auth == 'true' && ' ' || inputs.predefinedAcl }} # when using WIF auth, we cannot use predefinedAcl
         gzip: ${{ inputs.gzip }}
-        process_gcloudignore: false
+        process_gcloudignore: ${{ inputs.process_gcloudignore }}
 
     - name: Cleanup checkout directory
       if: ${{ !cancelled() }}

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -119,7 +119,7 @@ runs:
         parent: ${{ inputs.parent }}
         predefinedAcl: ${{ inputs.use_wif_auth == 'true' && ' ' || inputs.predefinedAcl }} # when using WIF auth, we cannot use predefinedAcl
         gzip: ${{ inputs.gzip }}
-        process_gcloudignore: ${{ inputs.process_gcloudignore }}
+        process_gcloudignore: ${{ inputs.process_gcloudignore == 'true' }}
 
     - name: Cleanup checkout directory
       if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
Add `process_gcloudignore` as a configurable input to the push-to-gcs action with a default value of `false`.

## Changes
- Added `process_gcloudignore` input to action.yaml (defaults to `false`)
- Updated README.md to document the new input

This allows users to optionally enable `.gcloudignore` file processing when uploading to GCS.


Can't create branches here so had to fork