### PR TITLE
fix(docker-build-push-multiarch): add step names

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -224,6 +224,7 @@ jobs:
       runner-type-manifest: ${{ steps.runners.outputs.runner-type-manifest }}
     steps:
       - id: matrix
+        name: Convert platforms to runner arches
         shell: bash
         env:
           PLATFORMS: ${{ inputs.platforms }}
@@ -254,6 +255,7 @@ jobs:
           # Export as GitHub Action output
           echo "runner-arches=$MATRIX" | tee -a "${GITHUB_OUTPUT}"
       - id: runners
+        name: Set runner types
         shell: bash
         env:
           RUNNER_TYPE: ${{ inputs.runner-type }}


### PR DESCRIPTION
When using this action, in the GitHub Action logs I see:

<img width="649" height="90" alt="image" src="https://github.com/user-attachments/assets/e0ca5716-df01-4a5e-8708-e64b13533896" />

Adding names to steps to avoid that, and also make it easier to query traces by step name.