### PR TITLE
fix(docker-build-push-image): pass builder name to docker/build-push-action

### DIFF
--- a/actions/docker-build-push-image/action.yaml
+++ b/actions/docker-build-push-image/action.yaml
@@ -316,6 +316,7 @@ runs:
       uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
 
     - name: Set up Docker Buildx
+      id: setup-buildx
       uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       with:
         driver: ${{ inputs.docker-buildx-driver }}
@@ -338,6 +339,7 @@ runs:
         annotations: ${{ steps.meta.outputs.annotations }}
         build-args: ${{ inputs.build-args }}
         build-contexts: ${{ inputs.build-contexts }}
+        builder: ${{ steps.setup-buildx.outputs.name }}
         cache-from: ${{ inputs.cache-from }}
         cache-to: ${{ inputs.cache-to }}
         context: ${{ inputs.context }}


### PR DESCRIPTION
Currently in `docker-build-push-action` we're not assigning a buildx builder when calling `docker/build-push-action`, so we're using a _new_ builder instead of the one we setup using `docker/setup-buildx`. This resolves that by passing the [builder name](https://github.com/docker/setup-buildx-action?tab=readme-ov-file#outputs) that we've created.

* Docker Buildx setup: Added an `id` (`setup-buildx`) to the Buildx setup step, allowing outputs from this step to be referenced in later steps.
* Docker Buildx usage: Updated the Docker build step to use the Buildx builder instance created earlier by referencing `${{ steps.setup-buildx.outputs.name }}`.