### PR TITLE
chore(multiple): deprecate old docker actions and add migration guide

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -1,5 +1,9 @@
 # build-push-to-dockerhub
 
+> [!WARNING]
+> This GitHub Action is deprecated and will be removed from main after Jan 31, 2026.
+> Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating).
+
 > [!NOTE]
 > If you are at Grafana Labs:
 >

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -70,6 +70,11 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation Warning
+      shell: sh
+      run: |
+        echo "::warning::This GitHub Action is deprecated and will be removed from main after Jan 31, 2026. Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating)."
+
     # See this conversation for more context as to why we don't want to allow pushes on pull requests
     # https://github.com/grafana/shared-workflows/pull/143#discussion_r1628314620
     - name: Check if push is allowed

--- a/actions/docker-build-push-image/README.md
+++ b/actions/docker-build-push-image/README.md
@@ -144,3 +144,75 @@ So then the full checklist of work to do to implement a new registry is:
       on `${{ inputs.push == 'true' && steps.registries.outputs.include-<yourRegistry> == 'true' }}`, where yourRegistry is
       the value that will be passed into the `registries` input. Again, use existing repos as examples.
 - [ ] Celebrate
+
+## Migrating
+
+This action is intended to replace `build-push-to-dockerhub` and `build-push-to-dockerhub`.
+
+### Migrating from `build-push-to-dockerhub`
+
+1. Use the new action
+2. Rename dockerhub specific settings
+3. Add `registries: dockerhub`
+
+```bash
+# old
+  - id: push-to-dockerhub
+    uses: grafana/shared-workflows/actions/build-push-to-dockerhub@build-push-to-dockerhub/v0.4.0
+    with:
+      repository: ${{ github.repository }} # or any other dockerhub repository
+      context: .
+      tags: |-
+        "2024-04-01-abcd1234"
+        "latest"
+
+# new
+  - id: push-to-dockerhub
+    # CHANGE: use the new action
+    uses: grafana/shared-workflows/actions/docker-build-push-image@docker-build-push-image/v0.1.0
+    with:
+      # CHANGE: dockerhub ` specific configs
+      dockerhub-repository: ${{ github.repository }} # or any other dockerhub repository
+      context: .
+      tags: |-
+        "2024-04-01-abcd1234"
+        "latest"
+      # ADD: registry
+      registries: dockerhub
+```
+
+### Migrating from `push-to-gar-docker`
+
+1. Use the new action
+2. Rename gar specific settings
+3. Add `registries: gar`
+
+```bash
+# old
+  - id: push-to-gar
+    uses: grafana/shared-workflows/actions/push-to-gar-docker@push-to-gar-docker/v0.6.1
+    with:
+      registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
+      image_name: "backstage" # name of the image to be published, required
+      environment: "dev" # can be either dev/prod
+      tags: |-
+        "<IMAGE_TAG>"
+        "latest"
+      context: "<YOUR_CONTEXT>" # e.g. "." - where the Dockerfile is
+
+# new
+  - id: push-to-gar
+    # CHANGE: use the new action
+    uses: grafana/shared-workflows/actions/docker-build-push-image@docker-build-push-image/v0.1.0
+    with:
+      # CHANGE: gar specific configs
+      gar-registry: "<YOUR-GAR>" # e.g. us-docker.pkg.dev, optional
+      gar-image: "backstage" # name of the image to be published, required
+      gar-environment: "dev" # can be either dev/prod
+      tags: |-
+        "<IMAGE_TAG>"
+        "latest"
+      context: "<YOUR_CONTEXT>" # e.g. "." - where the Dockerfile is
+      # ADD: registry
+      registries: gar
+```

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -1,5 +1,9 @@
 # push-to-gar-docker
 
+> [!WARNING]
+> This GitHub Action is deprecated and will be removed from main after Jan 31, 2026.
+> Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating).
+
 > [!NOTE]
 > If you are at Grafana Labs:
 >

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -129,6 +129,11 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Deprecation Warning
+      shell: sh
+      run: |
+        echo "::warning::This GitHub Action is deprecated and will be removed from main after Jan 31, 2026. Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating)."
+
     - name: Checkout
       env:
         action_repo: ${{ github.action_repository }}


### PR DESCRIPTION
This pull request introduces deprecation notices for the `build-push-to-dockerhub` and `push-to-gar-docker` GitHub Actions, guiding users to migrate to the new `docker-build-push-image` action. It updates documentation and workflow files to provide clear migration instructions and runtime warnings.

Deprecation and migration guidance:

* Added deprecation warnings to the top of the `README.md` files for both `actions/build-push-to-dockerhub` and `actions/push-to-gar-docker`, informing users of the removal timeline and the recommended migration path. [[1]](diffhunk://#diff-f63b08ade8c2f33b4b8d70e8dc733819a744f95418c95120c7dfdc35f7267daeR3-R6) [[2]](diffhunk://#diff-508a84f0112127461c8c1801dfd39d202ecda902821a89b8b933708ec25163c3R3-R6)
* Inserted a new "Migrating" section in `actions/docker-build-push-image/README.md` with step-by-step instructions and code examples for migrating from both deprecated actions to `docker-build-push-image`.

Workflow runtime warnings:

* Added a deprecation warning step in both `actions/build-push-to-dockerhub/action.yaml` and `actions/push-to-gar-docker/action.yaml` to display a warning message during workflow execution, ensuring users are notified even if they miss the documentation updates. [[1]](diffhunk://#diff-e5c257e38e7a7d2eda4c436b8fe7d23009f8ac151bc1e823ae0c012f75de91e3R73-R77) [[2]](diffhunk://#diff-cd7255ed249c21034dc35c5e4e4db93b4cc690ce2c0f7d4034e1be574484a8feR132-R136)