### PR TITLE
docs: add guide for deprecating workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,6 @@ jobs:
 
 Every semver-like string between the `x-release-please-start-version` and `x-release-please-end-version` comments will be updated with the new version whenever the component is released.
 
-
 ### Deprecating Shared Workflows
 
 When deprecating a shared-workflow, follow this procedure:
@@ -200,4 +199,3 @@ When deprecating a shared-workflow, follow this procedure:
 1. Post a deprecation notice and warning in the affected action. Also provide a migration guide. Use [this commit](https://github.com/grafana/shared-workflows/commit/b6c252dc86cb65eaf2d8344d6d51ca07436214a2) as an example.
 2. Once you've merged the changes from step 1, release the affected action so that the latest version includes the deprecation notice. Renovate will automatically start to roll this version out.
 3. On the agreed upon date, delete the action from `main`.
-


### PR DESCRIPTION
This pull request updates the `README.md` to document the process for deprecating shared workflows. The new section provides clear, step-by-step guidance for maintainers to follow when deprecating a shared workflow, helping ensure consistency and clarity for users.

**Documentation updates:**

* Added a "Deprecating Shared Workflows" section to the `README.md`, outlining the recommended procedure for posting deprecation notices, releasing updates, and eventually deleting deprecated shared workflows.