### PR TITLE
fix(generate-openapi-clients): fix error on model template generation

### DIFF
--- a/actions/generate-openapi-clients/templates/go/model_simple.mustache
+++ b/actions/generate-openapi-clients/templates/go/model_simple.mustache
@@ -226,7 +226,7 @@ func (o *{{classname}}) Get{{name}}Ok() ({{^isArray}}{{^isFreeFormObject}}*{{/is
 
 // Has{{name}} returns a boolean if a field has been set.
 func (o *{{classname}}) Has{{name}}() bool {
-	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+	if o != nil && {{^isNullable}}!IsNil(o.{{name}}){{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}!IsNil(o.{{name}}){{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
 		return true
 	}
 


### PR DESCRIPTION
The model template seems to have a bug where arrays and maps generate a wrong condition to check if the property is set:
```
// HasLabels returns a boolean if a field has been set.
func (o *PostHMClustersRequest) HasLabels() bool {
	if o != nil && IsNil(o.Labels) {
		return true
	}
```

That seems to be wrong, because o.Labels is not set if nil, but it returns true.