### PR TITLE
fix(publish-techdocs): use working directory for artifact upload path

### DIFF
--- a/.github/workflows/publish-techdocs.yaml
+++ b/.github/workflows/publish-techdocs.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: site
-          path: site
+          path: ${{ inputs.default-working-directory }}/site
 
       - name: Publish docs site
         if: inputs.publish


### PR DESCRIPTION
The artifact upload path was hardcoded to `site`, but `techdocs-cli generate` outputs to `site/` inside `inputs.default-working-directory`. When that input differs from `.`, the upload fails because `site/` doesn't exist at the repository root.