### PR TITLE
chore(multiple): update deprecation deadline to March 31, 2026

### DIFF
--- a/actions/build-push-to-dockerhub/README.md
+++ b/actions/build-push-to-dockerhub/README.md
@@ -1,8 +1,10 @@
 # build-push-to-dockerhub
 
 > [!WARNING]
-> This GitHub Action is deprecated and will be removed from main after Jan 31, 2026.
+> This GitHub Action is deprecated and will be removed from main after March 31, 2026.
 > Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating).
+>
+> **Note**: The original deprecation date of January 31, 2026 was incorrect. We apologize for any confusion.
 
 > [!NOTE]
 > If you are at Grafana Labs:

--- a/actions/build-push-to-dockerhub/action.yaml
+++ b/actions/build-push-to-dockerhub/action.yaml
@@ -73,7 +73,7 @@ runs:
     - name: Deprecation Warning
       shell: sh
       run: |
-        echo "::warning::This GitHub Action is deprecated and will be removed from main after Jan 31, 2026. Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating)."
+        echo "::warning::This GitHub Action is deprecated and will be removed from main after March 31, 2026. Please migrate to docker-build-push-image: https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating"
 
     # See this conversation for more context as to why we don't want to allow pushes on pull requests
     # https://github.com/grafana/shared-workflows/pull/143#discussion_r1628314620

--- a/actions/push-to-gar-docker/README.md
+++ b/actions/push-to-gar-docker/README.md
@@ -1,8 +1,10 @@
 # push-to-gar-docker
 
 > [!WARNING]
-> This GitHub Action is deprecated and will be removed from main after Jan 31, 2026.
+> This GitHub Action is deprecated and will be removed from main after March 31, 2026.
 > Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating).
+>
+> **Note**: The original deprecation date of January 31, 2026 was incorrect. We apologize for any confusion.
 
 > [!NOTE]
 > If you are at Grafana Labs:

--- a/actions/push-to-gar-docker/action.yaml
+++ b/actions/push-to-gar-docker/action.yaml
@@ -132,7 +132,7 @@ runs:
     - name: Deprecation Warning
       shell: sh
       run: |
-        echo "::warning::This GitHub Action is deprecated and will be removed from main after Jan 31, 2026. Please migrate to [docker-build-push-image](https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating)."
+        echo "::warning::This GitHub Action is deprecated and will be removed from main after March 31, 2026. Please migrate to docker-build-push-image: https://github.com/grafana/shared-workflows/tree/main/actions/docker-build-push-image#migrating"
 
     - name: Checkout
       env:


### PR DESCRIPTION
Updates the deprecation deadline for `push-to-gar-docker` and `build-push-to-dockerhub` actions from January 31, 2026 to March 31, 2026.

Changes:
- Updated deprecation date in README.md files with apology note for the confusion
- Updated runtime warnings in action.yaml files
- Original January 31 date was incorrect and has been corrected

Part of https://github.com/grafana/deployment_tools/issues/433882