### PR TITLE
chore(docker-build-push-multiarch): update to docker-build-push-image v0.3.1

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -336,7 +336,7 @@ jobs:
           persist-credentials: false
       - name: Build Docker Image
         id: build
-        uses: grafana/shared-workflows/actions/docker-build-push-image@ef27c620a88acc9f3007f30be5e9407324e8975b # docker-build-push-image/v0.3.0
+        uses: grafana/shared-workflows/actions/docker-build-push-image@438c8d6321147607b3f6f0e922508e78e746af9b # docker-build-push-image/v0.3.1
         with:
           # from inputs
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Updates `docker-build-push-multiarch` workflow to use the latest docker-build-push-image action (v0.3.1).