### PR TITLE
feat(docker-import-digests-push-manifest): add manifest summaries

### DIFF
--- a/actions/docker-import-digests-push-manifest/action.yaml
+++ b/actions/docker-import-digests-push-manifest/action.yaml
@@ -12,6 +12,10 @@ inputs:
       CSV of Docker images to push. These images should not include tags.
       Ex: us-docker.pkg.dev/grafanalabs-dev/gar-registry/image-name,docker.io/grafana/dockerhub-image
     required: true
+  generate-summary:
+    description: |
+      Generates both a markdown summary and outputs the env variable OCI_MANIFEST_OUTPUT_JSON.
+    default: "false"
   push:
     description: |
       Whether to push the manifest to the configured registries.
@@ -20,6 +24,13 @@ inputs:
     description: |
       List of Docker tags to be pushed.
     required: true
+outputs:
+  image-digests:
+    description: CSV list of image digests.
+    value: ${{ steps.summary.outputs.image-digests }}
+  oci-manifest-output-json:
+    description: JSON array of manifests with tag, indexDigest, and per-platform digest information.
+    value: ${{ steps.summary.outputs.oci-manifest-output-json }}
 
 runs:
   using: composite
@@ -154,3 +165,95 @@ runs:
           echo "Inspecting $tag"
           docker buildx imagetools inspect "$tag"
         done
+
+    - name: Set up Go
+      if: ${{ inputs.push == 'true' && inputs.generate-summary == 'true' }}
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
+      with:
+        go-version: "1.25"
+        cache: true
+        cache-dependency-path: _shared-workflows-docker-import-digests-push-manifest/actions/docker-import-digests-push-manifest/go.sum
+
+    - name: Generate manifest summary
+      id: summary
+      if: ${{ inputs.push == 'true' && inputs.generate-summary == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        cd _shared-workflows-docker-import-digests-push-manifest/actions/docker-import-digests-push-manifest
+
+        mapfile -t TAGS < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+
+        # Run your Go tool once
+        OCI_MANIFEST_OUTPUT_JSON="$(
+          go run . "${TAGS[@]}"
+        )"
+        # Persist for future steps (multiline-safe)
+        {
+          echo "OCI_MANIFEST_OUTPUT_JSON<<EOF"
+          echo "$OCI_MANIFEST_OUTPUT_JSON"
+          echo "EOF"
+        } >> "$GITHUB_ENV"
+        echo $OCI_MANIFEST_OUTPUT_JSON
+
+        echo "## Manifest summary" >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+        echo "This job produced the following OCI image manifests and attestations." >> "$GITHUB_STEP_SUMMARY"
+        echo "" >> "$GITHUB_STEP_SUMMARY"
+
+        # Per-tag section
+        jq -r '
+          map(
+            "### `" + .tag + "`\n" +
+            "**Index digest:** `" + .indexDigest + "`\n\n" +
+
+            (
+              .manifests
+              | map(select(.kind == "image"))
+              | if length > 0 then
+                  "| Platform | Digest |\n|---|---|\n" +
+                  (map("| `" + .platform + "` | `" + .digest + "` |") | join("\n")) +
+                  "\n\n"
+                else
+                  "_No image manifests_\n\n"
+                end
+            ) +
+
+            (
+              .manifests
+              | map(select(.kind == "attestation"))
+              | if length > 0 then
+                  "<details><summary>Attestations</summary>\n\n" +
+                  "| Digest | Refers to |\n|---|---|\n" +
+                  (map("| `" + .digest + "` | `" + .refersTo + "` |") | join("\n")) +
+                  "\n\n</details>\n"
+                else
+                  ""
+                end
+            ) +
+            "\n---\n\n"
+          )
+          | join("")
+        ' <<< "$OCI_MANIFEST_OUTPUT_JSON" >> "$GITHUB_STEP_SUMMARY"
+
+        TAG_DIGESTS="$(
+          jq -r '.[] | "\(.tag)@\(.indexDigest)"' <<< "$OCI_MANIFEST_OUTPUT_JSON"
+        )"
+
+        # Print for visibility (optional)
+        echo "Published image digests:"
+        echo "$TAG_DIGESTS"
+
+        # Export as multiline step output
+        {
+          echo "image-digests<<EOF"
+          echo "$TAG_DIGESTS"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "oci-manifest-output-json<<EOF"
+          echo "$OCI_MANIFEST_OUTPUT_JSON"
+          echo "EOF"
+        } >> "$GITHUB_OUTPUT"

--- a/actions/docker-import-digests-push-manifest/go.mod
+++ b/actions/docker-import-digests-push-manifest/go.mod
@@ -1,0 +1,3 @@
+module github.com/grafana/shared-workflows/actions/docker-import-digests-push-manifest/oci-output
+
+go 1.25

--- a/actions/docker-import-digests-push-manifest/go.sum
+++ b/actions/docker-import-digests-push-manifest/go.sum
@@ -1,0 +1,8 @@
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=

--- a/actions/docker-import-digests-push-manifest/internal/parser/parser.go
+++ b/actions/docker-import-digests-push-manifest/internal/parser/parser.go
@@ -1,0 +1,104 @@
+package parser
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+)
+
+type Manifest struct {
+	Name        string            `json:"name,omitempty"`
+	MediaType   string            `json:"mediaType,omitempty"`
+	Digest      string            `json:"digest"`
+	Platform    string            `json:"platform,omitempty"`
+	Kind        string            `json:"kind,omitempty"`     // image | attestation
+	RefersTo    string            `json:"refersTo,omitempty"` // digest of image
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+type Report struct {
+	Tag         string     `json:"tag,omitempty"`
+	IndexDigest string     `json:"indexDigest,omitempty"`
+	Manifests   []Manifest `json:"manifests"`
+}
+
+func extractDigestFromName(name string) string {
+	if i := strings.LastIndex(name, "@sha256:"); i != -1 {
+		return name[i+1:]
+	}
+	return ""
+}
+
+func ParseInspectOutput(input []byte) Report {
+	scanner := bufio.NewScanner(bytes.NewReader(input))
+
+	var out Report
+	var current Manifest
+	var inManifests bool
+	var inAnnotations bool
+
+	flush := func() {
+		if current.Digest == "" {
+			current = Manifest{}
+			return
+		}
+
+		if current.Platform == "unknown/unknown" {
+			current.Platform = ""
+			current.Kind = "attestation"
+		} else {
+			current.Kind = "image"
+		}
+
+		if current.Kind == "attestation" && current.Annotations != nil {
+			if d, ok := current.Annotations["vnd.docker.reference.digest"]; ok {
+				current.RefersTo = d
+			}
+		}
+
+		out.Manifests = append(out.Manifests, current)
+		current = Manifest{}
+		inAnnotations = false
+	}
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		switch {
+		case strings.HasPrefix(line, "Digest:") && !inManifests && out.IndexDigest == "":
+			out.IndexDigest = strings.TrimSpace(strings.TrimPrefix(line, "Digest:"))
+
+		case strings.HasPrefix(line, "Manifests"):
+			inManifests = true
+
+		case strings.HasPrefix(line, "Name:") && inManifests:
+			flush()
+			current = Manifest{}
+			current.Name = strings.TrimSpace(strings.TrimPrefix(line, "Name:"))
+			current.Digest = extractDigestFromName(current.Name)
+
+		case strings.HasPrefix(line, "MediaType:") && inManifests:
+			current.MediaType = strings.TrimSpace(strings.TrimPrefix(line, "MediaType:"))
+
+		case strings.HasPrefix(line, "Platform:") && inManifests:
+			current.Platform = strings.TrimSpace(strings.TrimPrefix(line, "Platform:"))
+
+		case strings.HasPrefix(line, "Annotations:") && inManifests:
+			inAnnotations = true
+			current.Annotations = map[string]string{}
+
+		case inAnnotations && strings.Contains(line, ":"):
+			parts := strings.SplitN(line, ":", 2)
+			key := strings.TrimSpace(parts[0])
+			val := strings.TrimSpace(parts[1])
+			current.Annotations[key] = val
+		}
+	}
+
+	flush()
+
+	if out.Manifests == nil {
+		out.Manifests = []Manifest{}
+	}
+	return out
+}

--- a/actions/docker-import-digests-push-manifest/internal/parser/parser_test.go
+++ b/actions/docker-import-digests-push-manifest/internal/parser/parser_test.go
@@ -1,0 +1,73 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseInspectOutput_AllFixtures(t *testing.T) {
+	fixturesDir := "../../test-data"
+
+	testFiles := []string{
+		filepath.Join(fixturesDir, "gar-manifest.txt"),
+		filepath.Join(fixturesDir, "dockerhub-manifest.txt"),
+	}
+
+	for _, path := range testFiles {
+		name := filepath.Base(path)
+
+		t.Run(name, func(t *testing.T) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("failed to read fixture %s: %v", path, err)
+			}
+
+			report := ParseInspectOutput(data)
+
+			// --- Basic invariants (should hold for all inspect outputs) ---
+
+			if report.IndexDigest == "" {
+				t.Fatalf("indexDigest is empty")
+			}
+
+			if report.Manifests == nil {
+				t.Fatalf("manifests slice is nil")
+			}
+
+			// --- Validate manifests ---
+			imageDigests := map[string]bool{}
+			attestationRefs := map[string]bool{}
+
+			for _, m := range report.Manifests {
+				if m.Digest == "" {
+					t.Fatalf("manifest missing digest: %+v", m)
+				}
+
+				switch m.Kind {
+				case "image":
+					if m.Platform == "" {
+						t.Fatalf("image manifest missing platform: %+v", m)
+					}
+					imageDigests[m.Digest] = true
+
+				case "attestation":
+					if m.RefersTo == "" {
+						t.Fatalf("attestation missing refersTo: %+v", m)
+					}
+					attestationRefs[m.RefersTo] = true
+
+				default:
+					t.Fatalf("unexpected manifest kind %q", m.Kind)
+				}
+			}
+
+			// --- Attestations must refer to real images ---
+			for ref := range attestationRefs {
+				if !imageDigests[ref] {
+					t.Fatalf("attestation refers to unknown image digest: %s", ref)
+				}
+			}
+		})
+	}
+}

--- a/actions/docker-import-digests-push-manifest/oci-output.go
+++ b/actions/docker-import-digests-push-manifest/oci-output.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/grafana/shared-workflows/actions/docker-import-digests-push-manifest/oci-output/internal/parser"
+)
+
+func runInspect(ctx context.Context, tag string) ([]byte, error) {
+	cctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(cctx, "docker", "buildx", "imagetools", "inspect", tag)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("inspect failed for %s: %w\n%s", tag, err, string(out))
+	}
+	return out, nil
+}
+
+func main() {
+	var (
+		fromFile = flag.String("from-file", "", "read imagetools output from file")
+		stdin    = flag.Bool("stdin", false, "read imagetools output from stdin")
+	)
+	flag.Parse()
+
+	ctx := context.Background()
+
+	var reports []parser.Report
+
+	switch {
+	case *fromFile != "":
+		data, err := os.ReadFile(*fromFile)
+		if err != nil {
+			panic(err)
+		}
+		reports = append(reports, parser.ParseInspectOutput(data))
+
+	case *stdin:
+		data, err := os.ReadFile(os.Stdin.Name())
+		if err != nil {
+			panic(err)
+		}
+		reports = append(reports, parser.ParseInspectOutput(data))
+
+	default:
+		tags := flag.Args()
+		if len(tags) == 0 {
+			fmt.Fprintln(os.Stderr, "usage: manifest-report [--from-file file] [--stdin] <tag...>")
+			os.Exit(2)
+		}
+		for _, tag := range tags {
+			raw, err := runInspect(ctx, tag)
+			if err != nil {
+				panic(err)
+			}
+			r := parser.ParseInspectOutput(raw)
+			r.Tag = tag
+			reports = append(reports, r)
+		}
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(reports)
+}

--- a/actions/docker-import-digests-push-manifest/test-data/dockerhub-manifest.txt
+++ b/actions/docker-import-digests-push-manifest/test-data/dockerhub-manifest.txt
@@ -1,0 +1,26 @@
+Name:      docker.io/grafana/cicd-test:rickytest-manifest-outputs
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:eec7b9d9edcc920bafac273b7feee1ea53292a34a44c413fb8b91e2ed646a904
+
+Manifests:
+  Name:        docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:ce31c6dfb3a05558a79966fdd2a3e20371ec37101747e3f04a8f2604bfa1f4fc
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/amd64
+
+  Name:        docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:dcaac863923cbb8ca6e885b7f987d53f4c1b85ffa4c87f7374bcc714e9910c54
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:ce31c6dfb3a05558a79966fdd2a3e20371ec37101747e3f04a8f2604bfa1f4fc
+    vnd.docker.reference.type:   attestation-manifest
+
+  Name:        docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:1592db1fa12a206f24527658cf37f8b9463f9ba7a5e7588061eb4503cfdcf4b6
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/arm64
+
+  Name:        docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:099c17feae0128ef83ee3662bcde0a7cf24239f2af3927d384d929dccfd9ffe8
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:1592db1fa12a206f24527658cf37f8b9463f9ba7a5e7588061eb4503cfdcf4b6
+    vnd.docker.reference.type:   attestation-manifest

--- a/actions/docker-import-digests-push-manifest/test-data/gar-manifest.txt
+++ b/actions/docker-import-digests-push-manifest/test-data/gar-manifest.txt
@@ -1,0 +1,26 @@
+Name:      us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs
+MediaType: application/vnd.oci.image.index.v1+json
+Digest:    sha256:eec7b9d9edcc920bafac273b7feee1ea53292a34a44c413fb8b91e2ed646a904
+
+Manifests:
+  Name:        us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:ce31c6dfb3a05558a79966fdd2a3e20371ec37101747e3f04a8f2604bfa1f4fc
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/amd64
+
+  Name:        us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:dcaac863923cbb8ca6e885b7f987d53f4c1b85ffa4c87f7374bcc714e9910c54
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:ce31c6dfb3a05558a79966fdd2a3e20371ec37101747e3f04a8f2604bfa1f4fc
+    vnd.docker.reference.type:   attestation-manifest
+
+  Name:        us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:1592db1fa12a206f24527658cf37f8b9463f9ba7a5e7588061eb4503cfdcf4b6
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    linux/arm64
+
+  Name:        us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:099c17feae0128ef83ee3662bcde0a7cf24239f2af3927d384d929dccfd9ffe8
+  MediaType:   application/vnd.oci.image.manifest.v1+json
+  Platform:    unknown/unknown
+  Annotations:
+    vnd.docker.reference.digest: sha256:1592db1fa12a206f24527658cf37f8b9463f9ba7a5e7588061eb4503cfdcf4b6
+    vnd.docker.reference.type:   attestation-manifest

--- a/actions/docker-import-digests-push-manifest/test-data/oci-output.json
+++ b/actions/docker-import-digests-push-manifest/test-data/oci-output.json
@@ -1,0 +1,86 @@
+[
+  {
+    "tag": "us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs",
+    "indexDigest": "sha256:c3ff43832a55beab44333fae1647717fc2cb0be8096ac3c6ad855bb1ee880b90",
+    "manifests": [
+      {
+        "name": "us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "platform": "linux/amd64",
+        "kind": "image"
+      },
+      {
+        "name": "us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:b12caf961a9446e8eb4d85641f0b3e3935d4e17297b95c1e30122513eca22abd",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:b12caf961a9446e8eb4d85641f0b3e3935d4e17297b95c1e30122513eca22abd",
+        "kind": "attestation",
+        "refersTo": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "annotations": {
+          "vnd.docker.reference.digest": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+          "vnd.docker.reference.type": "attestation-manifest"
+        }
+      },
+      {
+        "name": "us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "platform": "linux/arm64",
+        "kind": "image"
+      },
+      {
+        "name": "us-docker.pkg.dev/grafanalabs-dev/docker-cicd-test-dev/cicd-test:rickytest-manifest-outputs@sha256:927e3f82cc9aa3fdc0f7827d401acac3ff52105087d9b09cbdf5c468cb2c2f73",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:927e3f82cc9aa3fdc0f7827d401acac3ff52105087d9b09cbdf5c468cb2c2f73",
+        "kind": "attestation",
+        "refersTo": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "annotations": {
+          "vnd.docker.reference.digest": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+          "vnd.docker.reference.type": "attestation-manifest"
+        }
+      }
+    ]
+  },
+  {
+    "tag": "docker.io/grafana/cicd-test:rickytest-manifest-outputs",
+    "indexDigest": "sha256:c3ff43832a55beab44333fae1647717fc2cb0be8096ac3c6ad855bb1ee880b90",
+    "manifests": [
+      {
+        "name": "docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "platform": "linux/amd64",
+        "kind": "image"
+      },
+      {
+        "name": "docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:b12caf961a9446e8eb4d85641f0b3e3935d4e17297b95c1e30122513eca22abd",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:b12caf961a9446e8eb4d85641f0b3e3935d4e17297b95c1e30122513eca22abd",
+        "kind": "attestation",
+        "refersTo": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+        "annotations": {
+          "vnd.docker.reference.digest": "sha256:8eb8cfe33d2f104d99579505fff909bd4e84eff7bc5ca809c441bd8acd48ffbc",
+          "vnd.docker.reference.type": "attestation-manifest"
+        }
+      },
+      {
+        "name": "docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "platform": "linux/arm64",
+        "kind": "image"
+      },
+      {
+        "name": "docker.io/grafana/cicd-test:rickytest-manifest-outputs@sha256:927e3f82cc9aa3fdc0f7827d401acac3ff52105087d9b09cbdf5c468cb2c2f73",
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "digest": "sha256:927e3f82cc9aa3fdc0f7827d401acac3ff52105087d9b09cbdf5c468cb2c2f73",
+        "kind": "attestation",
+        "refersTo": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+        "annotations": {
+          "vnd.docker.reference.digest": "sha256:e09f16d819675ede0aac899700e8749eb3f0e66efd7b55619407b6372ba6cc90",
+          "vnd.docker.reference.type": "attestation-manifest"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
This pull request introduces a new Go-based tool and supporting workflow enhancements to generate and expose detailed OCI image manifest summaries during multi-architecture Docker image builds. It adds a manifest inspection utility, updates the related GitHub Actions workflow and documentation, and exposes new outputs for downstream jobs and users.

## Summary

Part of #1596.

After a successful push, `docker-import-digests-push-manifest` now has the ability to inspect each manifest and surface the results so callers can easily reference pushed digests without parsing noisy `docker buildx imagetools inspect` output.

- Adds `generate-summary` input (default `false`) — runs a Go tool to inspect pushed manifests, writes a formatted job summary, and sets `OCI_MANIFEST_OUTPUT_JSON` for downstream steps
- Adds `image-digests` step output with `tag@sha256:...` pairs (one per line)
- Guards both new steps on `push == 'true'` so dry runs don't fail trying to inspect images that don't exist yet

## Test plan

- [x] Verify a push=true run produces a job summary with index digest + per-platform table
- [x] Verify `image-digests` output is available in calling workflow
- [x] Verify a push=false run skips both new steps cleanly
- [x] Verify `OCI_MANIFEST_OUTPUT_JSON` is set for steps after the action


## Testing Notes

- With `generate-summary=true` and `push=true`: https://github.com/grafana/cicd-test/actions/runs/22362308540
- With `generate-summary=true` and `push=false`: https://github.com/grafana/cicd-test/actions/runs/22362308523
- With `generate-summary=false` and `push=true`: https://github.com/grafana/cicd-test/actions/runs/22362487903

Generating the report has been observed to add between 4 and 8 seconds of runtime to the action.