### PR TITLE
feat(docker-build-push-multiarch): use didpm v0.2.0, expose manifest outputs

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.md
+++ b/.github/workflows/docker-build-push-multiarch.md
@@ -81,16 +81,17 @@ jobs:
 
 ## Outputs
 
-| Name            | Type   | Description                                                                                                        |
-| --------------- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| `annotations`   | String | Generated annotations (from docker/metadata-action)                                                                |
-| `digest`        | String | Image digest (from docker/build-push-action)                                                                       |
-| `imageid`       | String | Image ID (from docker/build-push-action)                                                                           |
-| `images`        | String | Comma separated list of the images that were built                                                                 |
-| `json`          | String | JSON output of tags and labels (from docker/metadata-action)                                                       |
-| `labels`        | String | Generated Docker labels (from docker/metadata-action)                                                              |
-| `metadata`      | String | Build result metadata (from docker/build-push-action)                                                              |
-| `runner_arches` | String | The list of OS used to build images (for mapping to self hosted runners)                                           |
-| `image-digests` | String | Newline-separated list of image digests in the format `<image>:<tag>@<digest>` (requires `generate-summary: true`) |
-| `tags`          | String | Generated Docker tags (from docker/metadata-action)                                                                |
-| `version`       | String | Generated Docker image version (from docker/metadata-action)                                                       |
+| Name                       | Type   | Description                                                                                                            |
+| -------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `annotations`              | String | Generated annotations (from docker/metadata-action)                                                                    |
+| `digest`                   | String | Image digest (from docker/build-push-action)                                                                           |
+| `imageid`                  | String | Image ID (from docker/build-push-action)                                                                               |
+| `images`                   | String | Comma separated list of the images that were built                                                                     |
+| `json`                     | String | JSON output of tags and labels (from docker/metadata-action)                                                           |
+| `labels`                   | String | Generated Docker labels (from docker/metadata-action)                                                                  |
+| `metadata`                 | String | Build result metadata (from docker/build-push-action)                                                                  |
+| `runner_arches`            | String | The list of OS used to build images (for mapping to self hosted runners)                                               |
+| `image-digests`            | String | Newline-separated list of image digests in the format `<image>:<tag>@<digest>` (requires `generate-summary: true`)     |
+| `oci-manifest-output-json` | String | JSON array of manifests with tag, indexDigest, and per-platform digest information (requires `generate-summary: true`) |
+| `tags`                     | String | Generated Docker tags (from docker/metadata-action)                                                                    |
+| `version`                  | String | Generated Docker image version (from docker/metadata-action)                                                           |

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -220,6 +220,9 @@ on:
       image-digests:
         description: "Newline-separated list of image digests in the format <image>:<tag>@<digest> (from docker-import-digests-push-manifest)"
         value: ${{ jobs.merge-digest.outputs.image-digests }}
+      oci-manifest-output-json:
+        description: "JSON array of manifests with tag, indexDigest, and per-platform digest information (from docker-import-digests-push-manifest)"
+        value: ${{ jobs.merge-digest.outputs.oci-manifest-output-json }}
 
 env:
   ARCH_TO_PLATFORM_MAP: '{"arm64": "linux/arm64", "x64": "linux/amd64"}'
@@ -390,6 +393,7 @@ jobs:
       id-token: write
     outputs:
       image-digests: ${{ steps.merge.outputs.image-digests }}
+      oci-manifest-output-json: ${{ steps.merge.outputs.oci-manifest-output-json }}
     steps:
       - name: Download Multi-Arch Digests, Construct and Upload Manifest
         id: merge


### PR DESCRIPTION
## Summary

- Bumps `docker-import-digests-push-manifest` to v0.2.0
- Adds `generate-summary` input (default: `false`) to opt into manifest summary reports and the `OCI_MANIFEST_OUTPUT_JSON` env variable
- Wires the new `image-digests` and `oci-manifest-output-json` outputs from the `merge-digest` job through to the workflow outputs
- Updates README with new inputs and outputs

Closes #1596

## Test

Validated with a [successful run in grafana/cicd-test](https://github.com/grafana/cicd-test/actions/runs/22421556982) — all jobs green including `echo-outputs` which exercises both the `image-digests` and `oci-manifest-output-json` outputs.