### PR TITLE
fix: make zizmor skip ANSI color escapes

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -434,6 +434,7 @@ jobs:
         id: zizmor-plain
         shell: bash
         env:
+          NO_COLOR: 1
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         run: |


### PR DESCRIPTION
This PR fixes https://github.com/grafana/deployment_tools/issues/540838 for the `reusable-zizmor` workflow.