### PR TITLE
refactor(zizmor): remove PR comments, rely on Code Scanning annotations

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -6,9 +6,9 @@ whether there is potential for untrusted code to be injected via a template. See
 a full list of checks in [the documentation][zizmor-checks].
 
 This workflow will run zizmor and upload results to GitHub's code scanning
-service (requires an Advanced Security subscription for private repositories).
-Findings are surfaced as inline annotations on pull requests via GitHub's Code
-Scanning integration.
+service. Findings are surfaced as inline annotations on pull requests via
+GitHub's Code Scanning integration. For private repositories without Advanced
+Security, the workflow falls back to posting a PR comment with the results.
 
 [reusable workflow]: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 [zizmor]: https://woodruffw.github.io/zizmor/
@@ -44,9 +44,12 @@ jobs:
       # Zizmor's default config behaviour will be used.
       id-token: write
 
+      # fallback: comment on PR when code-scanning upload is unavailable
+      # (private repos without Advanced Security)
+      pull-requests: write
       # required to upload the results to GitHub's code scanning service. This
       # doesn't work if the repo doesn't have Advanced Security enabled. In that
-      # case we'll skip the upload.
+      # case the workflow falls back to posting a PR comment.
       security-events: write
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@<some sha>
@@ -83,9 +86,12 @@ jobs:
       # Zizmor's default config behaviour will be used.
       id-token: write
 
+      # fallback: comment on PR when code-scanning upload is unavailable
+      # (private repos without Advanced Security)
+      pull-requests: write
       # required to upload the results to GitHub's code scanning service. This
       # doesn't work if the repo doesn't have Advanced Security enabled. In that
-      # case we'll skip the upload.
+      # case the workflow falls back to posting a PR comment.
       security-events: write
 
     uses: grafana/shared-workflows/.github/workflows/reusable-zizmor.yml@<some sha>

--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -5,11 +5,10 @@ tool on a repo's GitHub Actions workflow files. This will report things such as
 whether there is potential for untrusted code to be injected via a template. See
 a full list of checks in [the documentation][zizmor-checks].
 
-This workflow will run zizmor, upload results to GitHub's code scanning service
-(requires an Advanced Security subscription for private repositories), and
-comment on the pull request with the results. The comment will be re-posted on
-each run - and previous comments hidden - so the most recent comment will always
-show the current results.
+This workflow will run zizmor and upload results to GitHub's code scanning
+service (requires an Advanced Security subscription for private repositories).
+Findings are surfaced as inline annotations on pull requests via GitHub's Code
+Scanning integration.
 
 [reusable workflow]: https://docs.github.com/en/actions/using-workflows/reusing-workflows
 [zizmor]: https://woodruffw.github.io/zizmor/
@@ -45,8 +44,6 @@ jobs:
       # Zizmor's default config behaviour will be used.
       id-token: write
 
-      # required to comment on pull requests with the results of the check
-      pull-requests: write
       # required to upload the results to GitHub's code scanning service. This
       # doesn't work if the repo doesn't have Advanced Security enabled. In that
       # case we'll skip the upload.
@@ -86,8 +83,6 @@ jobs:
       # Zizmor's default config behaviour will be used.
       id-token: write
 
-      # required to comment on pull requests with the results of the check
-      pull-requests: write
       # required to upload the results to GitHub's code scanning service. This
       # doesn't work if the repo doesn't have Advanced Security enabled. In that
       # case we'll skip the upload.
@@ -140,7 +135,7 @@ to introduce this workflow and fix all of the issues at once. There are a few
 ways to get started if this is the case:
 
 1. Set `fail-severity: never` to run the check without failing the build.
-   Results will still be posted to pull requests but they won't be blocking.
+   Results will still be visible via Code Scanning annotations but won't be blocking.
 2. Adopt an incremental approach to fixing issues. For example, start with
    `min-severity: high`. Once all high severity issues are resolved, lower the
    severity to `medium` and then onwards to `low`.

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -253,8 +253,6 @@ jobs:
       actions: read
       contents: read
 
-      # comment with the results
-      pull-requests: write
       # upload the results to code-scanning dashboard.
       security-events: write
 
@@ -262,7 +260,7 @@ jobs:
       MIN_SEVERITY: ${{ inputs.min-severity }}
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
       # renovate: datasource=pypi depName=zizmor
-      ZIZMOR_VERSION: 1.23.1
+      ZIZMOR_VERSION: 1.24.1
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
       DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.sha }}
@@ -438,11 +436,9 @@ jobs:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         run: |
-          set -o pipefail
-
-          echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
-          # don't fail the build if zizmor fails - we want to capture the output
-          # and the exit code
+          # Run zizmor again with plain output for human-readable logs.
+          # Don't fail the build here - we capture the exit code for the
+          # "Fail the build" step to evaluate against fail-severity.
           set +e
           uvx zizmor@"${ZIZMOR_VERSION}" \
             --format plain \
@@ -452,11 +448,9 @@ jobs:
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
             ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            | tee -a "${GITHUB_OUTPUT}"
+            .
           zizmor_exit_code=$?
           set -e
-          echo "EOF" >> "${GITHUB_OUTPUT}"
 
           # Error 1 is a failure of zizmor itself
           if [ "${zizmor_exit_code}" -eq 1 ]; then
@@ -471,29 +465,6 @@ jobs:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
         if: steps.setup-config.outputs.zizmor-config
         run: rm "${ZIZMOR_CONFIG_PATH}"
-
-      - name: Hide any previous comments
-        if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
-        id: hide-comments
-        uses: int128/hide-comment-action@42badf94b3efd95bf2138bd9c74da19203e83f40 # v1.55.0
-        with:
-          ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
-
-      - name: Comment with zizmor results
-        if: steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
-        uses: int128/comment-action@b85aa71d92f4460f5a61f8ac460a45caeb2df451 # v1.56.0
-        with:
-          post: |
-            :cry: zizmor failed with exit code ${{ steps.zizmor-plain.outputs.zizmor-exit-code }}.
-
-            <details>
-            <summary>Expand for full output</summary>
-
-            ```
-            ${{ steps.zizmor-plain.outputs.zizmor-results }}
-            ```
-            </details>
-            ${{ steps.hide-comments.outputs.ends-with }}
 
       - name: Fail the build
         if: inputs.fail-severity != 'never' && steps.zizmor-plain.outputs.zizmor-exit-code != 0

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -253,6 +253,9 @@ jobs:
       actions: read
       contents: read
 
+      # fallback: comment on PR when code-scanning upload is unavailable
+      # (private repos without Advanced Security)
+      pull-requests: write
       # upload the results to code-scanning dashboard.
       security-events: write
 
@@ -421,6 +424,7 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
+        id: upload-sarif
         uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         continue-on-error: true
         with:
@@ -436,9 +440,14 @@ jobs:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
         run: |
+          set -o pipefail
+
+          echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
           # Run zizmor again with plain output for human-readable logs.
           # Don't fail the build here - we capture the exit code for the
           # "Fail the build" step to evaluate against fail-severity.
+          # Output is also captured for the fallback PR comment when
+          # Code Scanning is unavailable.
           set +e
           uvx zizmor@"${ZIZMOR_VERSION}" \
             --format plain \
@@ -448,9 +457,11 @@ jobs:
             ${RUNNER_DEBUG:+"--verbose"} \
             ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
             ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            .
+            . \
+            | tee -a "${GITHUB_OUTPUT}"
           zizmor_exit_code=$?
           set -e
+          echo "EOF" >> "${GITHUB_OUTPUT}"
 
           # Error 1 is a failure of zizmor itself
           if [ "${zizmor_exit_code}" -eq 1 ]; then
@@ -465,6 +476,31 @@ jobs:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
         if: steps.setup-config.outputs.zizmor-config
         run: rm "${ZIZMOR_CONFIG_PATH}"
+
+      # Fallback: post a PR comment with findings when Code Scanning is
+      # unavailable (e.g. private repos without Advanced Security).
+      - name: Hide any previous comments
+        if: ${{ !cancelled() && steps.upload-sarif.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
+        id: hide-comments
+        uses: int128/hide-comment-action@42badf94b3efd95bf2138bd9c74da19203e83f40 # v1.55.0
+        with:
+          ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
+
+      - name: Comment with zizmor results
+        if: steps.upload-sarif.outcome == 'failure' && steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
+        uses: int128/comment-action@b85aa71d92f4460f5a61f8ac460a45caeb2df451 # v1.56.0
+        with:
+          post: |
+            :cry: zizmor failed with exit code ${{ steps.zizmor-plain.outputs.zizmor-exit-code }}.
+
+            <details>
+            <summary>Expand for full output</summary>
+
+            ```
+            ${{ steps.zizmor-plain.outputs.zizmor-results }}
+            ```
+            </details>
+            ${{ steps.hide-comments.outputs.ends-with }}
 
       - name: Fail the build
         if: inputs.fail-severity != 'never' && steps.zizmor-plain.outputs.zizmor-exit-code != 0


### PR DESCRIPTION
## Summary

- Make the PR comment a **fallback** for private repos without Advanced Security, instead of always posting it
- Update zizmor from 1.23.1 to 1.24.1
- Update documentation to reflect the changes

## Motivation

When zizmor finds issues, developers on **public repos** (which have GitHub Advanced Security) currently see duplicate feedback:
1. A PR comment from `github-actions` bot with plain-text results
2. Inline Code Scanning annotations from `github-advanced-security[bot]` (via SARIF upload)

The Code Scanning annotations are strictly better — they show findings inline at the exact location in the code, support dismissals, and have alert tracking. The PR comment duplicates this information in a less useful format.

However, **private repos without Advanced Security** can't use Code Scanning (the SARIF upload silently fails). For these repos, the PR comment is the only way to surface findings.

## Changes

### `reusable-zizmor.yml`
- **Added `id: upload-sarif`** to the Code Scanning upload step to track its outcome
- **Conditioned PR comment steps** on `steps.upload-sarif.outcome == 'failure'` — the comment is only posted when Code Scanning is unavailable (e.g. private repos without Advanced Security)
- **Updated** zizmor from 1.23.1 to 1.24.1:
  - v1.24.0: SARIF output now uses codeflows instead of related locations, improving rendering on GitHub Advanced Security
  - v1.24.1: bugfix for ref-version-mismatch false positives
  - Many other bug fixes and improvements

### `reusable-zizmor.md`
- Updated description to explain the Code Scanning + fallback behavior
- Updated permission comments in examples to explain `pull-requests: write` is for the fallback
- Updated "Getting started" section wording

## Behavior matrix

| Repo type | Code Scanning | PR comment | Failing checks |
|-----------|--------------|------------|----------------|
| Public (has GHAS) | Inline annotations | **No** (SARIF upload succeeded) | Workflow job + Code Scanning check |
| Private without GHAS | No (upload fails) | **Yes** (fallback) | Workflow job only |