### PR TITLE
fix(reusable-zizmor): customize runner for bench step

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -541,7 +541,7 @@ jobs:
     needs: [analysis, job-workflow-ref]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.analysis.result == 'success' || needs.analysis.result == 'failure') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
In a previous commit there was a comment hinting at the used image not supporting arm runners. Judging by the image build process there, amd64 AND arm64 should be supported, covering our setups.

Local testing on a Mac with Apple Silicon indicates that this assumption is correct.