### PR TITLE
fix(.release-please-manifest): add missing comma

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -29,6 +29,6 @@
     "actions/docker-import-digests-push-manifest": "0.2.1",
     "actions/socket-export-sbom": "0.1.0",
     "actions/component-change-detection": "1.0.0",
-    "actions/issues-update-project-status": "0.1.1"
+    "actions/issues-update-project-status": "0.1.1",
     "actions/go-flaky-tests": "0.1.0"
 }


### PR DESCRIPTION
Due to multiple releases, one comma went missing (wrong rebase) and there was no CI to check if the JSON is actually correct.

This PR adds the comma back. Will be another PR with a CI check to make sure the JSON is valid.