### PR TITLE
ci(release-please-manifest): add validation step

### DIFF
--- a/.github/workflows/lint-shared-workflows.yaml
+++ b/.github/workflows/lint-shared-workflows.yaml
@@ -136,3 +136,6 @@ jobs:
         with:
           schema: github-action.json
           jsons: ${{ steps.convert-action-yaml-to-json.outputs.converted-files }}
+
+      - name: Validate release-please-manifest.json
+        run: yq . .release-please-manifest.json > /dev/null && echo "Valid JSON"


### PR DESCRIPTION
Adds a small step to make sure that the `.release-please-manifest.json` is valid.