### PR TITLE
chore(README): add note about immutable releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A public-facing, centralized place to store reusable GitHub workflows and action
 used by Grafana Labs. See the `actions/` directory for the individual actions
 themselves.
 
+> **Note:** As of May 4th 2026, all action releases are immutable. Once a version tag is created, it will not be moved or overwritten.
+
 [scorecard]: https://scorecard.dev/viewer/?uri=github.com/grafana/shared-workflows
 [scorecard image]: https://api.scorecard.dev/projects/github.com/grafana/shared-workflows/badge
 


### PR DESCRIPTION
Part of: https://github.com/grafana/shared-workflows/issues/1917

Adds note about immutable releases. All releases starting from May 4th 2026 will now be immutable.