### PR TITLE
sync: align feat/zizmor-collection-ignore-326-v2 with fork (docs, tests, commit cleanup)

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -187,11 +187,11 @@ files can be ignored][zizmor-ignore-config].
 
 ## Skipping vendored workflow trees ([security-appsec#326](https://github.com/grafana/security-appsec/issues/326))
 
-Vendored trees can still contain `.github/workflows/`. Add **`.github/zizmor-collection-ignore`**: one **directory prefix** per line (lines like `ksonnet/vendor/**/*` work—the `/**` suffix is stripped). Comments (`#`) and blank lines are OK. Without this file, zizmor still scans `.`. Explicit targets, batching, and SARIF merging are handled in **`actions/zizmor-collection-paths`** (Python), not shell `find`/`jq`.
+Vendored trees can still contain `.github/workflows/`. Add **`.github/zizmor-collection-ignore`** at the repo root with one directory prefix per line. Lines like `ksonnet/vendor/**/*` work (a trailing `/**` is stripped). Do not use `..` or absolute paths. Comments (`#`) and blank lines are OK. Without this file, zizmor still scans `.`.
 
 ```text
 ksonnet/vendor
 terraform/modules/github.com/github-aws-runners
 ```
 
-[gitignore]: https://git-scm.com/docs/gitignore
+Explicit path collection, batching, and SARIF merging live in **`actions/zizmor-collection-paths`**. The reusable workflow always runs those helpers from the **OIDC-pinned `shared-workflows` checkout** (`_shared-workflows-zizmor`), not from the scanned repository.

--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -184,3 +184,14 @@ files can be ignored][zizmor-ignore-config].
 
 [zizmor-config]: https://woodruffw.github.io/zizmor/configuration/
 [zizmor-ignore-config]: https://woodruffw.github.io/zizmor/usage/#with-zizmoryml
+
+## Skipping vendored workflow trees ([security-appsec#326](https://github.com/grafana/security-appsec/issues/326))
+
+Vendored trees can still contain `.github/workflows/`. Add **`.github/zizmor-collection-ignore`**: one **directory prefix** per line (lines like `ksonnet/vendor/**/*` work—the `/**` suffix is stripped). Comments (`#`) and blank lines are OK. Without this file, zizmor still scans `.`. Explicit targets, batching, and SARIF merging are handled in **`actions/zizmor-collection-paths`** (Python), not shell `find`/`jq`.
+
+```text
+ksonnet/vendor
+terraform/modules/github.com/github-aws-runners
+```
+
+[gitignore]: https://git-scm.com/docs/gitignore

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -203,14 +203,10 @@ jobs:
 
             const AUDIENCE = 'zizmor-job-workflow-ref';
 
-            // Fork PRs (and some other contexts) have no OIDC token. Detect that
-            // up front and use fallback without throwing, so the step succeeds
-            // and the log stays clear.
+            // Fork PRs have no OIDC token, so we can't detect the workflow ref. Use main.
             const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
             if (!runtimeUrl) {
-              core.info(
-                "No OIDC token available (e.g. pull request from a fork). Using fallback: grafana/shared-workflows@main for default config."
-              );
+              core.info("No OIDC token (e.g. fork PR). Using grafana/shared-workflows@main for default config.");
               core.setOutput('owner', 'grafana');
               core.setOutput('repo', 'shared-workflows');
               core.setOutput('sha', 'main');
@@ -279,6 +275,46 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      # security-appsec#326: optional zizmor-collection-ignore (see reusable-zizmor.md).
+      - name: Zizmor helper present in workspace?
+        id: zizmor-remote
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f "${GITHUB_WORKSPACE}/actions/zizmor-collection-paths/run_zizmor.py" ]; then
+            echo "need_remote=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "need_remote=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Checkout shared-workflows (helper scripts only)
+        if: steps.zizmor-remote.outputs.need_remote == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ needs.job-workflow-ref.outputs.owner }}/${{ needs.job-workflow-ref.outputs.repo }}
+          ref: ${{ needs.job-workflow-ref.outputs.sha }}
+          path: _shared-workflows-zizmor
+          persist-credentials: false
+
+      - name: Zizmor paths + helper_root
+        id: zizmor-helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${GITHUB_WORKSPACE}/actions/zizmor-collection-paths"
+          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
+            ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
+          fi
+          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
+            echo "::error::zizmor helper missing (expected under workspace or _shared-workflows-zizmor)." >&2
+            exit 1
+          fi
+          echo "helper_root=${ROOT}" >> "${GITHUB_OUTPUT}"
+          python3 "${ROOT}/collection_paths.py" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --ignore-file "${GITHUB_WORKSPACE}/.github/zizmor-collection-ignore" \
+            --paths-out "${RUNNER_TEMP}/zizmor-explicit-inputs.txt"
 
       - name: Restore config from cache
         id: cache-config
@@ -407,22 +443,12 @@ jobs:
         env:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
-        shell: sh
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
+        shell: bash
         run: |
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format sarif \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            > results.sarif
-          exit_code=$?
-          # Only fail on exit code 1 (zizmor crash). 0 = no findings, 10-14 = findings by severity.
-          if [ "${exit_code}" -eq 1 ]; then exit 1; fi
-          exit 0
+          set -euo pipefail
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" sarif --batch-size 400 --out results.sarif
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -447,37 +473,11 @@ jobs:
           NO_COLOR: 1
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
         run: |
-          set -o pipefail
-
-          echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
-          # Run zizmor again with plain output for human-readable logs.
-          # Don't fail the build here - we capture the exit code for the
-          # "Fail the build" step to evaluate against fail-severity.
-          # Output is also captured for the fallback PR comment when
-          # Code Scanning is unavailable.
-          set +e
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format plain \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            | tee -a "${GITHUB_OUTPUT}"
-          zizmor_exit_code=$?
-          set -e
-          echo "EOF" >> "${GITHUB_OUTPUT}"
-
-          # Error 1 is a failure of zizmor itself
-          if [ "${zizmor_exit_code}" -eq 1 ]; then
-            echo "zizmor itself failed - check the above output. failing the workflow."
-            exit 1
-          fi
-
-          echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
+          set -euo pipefail
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" plain-github-output --batch-size 400
 
       - name: Remove zizmor config
         env:

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -276,20 +276,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # security-appsec#326: optional zizmor-collection-ignore (see reusable-zizmor.md).
-      - name: Zizmor helper present in workspace?
-        id: zizmor-remote
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -f "${GITHUB_WORKSPACE}/actions/zizmor-collection-paths/run_zizmor.py" ]; then
-            echo "need_remote=false" >> "${GITHUB_OUTPUT}"
-          else
-            echo "need_remote=true" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Checkout shared-workflows (helper scripts only)
-        if: steps.zizmor-remote.outputs.need_remote == 'true'
+      # .github/zizmor-collection-ignore (optional) — see reusable-zizmor.md
+      - name: Checkout shared-workflows (zizmor helper scripts)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ needs.job-workflow-ref.outputs.owner }}/${{ needs.job-workflow-ref.outputs.repo }}
@@ -302,12 +290,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ROOT="${GITHUB_WORKSPACE}/actions/zizmor-collection-paths"
+          ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
           if [ ! -f "${ROOT}/run_zizmor.py" ]; then
-            ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
-          fi
-          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
-            echo "::error::zizmor helper missing (expected under workspace or _shared-workflows-zizmor)." >&2
+            echo "::error::zizmor helper missing at ${ROOT} (pin reusable-zizmor.yml to a SHA that includes actions/zizmor-collection-paths)." >&2
             exit 1
           fi
           echo "helper_root=${ROOT}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/test-zizmor-collection-paths.yml
+++ b/.github/workflows/test-zizmor-collection-paths.yml
@@ -1,0 +1,47 @@
+name: Test zizmor-collection-paths action
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/zizmor-collection-paths/**
+      - .github/workflows/test-zizmor-collection-paths.yml
+      - .github/workflows/reusable-zizmor.yml
+
+  pull_request:
+    paths:
+      - actions/zizmor-collection-paths/**
+      - .github/workflows/test-zizmor-collection-paths.yml
+      - .github/workflows/reusable-zizmor.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Unit tests
+        run: |
+          cd actions/zizmor-collection-paths
+          python3 -m unittest discover -v

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ yarn-error.log*
 
 node_modules/
 
+__pycache__/
+*.py[cod]
+
 coverage/
 dist/
 

--- a/actions/zizmor-collection-paths/README.md
+++ b/actions/zizmor-collection-paths/README.md
@@ -1,0 +1,11 @@
+# zizmor-collection-paths
+
+Used by [`.github/workflows/reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml) when a repo has [`.github/zizmor-collection-ignore`](../../.github/workflows/reusable-zizmor.md#skipping-vendored-workflow-trees-security-appsec326).
+
+Collects workflow and composite-action paths under the checked-out repo root, skipping directory prefixes listed in the ignore file. Scripts run from the OIDC-pinned `shared-workflows` checkout (`_shared-workflows-zizmor`), not from the repo being scanned.
+
+## Tests
+
+```bash
+cd actions/zizmor-collection-paths && python3 -m unittest discover -v
+```

--- a/actions/zizmor-collection-paths/__init__.py
+++ b/actions/zizmor-collection-paths/__init__.py
@@ -1,0 +1,1 @@
+"""zizmor collection-path helper package."""

--- a/actions/zizmor-collection-paths/action.yml
+++ b/actions/zizmor-collection-paths/action.yml
@@ -1,0 +1,36 @@
+name: Zizmor collection paths
+description: >-
+  Reads optional .github/zizmor-collection-ignore (security-appsec#326). If the file is missing or
+  yields no prefixes, outputs use_explicit_paths=false and zizmor keeps scanning .; otherwise
+  writes an explicit path list for batch zizmor runs.
+
+inputs:
+  repo-root:
+    description: Checked-out repository root (same as zizmor scan root).
+    required: true
+  paths-out:
+    description: Absolute path to the newline-separated file zizmor will read.
+    required: true
+
+outputs:
+  use_explicit_paths:
+    description: "true when zizmor should scan explicit paths instead of `.`"
+    value: ${{ steps.run.outputs.use_explicit_paths }}
+  paths_list:
+    description: Absolute path to the explicit inputs file (empty when not used)
+    value: ${{ steps.run.outputs.paths_list }}
+
+runs:
+  using: composite
+  steps:
+    - id: run
+      shell: bash
+      env:
+        REPO_ROOT: ${{ inputs.repo-root }}
+        PATHS_OUT: ${{ inputs.paths-out }}
+      run: |
+        set -euo pipefail
+        python3 "${{ github.action_path }}/collection_paths.py" \
+          --repo-root "${REPO_ROOT}" \
+          --ignore-file "${REPO_ROOT}/.github/zizmor-collection-ignore" \
+          --paths-out "${PATHS_OUT}"

--- a/actions/zizmor-collection-paths/action.yml
+++ b/actions/zizmor-collection-paths/action.yml
@@ -1,8 +1,6 @@
 name: Zizmor collection paths
 description: >-
-  Reads optional .github/zizmor-collection-ignore (security-appsec#326). If the file is missing or
-  yields no prefixes, outputs use_explicit_paths=false and zizmor keeps scanning .; otherwise
-  writes an explicit path list for batch zizmor runs.
+  Reads optional .github/zizmor-collection-ignore and writes zizmor input paths for reusable-zizmor.
 
 inputs:
   repo-root:

--- a/actions/zizmor-collection-paths/collection_paths.py
+++ b/actions/zizmor-collection-paths/collection_paths.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# security-appsec#326: optional .github/zizmor-collection-ignore — directory prefixes to skip when collecting zizmor inputs.
+"""Collect zizmor input paths, honoring optional `.github/zizmor-collection-ignore`."""
 
 import argparse
 import os
@@ -7,17 +7,37 @@ import sys
 from pathlib import Path
 
 
+def _unsafe_prefix_reason(rel: str) -> str | None:
+    """Reject prefixes that escape the repository root."""
+    if not rel:
+        return "empty"
+    if rel.startswith(("/", "\\")):
+        return "absolute path"
+    norm = rel.replace("\\", "/")
+    parts = norm.split("/")
+    if ".." in parts:
+        return "parent segment"
+    if any(p == "" for p in parts):
+        return "empty path segment"
+    return None
+
+
 def normalize_prefix_line(line: str) -> str | None:
-    s = line.strip()
-    if not s or s.startswith("#"):
+    raw = line.strip()
+    if not raw or raw.startswith("#"):
         return None
-    s = s.removeprefix("/")
+    if raw.startswith(("/", "\\")):
+        return None
+    s = raw
     while True:
         old = s
         s = s.removesuffix("**").removesuffix("/*").rstrip("/")
         if s == old:
             break
     if "*" in s:
+        return None
+    s = s.replace("\\", "/")
+    if _unsafe_prefix_reason(s):
         return None
     return s or None
 
@@ -38,28 +58,42 @@ def excluded(path: Path, roots: list[Path]) -> bool:
     return any(path == r or r in path.parents for r in roots)
 
 
-def want_file(path: Path) -> bool:
-    if path.name in ("action.yml", "action.yaml", "dependabot.yml", "dependabot.yaml"):
+def want_file(path: Path, repo_root: Path) -> bool:
+    """True for repo-root workflows, root dependabot config, and composite action manifests."""
+    try:
+        rel = path.resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+    parts = rel.parts
+    if path.name in ("action.yml", "action.yaml"):
         return True
+    if path.name in ("dependabot.yml", "dependabot.yaml"):
+        return len(parts) == 2 and parts[0] == ".github"
     if path.suffix not in (".yml", ".yaml"):
         return False
-    return path.parent.name == "workflows" and path.parent.parent.name == ".github"
+    return len(parts) >= 3 and parts[0] == ".github" and parts[1] == "workflows"
 
 
 def collect_paths(repo_root: Path, prefixes: list[str], out: Path) -> int:
     repo_root = repo_root.resolve()
     out.parent.mkdir(parents=True, exist_ok=True)
-    skip = [(repo_root / p).resolve() for p in prefixes]
+    skip = []
+    for p in prefixes:
+        cand = (repo_root / p).resolve()
+        try:
+            cand.relative_to(repo_root)
+        except ValueError as e:
+            raise ValueError(f"ignore prefix {p!r} resolves outside repo root") from e
+        skip.append(cand)
     hits = []
 
     for dirpath, dirnames, filenames in os.walk(repo_root, topdown=True):
         here = Path(dirpath).resolve()
         pruned = [d for d in dirnames if not excluded((here / d).resolve(), skip)]
-        # os.walk only skips subtrees when dirnames is replaced in place (topdown=True).
         dirnames[:] = pruned
         for fn in filenames:
             f = (here / fn).resolve()
-            if excluded(f, skip) or not want_file(f):
+            if excluded(f, skip) or not want_file(f, repo_root):
                 continue
             hits.append("./" + str(f.relative_to(repo_root)).replace("\\", "/"))
 
@@ -92,7 +126,11 @@ def main() -> int:
             f.write("use_explicit_paths=false\npaths_list=\n")
         return 0
 
-    n = collect_paths(root, prefs, args.paths_out)
+    try:
+        n = collect_paths(root, prefs, args.paths_out)
+    except ValueError as e:
+        print(f"::error::{e}", file=sys.stderr)
+        return 1
     if n == 0:
         print(
             "::error::.github/zizmor-collection-ignore excluded every zizmor input; remove or relax a prefix.",

--- a/actions/zizmor-collection-paths/collection_paths.py
+++ b/actions/zizmor-collection-paths/collection_paths.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# security-appsec#326: optional .github/zizmor-collection-ignore — directory prefixes to skip when collecting zizmor inputs.
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def normalize_prefix_line(line: str) -> str | None:
+    s = line.strip()
+    if not s or s.startswith("#"):
+        return None
+    s = s.removeprefix("/")
+    while True:
+        old = s
+        s = s.removesuffix("**").removesuffix("/*").rstrip("/")
+        if s == old:
+            break
+    if "*" in s:
+        return None
+    return s or None
+
+
+def parse_prefixes_from_ignore(content: str) -> list[str]:
+    prefixes = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        p = normalize_prefix_line(line)
+        if p:
+            prefixes.append(p)
+    return prefixes
+
+
+def excluded(path: Path, roots: list[Path]) -> bool:
+    return any(path == r or r in path.parents for r in roots)
+
+
+def want_file(path: Path) -> bool:
+    if path.name in ("action.yml", "action.yaml", "dependabot.yml", "dependabot.yaml"):
+        return True
+    if path.suffix not in (".yml", ".yaml"):
+        return False
+    return path.parent.name == "workflows" and path.parent.parent.name == ".github"
+
+
+def collect_paths(repo_root: Path, prefixes: list[str], out: Path) -> int:
+    repo_root = repo_root.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    skip = [(repo_root / p).resolve() for p in prefixes]
+    hits = []
+
+    for dirpath, dirnames, filenames in os.walk(repo_root, topdown=True):
+        here = Path(dirpath).resolve()
+        pruned = [d for d in dirnames if not excluded((here / d).resolve(), skip)]
+        # os.walk only skips subtrees when dirnames is replaced in place (topdown=True).
+        dirnames[:] = pruned
+        for fn in filenames:
+            f = (here / fn).resolve()
+            if excluded(f, skip) or not want_file(f):
+                continue
+            hits.append("./" + str(f.relative_to(repo_root)).replace("\\", "/"))
+
+    lines = sorted(set(hits))
+    out.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return len(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo-root", type=Path, required=True)
+    ap.add_argument("--ignore-file", type=Path, required=True)
+    ap.add_argument("--paths-out", type=Path, required=True)
+    args = ap.parse_args()
+
+    gh = os.environ.get("GITHUB_OUTPUT")
+    if not gh:
+        print("GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    root = args.repo_root.resolve()
+    if not args.ignore_file.is_file():
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("use_explicit_paths=false\npaths_list=\n")
+        return 0
+
+    prefs = parse_prefixes_from_ignore(args.ignore_file.read_text(encoding="utf-8"))
+    if not prefs:
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("use_explicit_paths=false\npaths_list=\n")
+        return 0
+
+    n = collect_paths(root, prefs, args.paths_out)
+    if n == 0:
+        print(
+            "::error::.github/zizmor-collection-ignore excluded every zizmor input; remove or relax a prefix.",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(gh, "a", encoding="utf-8") as f:
+        f.write("use_explicit_paths=true\n")
+        f.write(f"paths_list={args.paths_out.resolve()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Called from reusable-zizmor.yml (security-appsec#326).
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from itertools import batched
+except ImportError:
+
+    def batched(iterable, n):  # Python <3.12
+        seq = list(iterable)
+        for i in range(0, len(seq), n):
+            yield seq[i : i + n]
+
+
+def _merge_sarif_parts(parts, dst: Path):
+    if not parts:
+        raise ValueError("no SARIF parts")
+    docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
+    if len(docs) == 1:
+        merged = docs[0]
+    else:
+        runs = []
+        for doc in docs:
+            r = doc.get("runs")
+            if isinstance(r, list):
+                runs.extend(r)
+        merged = {"$schema": docs[0].get("$schema"), "version": docs[0].get("version"), "runs": runs}
+    dst.write_text(json.dumps(merged), encoding="utf-8")
+
+
+def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
+    cmd = [
+        "uvx",
+        f"zizmor@{os.environ['ZIZMOR_VERSION']}",
+        "--format",
+        fmt,
+        "--min-severity",
+        os.environ["MIN_SEVERITY"],
+        "--min-confidence",
+        os.environ["MIN_CONFIDENCE"],
+        "--cache-dir",
+        os.environ["ZIZMOR_CACHE_DIR"],
+    ]
+    cfg = os.environ.get("ZIZMOR_CONFIG_PATH", "").strip()
+    if cfg:
+        cmd += ["--config", cfg]
+    dbg = os.environ.get("RUNNER_DEBUG", "").strip().lower()
+    if dbg in ("1", "true", "yes", "y", "on"):
+        cmd.append("--verbose")
+    cmd += (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").split()
+    cmd += paths
+    return cmd
+
+
+def _run(cmd: list[str], out: Path | None) -> int:
+    if out is None:
+        return subprocess.run(cmd, check=False).returncode
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("wb") as fh:
+        return subprocess.run(cmd, stdout=fh, check=False).returncode
+
+
+def _scan_paths():
+    if os.environ.get("USE_EXPLICIT_PATHS", "").strip().lower() != "true":
+        return ["."]
+    text = Path(os.environ["PATHS_LIST"]).read_text(encoding="utf-8")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    return lines if lines else None
+
+
+def _pipe_plain(cmd: list[str], fh) -> int:
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if proc.stdout is None:
+        return 1
+    with proc.stdout:
+        for line in proc.stdout:
+            fh.write(line)
+    return proc.wait()
+
+
+def _sarif(batch: int, out: Path) -> int:
+    paths = _scan_paths()
+    if paths is None:
+        out.write_text("")
+        return 0
+
+    chunks = [list(c) for c in batched(paths, batch)]
+    if len(chunks) == 1:
+        rc = _run(_zizmor_cmd("sarif", chunks[0]), out)
+        return 1 if rc == 1 else 0
+
+    with tempfile.TemporaryDirectory(prefix="zizmor-sarif-", dir=os.environ["RUNNER_TEMP"]) as name:
+        t = Path(name)
+        parts = []
+        for i, c in enumerate(chunks):
+            part = t / f"part-{i}.sarif"
+            if _run(_zizmor_cmd("sarif", c), part) == 1:
+                return 1
+            parts.append(part)
+        _merge_sarif_parts(parts, out)
+    return 0
+
+
+def _plain(batch: int) -> int:
+    gh = os.environ.get("GITHUB_OUTPUT")
+    if not gh:
+        print("GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    paths = _scan_paths()
+    with open(gh, "a", encoding="utf-8") as fh:
+        fh.write("zizmor-results<<EOF\n")
+        code = 0
+        if paths is not None:
+            for chunk in batched(paths, batch):
+                rc = _pipe_plain(_zizmor_cmd("plain", list(chunk)), fh)
+                if rc == 1:
+                    print("zizmor crashed; see output above.", file=sys.stderr)
+                    return 1
+                code = max(code, rc)
+        fh.write("EOF\n")
+        fh.write(f"zizmor-exit-code={code}\n")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    prog = Path(argv[0]).name if argv else "run_zizmor.py"
+    p = argparse.ArgumentParser(prog=prog)
+    sub = p.add_subparsers(dest="command", required=True)
+    ps = sub.add_parser("sarif", help="run zizmor with SARIF output")
+    ps.add_argument("--batch-size", type=int, default=400)
+    ps.add_argument("--out", type=Path, default=Path("results.sarif"))
+    pp = sub.add_parser("plain-github-output", help="append zizmor plain output to GITHUB_OUTPUT")
+    pp.add_argument("--batch-size", type=int, default=400)
+    if len(argv) < 2:
+        p.print_help(sys.stderr)
+        return 2
+    ns = p.parse_args(argv[1:])
+    if ns.command == "sarif":
+        return _sarif(ns.batch_size, ns.out)
+    return _plain(ns.batch_size)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-# Called from reusable-zizmor.yml (security-appsec#326).
+# Invoked from reusable-zizmor.yml.
 
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -17,6 +18,14 @@ except ImportError:
         seq = list(iterable)
         for i in range(0, len(seq), n):
             yield seq[i : i + n]
+
+
+# upload-sarif rejects an empty file; use an empty runs array instead.
+_EMPTY_SARIF = {
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [],
+}
 
 
 def _merge_sarif_parts(parts, dst: Path):
@@ -54,7 +63,9 @@ def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
     dbg = os.environ.get("RUNNER_DEBUG", "").strip().lower()
     if dbg in ("1", "true", "yes", "y", "on"):
         cmd.append("--verbose")
-    cmd += (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").split()
+    extra = (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").strip()
+    if extra:
+        cmd += shlex.split(extra)
     cmd += paths
     return cmd
 
@@ -88,7 +99,7 @@ def _pipe_plain(cmd: list[str], fh) -> int:
 def _sarif(batch: int, out: Path) -> int:
     paths = _scan_paths()
     if paths is None:
-        out.write_text("")
+        out.write_text(json.dumps(_EMPTY_SARIF), encoding="utf-8")
         return 0
 
     chunks = [list(c) for c in batched(paths, batch)]

--- a/actions/zizmor-collection-paths/test_collection_paths.py
+++ b/actions/zizmor-collection-paths/test_collection_paths.py
@@ -1,0 +1,197 @@
+"""Tests for collection_paths."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import collection_paths
+
+
+class NormalizePrefixTests(unittest.TestCase):
+    def test_strips_glob_suffixes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet/vendor/**/*"), "ksonnet/vendor")
+        self.assertEqual(collection_paths.normalize_prefix_line("terraform/modules/foo/*"), "terraform/modules/foo")
+
+    def test_comments_and_blank(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line(""))
+        self.assertIsNone(collection_paths.normalize_prefix_line("  # ignore"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("# full line"))
+
+    def test_rejects_unescaped_glob(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/*/bar"))
+
+    def test_rejects_double_slash_segment(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("a//b"))
+
+    def test_normalizes_backslashes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet\\vendor"), "ksonnet/vendor")
+
+
+class ParsePrefixesTests(unittest.TestCase):
+    def test_parse_multiline(self) -> None:
+        text = """
+# skip vendor
+ksonnet/vendor
+
+terraform/modules/github.com/github-aws-runners/**/*
+"""
+        got = collection_paths.parse_prefixes_from_ignore(text)
+        self.assertEqual(got, ["ksonnet/vendor", "terraform/modules/github.com/github-aws-runners"])
+
+
+class CollectPathsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, rel: str, content: str = "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n") -> None:
+        p = self.tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def test_includes_first_party_workflow(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("./.github/workflows/ci.yml", body)
+
+    def test_skips_nested_workflow_under_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        self._write("ksonnet/vendor/pkg/.github/workflows/nested.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("nested.yml", body)
+        self.assertEqual(body.count("./"), 1)
+
+    def test_dependabot_at_root(self) -> None:
+        self._write(".github/dependabot.yml", "version: 2\nupdates: []\n")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        self.assertGreaterEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("dependabot.yml", body)
+
+    def test_dependabot_not_outside_dot_github(self) -> None:
+        self._write("vendor/dep/.github/dependabot.yml", "version: 2\nupdates: []\n")
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("dependabot", body)
+        self.assertIn("./.github/workflows/ci.yml", body)
+        self.assertEqual(n, 1)
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX path joining with absolute second operand")
+    def test_collect_paths_rejects_absolute_resolved_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        with self.assertRaises(ValueError) as ctx:
+            collection_paths.collect_paths(self.tmp, ["/etc"], out)
+        self.assertIn("outside repo root", str(ctx.exception).lower())
+
+
+class UnsafePrefixTests(unittest.TestCase):
+    def test_rejects_parent_segments(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("../foo"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/../bar"))
+
+    def test_rejects_absolute(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("/etc/passwd"))
+
+
+class CliTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_main_missing_ignore_file(self) -> None:
+        gh = self.tmp / "gh.txt"
+        root = self.tmp / "repo"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        paths_out = self.tmp / "paths.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_ignore_only_comments(self) -> None:
+        gh = self.tmp / "gh2.txt"
+        root = self.tmp / "repo2"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("# nothing\n\n", encoding="utf-8")
+        paths_out = self.tmp / "paths2.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_explicit_paths_when_prefix_skips_vendor(self) -> None:
+        gh = self.tmp / "gh3.txt"
+        root = self.tmp / "repo3"
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / ".github" / "workflows" / "ci.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        (root / "vendor" / ".github" / "workflows").mkdir(parents=True)
+        (root / "vendor" / ".github" / "workflows" / "nested.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("vendor\n", encoding="utf-8")
+        paths_out = self.tmp / "paths3.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        out_txt = gh.read_text(encoding="utf-8")
+        self.assertIn("use_explicit_paths=true", out_txt)
+        self.assertIn("paths_list=", out_txt)
+        listed = paths_out.read_text(encoding="utf-8")
+        self.assertIn("ci.yml", listed)
+        self.assertNotIn("nested", listed)

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -1,0 +1,89 @@
+"""Tests for run_zizmor."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import run_zizmor
+
+
+class ZizmorCmdTests(unittest.TestCase):
+    def test_extra_args_use_shlex(self) -> None:
+        env = {
+            "ZIZMOR_VERSION": "1.24.1",
+            "MIN_SEVERITY": "low",
+            "MIN_CONFIDENCE": "low",
+            "ZIZMOR_CACHE_DIR": "/tmp/z",
+            "ZIZMOR_EXTRA_ARGS": '--audit "foo bar"',
+        }
+        with mock.patch.dict("os.environ", env, clear=False):
+            cmd = run_zizmor._zizmor_cmd("plain", [".github/workflows/ci.yml"])
+        self.assertIn("--audit", cmd)
+        idx = cmd.index("--audit")
+        self.assertEqual(cmd[idx + 1], "foo bar")
+
+
+class MergeSarifTests(unittest.TestCase):
+    def test_merge_two_parts(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            dpath = Path(d)
+            p1 = dpath / "a.sarif"
+            p2 = dpath / "b.sarif"
+            out = dpath / "out.sarif"
+            p1.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "a"}}}]}),
+                encoding="utf-8",
+            )
+            p2.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "b"}}}]}),
+                encoding="utf-8",
+            )
+            run_zizmor._merge_sarif_parts([p1, p2], out)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(len(doc["runs"]), 2)
+
+
+class SarifEmptyExplicitTests(unittest.TestCase):
+    def test_writes_minimal_sarif_when_explicit_paths_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "r.sarif"
+            env = {
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(Path(d) / "empty.txt"),
+                "RUNNER_TEMP": d,
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+                "ZIZMOR_CACHE_DIR": str(Path(d) / "cache"),
+            }
+            (Path(d) / "empty.txt").write_text("\n\n", encoding="utf-8")
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor._sarif(400, out)
+            self.assertEqual(rc, 0)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(doc.get("version"), "2.1.0")
+            self.assertEqual(doc.get("runs"), [])
+
+
+class PlainGithubOutputTests(unittest.TestCase):
+    def test_plain_github_output_empty_explicit_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            gh = Path(d) / "gh.txt"
+            empty = Path(d) / "empty.txt"
+            empty.write_text("\n\n", encoding="utf-8")
+            env = {
+                "GITHUB_OUTPUT": str(gh),
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(empty),
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+            }
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor.main(["run_zizmor.py", "plain-github-output", "--batch-size", "400"])
+            self.assertEqual(rc, 0)
+            body = gh.read_text(encoding="utf-8")
+            self.assertIn("zizmor-results<<EOF", body)
+            self.assertIn("zizmor-exit-code=0", body)


### PR DESCRIPTION
Updates `feat/zizmor-collection-ignore-326-v2` to match the squashed fork branch (`acb49f8`): single commit, shlex for `ZIZMOR_EXTRA_ARGS`, path hardening tests, docs.

Direct pushes to the upstream feature branch are blocked by rulesets; merge this PR to refresh the head of https://github.com/grafana/shared-workflows/pull/1935 .

Tracks https://github.com/grafana/security-appsec/issues/326