### PR TITLE
chore(reusable-zizmor): update bench version to v1.0.10

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -578,7 +578,7 @@ jobs:
           BENCH_SUITE_NAME: ${{ github.event.repository.name }}/zizmor
           BENCH_SERVICE_VERSION: ${{ github.sha }}
           # renovate: datasource=github-releases packageName=grafana/grafana-bench
-          BENCH_VERSION: "v1.0.9"
+          BENCH_VERSION: "v1.0.10"
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)


### PR DESCRIPTION
Updates bench version to `v1.0.10` to bypass ship correct per-arch binaries in multi-arch images as per https://github.com/grafana/grafana-bench/pull/968