### PR TITLE
feat(zizmor): optional vendored-path excludes

### DIFF
--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -184,3 +184,14 @@ files can be ignored][zizmor-ignore-config].
 
 [zizmor-config]: https://woodruffw.github.io/zizmor/configuration/
 [zizmor-ignore-config]: https://woodruffw.github.io/zizmor/usage/#with-zizmoryml
+
+## Skipping vendored workflow trees ([security-appsec#326](https://github.com/grafana/security-appsec/issues/326))
+
+Vendored trees can still contain `.github/workflows/`. Add **`.github/zizmor-collection-ignore`** at the repo root with one directory prefix per line. Lines like `ksonnet/vendor/**/*` work (a trailing `/**` is stripped). Do not use `..` or absolute paths. Comments (`#`) and blank lines are OK. Without this file, zizmor still scans `.`.
+
+```text
+ksonnet/vendor
+terraform/modules/github.com/github-aws-runners
+```
+
+Path collection and batched runs are implemented in `actions/zizmor-collection-paths`. The scripts run from the OIDC-pinned `shared-workflows` checkout at `_shared-workflows-zizmor/`; that directory is not scanned.

--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -215,3 +215,14 @@ files can be ignored][zizmor-ignore-config].
 
 [zizmor-config]: https://woodruffw.github.io/zizmor/configuration/
 [zizmor-ignore-config]: https://woodruffw.github.io/zizmor/usage/#with-zizmoryml
+
+## Skipping vendored workflow trees ([security-appsec#326](https://github.com/grafana/security-appsec/issues/326))
+
+Vendored trees can still contain `.github/workflows/`. Add **`.github/zizmor-collection-ignore`** at the repo root with one directory prefix per line. Lines like `ksonnet/vendor/**/*` work (a trailing `/**` is stripped). Do not use `..` or absolute paths. Comments (`#`) and blank lines are OK. Without this file, zizmor still scans `.`.
+
+```text
+ksonnet/vendor
+terraform/modules/github.com/github-aws-runners
+```
+
+Path collection and batched runs are implemented in `actions/zizmor-collection-paths`. The scripts run from the OIDC-pinned `shared-workflows` checkout at `_shared-workflows-zizmor/`; that directory is not scanned.

--- a/.github/workflows/reusable-zizmor.md
+++ b/.github/workflows/reusable-zizmor.md
@@ -225,4 +225,4 @@ ksonnet/vendor
 terraform/modules/github.com/github-aws-runners
 ```
 
-Path collection and batched runs are implemented in `actions/zizmor-collection-paths`. The scripts run from the OIDC-pinned `shared-workflows` checkout at `_shared-workflows-zizmor/`; that directory is not scanned.
+Path collection and batched runs are implemented by the composite action [`actions/zizmor-collection-paths`](../../actions/zizmor-collection-paths), **hash-pinned** in `reusable-zizmor.yml` (bump that SHA when you change the action). It runs from the Actions cache, so nothing lands in the caller workspace.

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -219,14 +219,10 @@ jobs:
 
             const AUDIENCE = 'zizmor-job-workflow-ref';
 
-            // Fork PRs (and some other contexts) have no OIDC token. Detect that
-            // up front and use fallback without throwing, so the step succeeds
-            // and the log stays clear.
+            // Fork PRs have no OIDC token, so we can't detect the workflow ref. Use main.
             const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
             if (!runtimeUrl) {
-              core.info(
-                "No OIDC token available (e.g. pull request from a fork). Using fallback: grafana/shared-workflows@main for default config."
-              );
+              core.info("No OIDC token (e.g. fork PR). Using grafana/shared-workflows@main for default config.");
               core.setOutput('owner', 'grafana');
               core.setOutput('repo', 'shared-workflows');
               core.setOutput('sha', 'main');
@@ -298,6 +294,31 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
+      # .github/zizmor-collection-ignore (optional) — see reusable-zizmor.md
+      - name: Checkout shared-workflows (zizmor helper scripts)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.job-workflow-ref.outputs.owner }}/${{ needs.job-workflow-ref.outputs.repo }}
+          ref: ${{ needs.job-workflow-ref.outputs.sha }}
+          path: _shared-workflows-zizmor
+          persist-credentials: false
+
+      - name: Zizmor paths + helper_root
+        id: zizmor-helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
+          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
+            echo "::error::zizmor helper missing at ${ROOT} (pin reusable-zizmor.yml to a SHA that includes actions/zizmor-collection-paths)." >&2
+            exit 1
+          fi
+          echo "helper_root=${ROOT}" >> "${GITHUB_OUTPUT}"
+          python3 "${ROOT}/collection_paths.py" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --ignore-file "${GITHUB_WORKSPACE}/.github/zizmor-collection-ignore" \
+            --paths-out "${RUNNER_TEMP}/zizmor-explicit-inputs.txt"
 
       - name: Restore config from cache
         id: cache-config
@@ -430,22 +451,12 @@ jobs:
         env:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
-        shell: sh
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
+        shell: bash
         run: |
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format sarif \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            > results.sarif
-          exit_code=$?
-          # Only fail on exit code 1 (zizmor crash). 0 = no findings, 10-14 = findings by severity.
-          if [ "${exit_code}" -eq 1 ]; then exit 1; fi
-          exit 0
+          set -euo pipefail
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" sarif --batch-size 400 --out results.sarif
 
       - name: Upload artifact
         if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
@@ -495,12 +506,13 @@ jobs:
           REPO_LOCAL_ZIZMOR_CONFIG: ${{ steps.setup-config.outputs['repo-local-zizmor-config'] }}
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
         run: |
-          set -o pipefail
-
-          echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
+          set -euo pipefail
 
           if [ "${VALIDATE_CONFIG_OUTCOME}" = "failure" ]; then
+            echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
             echo "Repo-local zizmor config policy validation failed for ${REPO_LOCAL_ZIZMOR_CONFIG}."
             if [ -f results.sarif ]; then
               python3 - <<'PY' | tee -a "${GITHUB_OUTPUT}"
@@ -518,33 +530,8 @@ jobs:
             exit 0
           fi
 
-          # Run zizmor again with plain output for human-readable logs.
-          # Don't fail the build here - we capture the exit code for the
-          # "Fail the build" step to evaluate against fail-severity.
-          # Output is also captured for the fallback PR comment when
-          # Code Scanning is unavailable.
-          set +e
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format plain \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            | tee -a "${GITHUB_OUTPUT}"
-          zizmor_exit_code=$?
-          set -e
-          echo "EOF" >> "${GITHUB_OUTPUT}"
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" plain-github-output --batch-size 400
 
-          # Error 1 is a failure of zizmor itself
-          if [ "${zizmor_exit_code}" -eq 1 ]; then
-            echo "zizmor itself failed - check the above output. failing the workflow."
-            exit 1
-          fi
-
-          echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Remove zizmor config
         env:
@@ -558,12 +545,14 @@ jobs:
         if: ${{ !cancelled() && steps.upload-sarif.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: hide-comments
         uses: int128/hide-comment-action@8cd375395d4b1630f8b70d17b802501a15d32561 # v1.66.0
+
         with:
           ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
 
       - name: Comment with zizmor results
         if: steps.upload-sarif.outcome == 'failure' && steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: int128/comment-action@9448863881c42b4c69f213d9a67c8b37e7c0f105 # v1.68.0
+
         with:
           post: |
             :cry: zizmor failed with exit code ${{ steps.zizmor-plain.outputs.zizmor-exit-code }}.
@@ -619,7 +608,6 @@ jobs:
 
   grafana-bench:
     name: Send zizmor metrics to Prometheus via Grafana Bench
-    continue-on-error: true
     needs: [analysis, job-workflow-ref]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.analysis.result == 'success' || needs.analysis.result == 'failure') }}
@@ -656,6 +644,7 @@ jobs:
           PROMETHEUS_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_URL }}
           PROMETHEUS_USER: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_USER }}
           PROMETHEUS_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_PASSWORD }}
+
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -532,7 +532,6 @@ jobs:
 
           python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" plain-github-output --batch-size 400
 
-
       - name: Remove zizmor config
         env:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -513,7 +513,7 @@ jobs:
 
           if [ "${VALIDATE_CONFIG_OUTCOME}" = "failure" ]; then
             echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
-            echo "Repo-local zizmor config policy validation failed for ${REPO_LOCAL_ZIZMOR_CONFIG}."
+            echo "Repo-local zizmor config policy validation failed for ${REPO_LOCAL_ZIZMOR_CONFIG}." >> "${GITHUB_OUTPUT}"
             if [ -f results.sarif ]; then
               python3 - <<'PY' | tee -a "${GITHUB_OUTPUT}"
           import json

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -203,14 +203,10 @@ jobs:
 
             const AUDIENCE = 'zizmor-job-workflow-ref';
 
-            // Fork PRs (and some other contexts) have no OIDC token. Detect that
-            // up front and use fallback without throwing, so the step succeeds
-            // and the log stays clear.
+            // Fork PRs have no OIDC token, so we can't detect the workflow ref. Use main.
             const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
             if (!runtimeUrl) {
-              core.info(
-                "No OIDC token available (e.g. pull request from a fork). Using fallback: grafana/shared-workflows@main for default config."
-              );
+              core.info("No OIDC token (e.g. fork PR). Using grafana/shared-workflows@main for default config.");
               core.setOutput('owner', 'grafana');
               core.setOutput('repo', 'shared-workflows');
               core.setOutput('sha', 'main');
@@ -279,6 +275,31 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+
+      # .github/zizmor-collection-ignore (optional) — see reusable-zizmor.md
+      - name: Checkout shared-workflows (zizmor helper scripts)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ needs.job-workflow-ref.outputs.owner }}/${{ needs.job-workflow-ref.outputs.repo }}
+          ref: ${{ needs.job-workflow-ref.outputs.sha }}
+          path: _shared-workflows-zizmor
+          persist-credentials: false
+
+      - name: Zizmor paths + helper_root
+        id: zizmor-helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
+          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
+            echo "::error::zizmor helper missing at ${ROOT} (pin reusable-zizmor.yml to a SHA that includes actions/zizmor-collection-paths)." >&2
+            exit 1
+          fi
+          echo "helper_root=${ROOT}" >> "${GITHUB_OUTPUT}"
+          python3 "${ROOT}/collection_paths.py" \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --ignore-file "${GITHUB_WORKSPACE}/.github/zizmor-collection-ignore" \
+            --paths-out "${RUNNER_TEMP}/zizmor-explicit-inputs.txt"
 
       - name: Restore config from cache
         id: cache-config
@@ -407,22 +428,12 @@ jobs:
         env:
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
-        shell: sh
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
+        shell: bash
         run: |
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format sarif \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            > results.sarif
-          exit_code=$?
-          # Only fail on exit code 1 (zizmor crash). 0 = no findings, 10-14 = findings by severity.
-          if [ "${exit_code}" -eq 1 ]; then exit 1; fi
-          exit 0
+          set -euo pipefail
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" sarif --batch-size 400 --out results.sarif
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -447,37 +458,11 @@ jobs:
           NO_COLOR: 1
           ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
+          USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
+          PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
         run: |
-          set -o pipefail
-
-          echo "zizmor-results<<EOF" >> "${GITHUB_OUTPUT}"
-          # Run zizmor again with plain output for human-readable logs.
-          # Don't fail the build here - we capture the exit code for the
-          # "Fail the build" step to evaluate against fail-severity.
-          # Output is also captured for the fallback PR comment when
-          # Code Scanning is unavailable.
-          set +e
-          uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format plain \
-            --min-severity "${MIN_SEVERITY}" \
-            --min-confidence "${MIN_CONFIDENCE}" \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            | tee -a "${GITHUB_OUTPUT}"
-          zizmor_exit_code=$?
-          set -e
-          echo "EOF" >> "${GITHUB_OUTPUT}"
-
-          # Error 1 is a failure of zizmor itself
-          if [ "${zizmor_exit_code}" -eq 1 ]; then
-            echo "zizmor itself failed - check the above output. failing the workflow."
-            exit 1
-          fi
-
-          echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
+          set -euo pipefail
+          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" plain-github-output --batch-size 400
 
       - name: Remove zizmor config
         env:
@@ -490,13 +475,13 @@ jobs:
       - name: Hide any previous comments
         if: ${{ !cancelled() && steps.upload-sarif.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: hide-comments
-        uses: int128/hide-comment-action@392bc214093dafaebdf99c7d6298245262832d15 # v1.58.0
+        uses: int128/hide-comment-action@d38cf5901fbb26e4d5790890955713b0ec539087 # v1.57.0
         with:
           ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
 
       - name: Comment with zizmor results
         if: steps.upload-sarif.outcome == 'failure' && steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
-        uses: int128/comment-action@49702e482c43a9789ce7925aff3208063dba4a11 # v1.59.0
+        uses: int128/comment-action@aeac1a068baa6d17e9673b817d27a310185aa95b # v1.58.0
         with:
           post: |
             :cry: zizmor failed with exit code ${{ steps.zizmor-plain.outputs.zizmor-exit-code }}.
@@ -546,7 +531,6 @@ jobs:
 
   grafana-bench:
     name: Send zizmor metrics to Prometheus via Grafana Bench
-    continue-on-error: true
     needs: [analysis, job-workflow-ref]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.analysis.result == 'success' || needs.analysis.result == 'failure') }}
@@ -578,7 +562,7 @@ jobs:
           BENCH_SUITE_NAME: ${{ github.event.repository.name }}/zizmor
           BENCH_SERVICE_VERSION: ${{ github.sha }}
           # renovate: datasource=github-releases packageName=grafana/grafana-bench
-          BENCH_VERSION: "v1.0.10"
+          BENCH_VERSION: "v1.0.9"
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -115,7 +115,7 @@ jobs:
         env:
           # Keep this updated in a simpler way than needing a full package.json.
           # renovate: datasource=npm depName=jose
-          JOSE_VERSION: 6.2.3
+          JOSE_VERSION: 6.2.4
         run: npm install "jose@${JOSE_VERSION}"
 
       - id: get-job-workflow-ref
@@ -219,10 +219,14 @@ jobs:
 
             const AUDIENCE = 'zizmor-job-workflow-ref';
 
-            // Fork PRs have no OIDC token, so we can't detect the workflow ref. Use main.
+            // Fork PRs (and some other contexts) have no OIDC token. Detect that
+            // up front and use fallback without throwing, so the step succeeds
+            // and the log stays clear.
             const runtimeUrl = process.env['ACTIONS_ID_TOKEN_REQUEST_URL'];
             if (!runtimeUrl) {
-              core.info("No OIDC token (e.g. fork PR). Using grafana/shared-workflows@main for default config.");
+              core.info(
+                "No OIDC token available (e.g. pull request from a fork). Using fallback: grafana/shared-workflows@main for default config."
+              );
               core.setOutput('owner', 'grafana');
               core.setOutput('repo', 'shared-workflows');
               core.setOutput('sha', 'main');
@@ -278,7 +282,7 @@ jobs:
       MIN_SEVERITY: ${{ inputs.min-severity }}
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
       # renovate: datasource=pypi depName=zizmor
-      ZIZMOR_VERSION: 1.27.0
+      ZIZMOR_VERSION: 1.28.0
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
       DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.sha }}
@@ -296,29 +300,9 @@ jobs:
           persist-credentials: false
 
       # .github/zizmor-collection-ignore (optional) — see reusable-zizmor.md
-      - name: Checkout shared-workflows (zizmor helper scripts)
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ needs.job-workflow-ref.outputs.owner }}/${{ needs.job-workflow-ref.outputs.repo }}
-          ref: ${{ needs.job-workflow-ref.outputs.sha }}
-          path: _shared-workflows-zizmor
-          persist-credentials: false
-
-      - name: Zizmor paths + helper_root
+      - name: Collect zizmor paths
         id: zizmor-helper
-        shell: bash
-        run: |
-          set -euo pipefail
-          ROOT="${GITHUB_WORKSPACE}/_shared-workflows-zizmor/actions/zizmor-collection-paths"
-          if [ ! -f "${ROOT}/run_zizmor.py" ]; then
-            echo "::error::zizmor helper missing at ${ROOT} (pin reusable-zizmor.yml to a SHA that includes actions/zizmor-collection-paths)." >&2
-            exit 1
-          fi
-          echo "helper_root=${ROOT}" >> "${GITHUB_OUTPUT}"
-          python3 "${ROOT}/collection_paths.py" \
-            --repo-root "${GITHUB_WORKSPACE}" \
-            --ignore-file "${GITHUB_WORKSPACE}/.github/zizmor-collection-ignore" \
-            --paths-out "${RUNNER_TEMP}/zizmor-explicit-inputs.txt"
+        uses: grafana/shared-workflows/actions/zizmor-collection-paths@8e6ceaffac6e92e59a9f90e6a414cb7413ad2503 # zizmor-collection-paths/v0.1.0
 
       - name: Restore config from cache
         id: cache-config
@@ -453,10 +437,11 @@ jobs:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
           USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
           PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
+          HELPER_ROOT: ${{ steps.zizmor-helper.outputs.helper_root }}
         shell: bash
         run: |
           set -euo pipefail
-          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" sarif --batch-size 400 --out results.sarif
+          python3 "${HELPER_ROOT}/run_zizmor.py" sarif --batch-size 400 --out results.sarif
 
       - name: Upload artifact
         if: ${{ !cancelled() && hashFiles('results.sarif') != '' }}
@@ -508,6 +493,7 @@ jobs:
           ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
           USE_EXPLICIT_PATHS: ${{ steps.zizmor-helper.outputs.use_explicit_paths }}
           PATHS_LIST: ${{ steps.zizmor-helper.outputs.paths_list }}
+          HELPER_ROOT: ${{ steps.zizmor-helper.outputs.helper_root }}
         run: |
           set -euo pipefail
 
@@ -530,7 +516,7 @@ jobs:
             exit 0
           fi
 
-          python3 "${{ steps.zizmor-helper.outputs.helper_root }}/run_zizmor.py" plain-github-output --batch-size 400
+          python3 "${HELPER_ROOT}/run_zizmor.py" plain-github-output --batch-size 400
 
       - name: Remove zizmor config
         env:
@@ -544,14 +530,12 @@ jobs:
         if: ${{ !cancelled() && steps.upload-sarif.outcome == 'failure' && github.event.pull_request.head.repo.full_name == github.repository }}
         id: hide-comments
         uses: int128/hide-comment-action@8cd375395d4b1630f8b70d17b802501a15d32561 # v1.66.0
-
         with:
           ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }} -->"
 
       - name: Comment with zizmor results
         if: steps.upload-sarif.outcome == 'failure' && steps.zizmor-plain.outputs.zizmor-exit-code != 0 && github.event.pull_request.head.repo.full_name == github.repository
         uses: int128/comment-action@9448863881c42b4c69f213d9a67c8b37e7c0f105 # v1.68.0
-
         with:
           post: |
             :cry: zizmor failed with exit code ${{ steps.zizmor-plain.outputs.zizmor-exit-code }}.
@@ -607,6 +591,7 @@ jobs:
 
   grafana-bench:
     name: Send zizmor metrics to Prometheus via Grafana Bench
+    continue-on-error: true
     needs: [analysis, job-workflow-ref]
     # Only run for grafana org and non-fork PRs (fork PRs have no OIDC/Vault access).
     if: ${{ github.repository_owner == 'grafana' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) && inputs.send-bench-metrics && always() && !cancelled() && (needs.analysis.result == 'success' || needs.analysis.result == 'failure') }}
@@ -643,7 +628,6 @@ jobs:
           PROMETHEUS_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_URL }}
           PROMETHEUS_USER: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_USER }}
           PROMETHEUS_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_PASSWORD }}
-
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)

--- a/.github/workflows/test-zizmor-collection-paths.yml
+++ b/.github/workflows/test-zizmor-collection-paths.yml
@@ -1,0 +1,47 @@
+name: Test zizmor-collection-paths action
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/zizmor-collection-paths/**
+      - .github/workflows/test-zizmor-collection-paths.yml
+      - .github/workflows/reusable-zizmor.yml
+
+  pull_request:
+    paths:
+      - actions/zizmor-collection-paths/**
+      - .github/workflows/test-zizmor-collection-paths.yml
+      - .github/workflows/reusable-zizmor.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Unit tests
+        run: |
+          cd actions/zizmor-collection-paths
+          python3 -m unittest discover -v

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ yarn-error.log*
 
 node_modules/
 
+__pycache__/
+*.py[cod]
+
 coverage/
 dist/
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ yarn-error.log*
 
 node_modules/
 
+__pycache__/
+*.py[cod]
+
 coverage/
 
 dist/

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -35,5 +35,6 @@
     "actions/wait-for-docker-publish": "0.3.0",
     "actions/download-branch-workflow-artifact": "0.1.0",
     "actions/annotate-coverage": "0.2.0",
-    "actions/signed-commits-info": "0.1.0"
+    "actions/signed-commits-info": "0.1.0",
+    "actions/zizmor-collection-paths": "0.1.0"
 }

--- a/actions/zizmor-collection-paths/README.md
+++ b/actions/zizmor-collection-paths/README.md
@@ -1,0 +1,7 @@
+# zizmor-collection-paths
+
+Used by [`reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml) when a repo has [`.github/zizmor-collection-ignore`](../../.github/workflows/reusable-zizmor.md#skipping-vendored-workflow-trees-security-appsec326).
+
+```bash
+cd actions/zizmor-collection-paths && python3 -m unittest discover -v
+```

--- a/actions/zizmor-collection-paths/README.md
+++ b/actions/zizmor-collection-paths/README.md
@@ -1,6 +1,8 @@
 # zizmor-collection-paths
 
-Used by [`reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml) when a repo has [`.github/zizmor-collection-ignore`](../../.github/workflows/reusable-zizmor.md#skipping-vendored-workflow-trees-security-appsec326).
+Composite action used by [`reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml) when a repo has [`.github/zizmor-collection-ignore`](../../.github/workflows/reusable-zizmor.md#skipping-vendored-workflow-trees-security-appsec326).
+
+Runs from the Actions cache (`GITHUB_ACTION_PATH`); nothing is checked out into the caller workspace.
 
 ```bash
 cd actions/zizmor-collection-paths && python3 -m unittest discover -v

--- a/actions/zizmor-collection-paths/action.yml
+++ b/actions/zizmor-collection-paths/action.yml
@@ -1,0 +1,28 @@
+name: Collect zizmor paths
+description: >-
+  Parses optional .github/zizmor-collection-ignore and emits explicit zizmor
+  scan paths (or signals default "." scanning). Used by reusable-zizmor.
+outputs:
+  use_explicit_paths:
+    description: "true when ignore prefixes are active; false to scan ."
+    value: ${{ steps.collect.outputs.use_explicit_paths }}
+  paths_list:
+    description: Path to the newline-separated explicit inputs file (when use_explicit_paths is true).
+    value: ${{ steps.collect.outputs.paths_list }}
+  helper_root:
+    description: Directory containing collection_paths.py and run_zizmor.py (GITHUB_ACTION_PATH).
+    value: ${{ steps.collect.outputs.helper_root }}
+
+runs:
+  using: composite
+  steps:
+    - name: Collect paths
+      id: collect
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "helper_root=${GITHUB_ACTION_PATH}" >> "${GITHUB_OUTPUT}"
+        python3 "${GITHUB_ACTION_PATH}/collection_paths.py" \
+          --repo-root "${GITHUB_WORKSPACE}" \
+          --ignore-file "${GITHUB_WORKSPACE}/.github/zizmor-collection-ignore" \
+          --paths-out "${RUNNER_TEMP}/zizmor-explicit-inputs.txt"

--- a/actions/zizmor-collection-paths/collection_paths.py
+++ b/actions/zizmor-collection-paths/collection_paths.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# reusable-zizmor.yml checks out shared-workflows here
+_HELPER_CHECKOUT_DIR = "_shared-workflows-zizmor"
+_SKIP_TOP_LEVEL_DIRS = frozenset({_HELPER_CHECKOUT_DIR})
+
+
+def _unsafe_prefix_reason(rel: str) -> str | None:
+    if not rel:
+        return "empty"
+    if rel.startswith(("/", "\\")):
+        return "absolute path"
+    norm = rel.replace("\\", "/")
+    parts = norm.split("/")
+    if ".." in parts:
+        return "parent segment"
+    if any(p == "" for p in parts):
+        return "empty path segment"
+    return None
+
+
+def normalize_prefix_line(line: str) -> str | None:
+    raw = line.strip()
+    if not raw or raw.startswith("#"):
+        return None
+    if raw.startswith(("/", "\\")):
+        return None
+    s = raw
+    while True:
+        old = s
+        s = s.removesuffix("**").removesuffix("/*").rstrip("/")
+        if s == old:
+            break
+    if "*" in s:
+        return None
+    s = s.replace("\\", "/")
+    if _unsafe_prefix_reason(s):
+        return None
+    return s or None
+
+
+def parse_prefixes_from_ignore(content: str) -> list[str]:
+    prefixes = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        p = normalize_prefix_line(line)
+        if p:
+            prefixes.append(p)
+    return prefixes
+
+
+def excluded(path: Path, roots: list[Path]) -> bool:
+    return any(path == r or r in path.parents for r in roots)
+
+
+def want_file(path: Path, repo_root: Path) -> bool:
+    try:
+        rel = path.resolve().relative_to(repo_root)
+    except ValueError:
+        return False
+    parts = rel.parts
+    if path.name in ("action.yml", "action.yaml"):
+        return True
+    if path.name in ("dependabot.yml", "dependabot.yaml"):
+        return len(parts) == 2 and parts[0] == ".github"
+    if path.suffix not in (".yml", ".yaml"):
+        return False
+    return len(parts) >= 3 and parts[0] == ".github" and parts[1] == "workflows"
+
+
+def collect_paths(repo_root: Path, prefixes: list[str], out: Path) -> int:
+    repo_root = repo_root.resolve()
+    out.parent.mkdir(parents=True, exist_ok=True)
+    skip = []
+    for p in prefixes:
+        cand = (repo_root / p).resolve()
+        try:
+            cand.relative_to(repo_root)
+        except ValueError as e:
+            raise ValueError(f"ignore prefix {p!r} resolves outside repo root") from e
+        skip.append(cand)
+    hits = []
+
+    for dirpath, dirnames, filenames in os.walk(repo_root, topdown=True):
+        here = Path(dirpath).resolve()
+        pruned = [
+            d
+            for d in dirnames
+            if d not in _SKIP_TOP_LEVEL_DIRS and not excluded((here / d).resolve(), skip)
+        ]
+        dirnames[:] = pruned
+        for fn in filenames:
+            f = (here / fn).resolve()
+            if excluded(f, skip) or not want_file(f, repo_root):
+                continue
+            hits.append("./" + str(f.relative_to(repo_root)).replace("\\", "/"))
+
+    lines = sorted(set(hits))
+    out.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+    return len(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo-root", type=Path, required=True)
+    ap.add_argument("--ignore-file", type=Path, required=True)
+    ap.add_argument("--paths-out", type=Path, required=True)
+    args = ap.parse_args()
+
+    gh = os.environ.get("GITHUB_OUTPUT")
+    if not gh:
+        print("GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    root = args.repo_root.resolve()
+    if not args.ignore_file.is_file():
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("use_explicit_paths=false\npaths_list=\n")
+        return 0
+
+    prefs = parse_prefixes_from_ignore(args.ignore_file.read_text(encoding="utf-8"))
+    if not prefs:
+        with open(gh, "a", encoding="utf-8") as f:
+            f.write("use_explicit_paths=false\npaths_list=\n")
+        return 0
+
+    try:
+        n = collect_paths(root, prefs, args.paths_out)
+    except ValueError as e:
+        print(f"::error::{e}", file=sys.stderr)
+        return 1
+    if n == 0:
+        print(
+            "::error::.github/zizmor-collection-ignore excluded every zizmor input; remove or relax a prefix.",
+            file=sys.stderr,
+        )
+        return 1
+
+    with open(gh, "a", encoding="utf-8") as f:
+        f.write("use_explicit_paths=true\n")
+        f.write(f"paths_list={args.paths_out.resolve()}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/zizmor-collection-paths/collection_paths.py
+++ b/actions/zizmor-collection-paths/collection_paths.py
@@ -5,10 +5,6 @@ import os
 import sys
 from pathlib import Path
 
-# reusable-zizmor.yml checks out shared-workflows here
-_HELPER_CHECKOUT_DIR = "_shared-workflows-zizmor"
-_SKIP_TOP_LEVEL_DIRS = frozenset({_HELPER_CHECKOUT_DIR})
-
 
 def _unsafe_prefix_reason(rel: str) -> str | None:
     if not rel:
@@ -47,9 +43,6 @@ def normalize_prefix_line(line: str) -> str | None:
 def parse_prefixes_from_ignore(content: str) -> list[str]:
     prefixes = []
     for line in content.splitlines():
-        line = line.strip()
-        if not line or line.lstrip().startswith("#"):
-            continue
         p = normalize_prefix_line(line)
         if p:
             prefixes.append(p)
@@ -61,6 +54,15 @@ def excluded(path: Path, roots: list[Path]) -> bool:
 
 
 def want_file(path: Path, repo_root: Path) -> bool:
+    """Return True if path is a zizmor input under repo_root.
+
+    Mirrors zizmor 1.28.0 input collection (workflow YAML under
+    .github/workflows/, action.yml/action.yaml, and root
+    .github/dependabot.yml). Re-check when bumping ZIZMOR_VERSION.
+
+    Symlinked workflows that resolve outside repo_root are skipped
+    (relative_to raises ValueError).
+    """
     try:
         rel = path.resolve().relative_to(repo_root)
     except ValueError:
@@ -90,11 +92,7 @@ def collect_paths(repo_root: Path, prefixes: list[str], out: Path) -> int:
 
     for dirpath, dirnames, filenames in os.walk(repo_root, topdown=True):
         here = Path(dirpath).resolve()
-        pruned = [
-            d
-            for d in dirnames
-            if d not in _SKIP_TOP_LEVEL_DIRS and not excluded((here / d).resolve(), skip)
-        ]
+        pruned = [d for d in dirnames if not excluded((here / d).resolve(), skip)]
         dirnames[:] = pruned
         for fn in filenames:
             f = (here / fn).resolve()

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from itertools import batched
+except ImportError:
+
+    def batched(iterable, n):  # Python <3.12
+        seq = list(iterable)
+        for i in range(0, len(seq), n):
+            yield seq[i : i + n]
+
+
+_EMPTY_SARIF = {
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [],
+}
+
+
+def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
+    cmd = [
+        "uvx",
+        f"zizmor@{os.environ['ZIZMOR_VERSION']}",
+        "--format",
+        fmt,
+        "--min-severity",
+        os.environ["MIN_SEVERITY"],
+        "--min-confidence",
+        os.environ["MIN_CONFIDENCE"],
+        "--cache-dir",
+        os.environ["ZIZMOR_CACHE_DIR"],
+    ]
+    cfg = os.environ.get("ZIZMOR_CONFIG_PATH", "").strip()
+    if cfg:
+        cmd += ["--config", cfg]
+    if os.environ.get("RUNNER_DEBUG", "").strip().lower() in ("1", "true", "yes", "y", "on"):
+        cmd.append("--verbose")
+    extra = (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").strip()
+    if extra:
+        cmd += shlex.split(extra)
+    cmd += paths
+    return cmd
+
+
+def _scan_paths() -> list[str] | None:
+    if os.environ.get("USE_EXPLICIT_PATHS", "").strip().lower() != "true":
+        return ["."]
+    lines = [
+        ln.strip()
+        for ln in Path(os.environ["PATHS_LIST"]).read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
+    return lines if lines else None
+
+
+def _zizmor_rc(rc: int) -> int:
+    # 0 = clean, 10–14 = findings by severity; only 1 is a crash.
+    return 1 if rc == 1 else 0
+
+
+def _merge_sarif_parts(parts: list[Path], dst: Path) -> None:
+    docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
+    if len(docs) == 1:
+        merged = docs[0]
+    else:
+        runs = []
+        for doc in docs:
+            runs.extend(doc.get("runs") or [])
+        merged = {
+            "$schema": docs[0].get("$schema"),
+            "version": docs[0].get("version"),
+            "runs": runs,
+        }
+    dst.write_text(json.dumps(merged), encoding="utf-8")
+
+
+def _run_sarif(paths: list[str] | None, batch: int, out: Path) -> int:
+    if paths is None:
+        out.write_text(json.dumps(_EMPTY_SARIF), encoding="utf-8")
+        return 0
+
+    chunks = list(batched(paths, batch))
+    if len(chunks) == 1:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("wb") as fh:
+            rc = subprocess.run(_zizmor_cmd("sarif", list(chunks[0])), stdout=fh, check=False).returncode
+        return _zizmor_rc(rc)
+
+    tmp = os.environ["RUNNER_TEMP"]
+    with tempfile.TemporaryDirectory(prefix="zizmor-sarif-", dir=tmp) as name:
+        parts: list[Path] = []
+        for i, chunk in enumerate(chunks):
+            part = Path(name) / f"part-{i}.sarif"
+            with part.open("wb") as fh:
+                rc = subprocess.run(_zizmor_cmd("sarif", list(chunk)), stdout=fh, check=False).returncode
+            if rc == 1:
+                return 1
+            parts.append(part)
+        _merge_sarif_parts(parts, out)
+    return 0
+
+
+def _run_plain(paths: list[str] | None, batch: int) -> int:
+    gh = os.environ.get("GITHUB_OUTPUT")
+    if not gh:
+        print("GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    with open(gh, "a", encoding="utf-8") as fh:
+        fh.write("zizmor-results<<EOF\n")
+        code = 0
+        if paths is not None:
+            for chunk in batched(paths, batch):
+                proc = subprocess.Popen(
+                    _zizmor_cmd("plain", list(chunk)),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+                if proc.stdout is None:
+                    return 1
+                fh.write(proc.stdout.read())
+                rc = proc.wait()
+                if rc == 1:
+                    print("zizmor crashed; see output above.", file=sys.stderr)
+                    return 1
+                code = max(code, rc)
+        fh.write("EOF\n")
+        fh.write(f"zizmor-exit-code={code}\n")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    p = argparse.ArgumentParser(prog=Path(argv[0]).name if argv else "run_zizmor.py")
+    sub = p.add_subparsers(dest="command", required=True)
+    ps = sub.add_parser("sarif")
+    ps.add_argument("--batch-size", type=int, default=400)
+    ps.add_argument("--out", type=Path, default=Path("results.sarif"))
+    pp = sub.add_parser("plain-github-output")
+    pp.add_argument("--batch-size", type=int, default=400)
+    if len(argv) < 2:
+        p.print_help(sys.stderr)
+        return 2
+
+    ns = p.parse_args(argv[1:])
+    paths = _scan_paths()
+    if ns.command == "sarif":
+        return _run_sarif(paths, ns.batch_size, ns.out)
+    return _run_plain(paths, ns.batch_size)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+try:
+    from itertools import batched
+except ImportError:
+
+    def batched(iterable, n):  # Python <3.12
+        seq = list(iterable)
+        for i in range(0, len(seq), n):
+            yield seq[i : i + n]
+
+
+_EMPTY_SARIF = {
+    "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+    "version": "2.1.0",
+    "runs": [],
+}
+
+
+def _merge_sarif_parts(parts, dst: Path):
+    if not parts:
+        raise ValueError("no SARIF parts")
+    docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
+    if len(docs) == 1:
+        merged = docs[0]
+    else:
+        runs = []
+        for doc in docs:
+            r = doc.get("runs")
+            if isinstance(r, list):
+                runs.extend(r)
+        merged = {"$schema": docs[0].get("$schema"), "version": docs[0].get("version"), "runs": runs}
+    dst.write_text(json.dumps(merged), encoding="utf-8")
+
+
+def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
+    cmd = [
+        "uvx",
+        f"zizmor@{os.environ['ZIZMOR_VERSION']}",
+        "--format",
+        fmt,
+        "--min-severity",
+        os.environ["MIN_SEVERITY"],
+        "--min-confidence",
+        os.environ["MIN_CONFIDENCE"],
+        "--cache-dir",
+        os.environ["ZIZMOR_CACHE_DIR"],
+    ]
+    cfg = os.environ.get("ZIZMOR_CONFIG_PATH", "").strip()
+    if cfg:
+        cmd += ["--config", cfg]
+    dbg = os.environ.get("RUNNER_DEBUG", "").strip().lower()
+    if dbg in ("1", "true", "yes", "y", "on"):
+        cmd.append("--verbose")
+    extra = (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").strip()
+    if extra:
+        cmd += shlex.split(extra)
+    cmd += paths
+    return cmd
+
+
+def _run(cmd: list[str], out: Path | None) -> int:
+    if out is None:
+        return subprocess.run(cmd, check=False).returncode
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("wb") as fh:
+        return subprocess.run(cmd, stdout=fh, check=False).returncode
+
+
+def _scan_paths():
+    if os.environ.get("USE_EXPLICIT_PATHS", "").strip().lower() != "true":
+        return ["."]
+    text = Path(os.environ["PATHS_LIST"]).read_text(encoding="utf-8")
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    return lines if lines else None
+
+
+def _pipe_plain(cmd: list[str], fh) -> int:
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if proc.stdout is None:
+        return 1
+    with proc.stdout:
+        for line in proc.stdout:
+            fh.write(line)
+    return proc.wait()
+
+
+def _sarif(batch: int, out: Path) -> int:
+    paths = _scan_paths()
+    if paths is None:
+        out.write_text(json.dumps(_EMPTY_SARIF), encoding="utf-8")
+        return 0
+
+    chunks = [list(c) for c in batched(paths, batch)]
+    if len(chunks) == 1:
+        rc = _run(_zizmor_cmd("sarif", chunks[0]), out)
+        return 1 if rc == 1 else 0
+
+    with tempfile.TemporaryDirectory(prefix="zizmor-sarif-", dir=os.environ["RUNNER_TEMP"]) as name:
+        t = Path(name)
+        parts = []
+        for i, c in enumerate(chunks):
+            part = t / f"part-{i}.sarif"
+            if _run(_zizmor_cmd("sarif", c), part) == 1:
+                return 1
+            parts.append(part)
+        _merge_sarif_parts(parts, out)
+    return 0
+
+
+def _plain(batch: int) -> int:
+    gh = os.environ.get("GITHUB_OUTPUT")
+    if not gh:
+        print("GITHUB_OUTPUT is not set", file=sys.stderr)
+        return 2
+
+    paths = _scan_paths()
+    with open(gh, "a", encoding="utf-8") as fh:
+        fh.write("zizmor-results<<EOF\n")
+        code = 0
+        if paths is not None:
+            for chunk in batched(paths, batch):
+                rc = _pipe_plain(_zizmor_cmd("plain", list(chunk)), fh)
+                if rc == 1:
+                    print("zizmor crashed; see output above.", file=sys.stderr)
+                    return 1
+                code = max(code, rc)
+        fh.write("EOF\n")
+        fh.write(f"zizmor-exit-code={code}\n")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    prog = Path(argv[0]).name if argv else "run_zizmor.py"
+    p = argparse.ArgumentParser(prog=prog)
+    sub = p.add_subparsers(dest="command", required=True)
+    ps = sub.add_parser("sarif", help="run zizmor with SARIF output")
+    ps.add_argument("--batch-size", type=int, default=400)
+    ps.add_argument("--out", type=Path, default=Path("results.sarif"))
+    pp = sub.add_parser("plain-github-output", help="append zizmor plain output to GITHUB_OUTPUT")
+    pp.add_argument("--batch-size", type=int, default=400)
+    if len(argv) < 2:
+        p.print_help(sys.stderr)
+        return 2
+    ns = p.parse_args(argv[1:])
+    if ns.command == "sarif":
+        return _sarif(ns.batch_size, ns.out)
+    return _plain(ns.batch_size)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -26,22 +26,6 @@ _EMPTY_SARIF = {
 }
 
 
-def _merge_sarif_parts(parts, dst: Path):
-    if not parts:
-        raise ValueError("no SARIF parts")
-    docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
-    if len(docs) == 1:
-        merged = docs[0]
-    else:
-        runs = []
-        for doc in docs:
-            r = doc.get("runs")
-            if isinstance(r, list):
-                runs.extend(r)
-        merged = {"$schema": docs[0].get("$schema"), "version": docs[0].get("version"), "runs": runs}
-    dst.write_text(json.dumps(merged), encoding="utf-8")
-
-
 def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
     cmd = [
         "uvx",
@@ -58,8 +42,7 @@ def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
     cfg = os.environ.get("ZIZMOR_CONFIG_PATH", "").strip()
     if cfg:
         cmd += ["--config", cfg]
-    dbg = os.environ.get("RUNNER_DEBUG", "").strip().lower()
-    if dbg in ("1", "true", "yes", "y", "on"):
+    if os.environ.get("RUNNER_DEBUG", "").strip().lower() in ("1", "true", "yes", "y", "on"):
         cmd.append("--verbose")
     extra = (os.environ.get("ZIZMOR_EXTRA_ARGS") or "").strip()
     if extra:
@@ -68,68 +51,85 @@ def _zizmor_cmd(fmt: str, paths: list[str]) -> list[str]:
     return cmd
 
 
-def _run(cmd: list[str], out: Path | None) -> int:
-    if out is None:
-        return subprocess.run(cmd, check=False).returncode
-    out.parent.mkdir(parents=True, exist_ok=True)
-    with out.open("wb") as fh:
-        return subprocess.run(cmd, stdout=fh, check=False).returncode
-
-
-def _scan_paths():
+def _scan_paths() -> list[str] | None:
     if os.environ.get("USE_EXPLICIT_PATHS", "").strip().lower() != "true":
         return ["."]
-    text = Path(os.environ["PATHS_LIST"]).read_text(encoding="utf-8")
-    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    lines = [
+        ln.strip()
+        for ln in Path(os.environ["PATHS_LIST"]).read_text(encoding="utf-8").splitlines()
+        if ln.strip()
+    ]
     return lines if lines else None
 
 
-def _pipe_plain(cmd: list[str], fh) -> int:
-    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-    if proc.stdout is None:
-        return 1
-    with proc.stdout:
-        for line in proc.stdout:
-            fh.write(line)
-    return proc.wait()
+def _zizmor_rc(rc: int) -> int:
+    # 0 = clean, 10–14 = findings by severity; only 1 is a crash.
+    return 1 if rc == 1 else 0
 
 
-def _sarif(batch: int, out: Path) -> int:
-    paths = _scan_paths()
+def _merge_sarif_parts(parts: list[Path], dst: Path) -> None:
+    docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
+    if len(docs) == 1:
+        merged = docs[0]
+    else:
+        runs = []
+        for doc in docs:
+            runs.extend(doc.get("runs") or [])
+        merged = {
+            "$schema": docs[0].get("$schema"),
+            "version": docs[0].get("version"),
+            "runs": runs,
+        }
+    dst.write_text(json.dumps(merged), encoding="utf-8")
+
+
+def _run_sarif(paths: list[str] | None, batch: int, out: Path) -> int:
     if paths is None:
         out.write_text(json.dumps(_EMPTY_SARIF), encoding="utf-8")
         return 0
 
-    chunks = [list(c) for c in batched(paths, batch)]
+    chunks = list(batched(paths, batch))
     if len(chunks) == 1:
-        rc = _run(_zizmor_cmd("sarif", chunks[0]), out)
-        return 1 if rc == 1 else 0
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("wb") as fh:
+            rc = subprocess.run(_zizmor_cmd("sarif", list(chunks[0])), stdout=fh, check=False).returncode
+        return _zizmor_rc(rc)
 
-    with tempfile.TemporaryDirectory(prefix="zizmor-sarif-", dir=os.environ["RUNNER_TEMP"]) as name:
-        t = Path(name)
-        parts = []
-        for i, c in enumerate(chunks):
-            part = t / f"part-{i}.sarif"
-            if _run(_zizmor_cmd("sarif", c), part) == 1:
+    tmp = os.environ["RUNNER_TEMP"]
+    with tempfile.TemporaryDirectory(prefix="zizmor-sarif-", dir=tmp) as name:
+        parts: list[Path] = []
+        for i, chunk in enumerate(chunks):
+            part = Path(name) / f"part-{i}.sarif"
+            with part.open("wb") as fh:
+                rc = subprocess.run(_zizmor_cmd("sarif", list(chunk)), stdout=fh, check=False).returncode
+            if rc == 1:
                 return 1
             parts.append(part)
         _merge_sarif_parts(parts, out)
     return 0
 
 
-def _plain(batch: int) -> int:
+def _run_plain(paths: list[str] | None, batch: int) -> int:
     gh = os.environ.get("GITHUB_OUTPUT")
     if not gh:
         print("GITHUB_OUTPUT is not set", file=sys.stderr)
         return 2
 
-    paths = _scan_paths()
     with open(gh, "a", encoding="utf-8") as fh:
         fh.write("zizmor-results<<EOF\n")
         code = 0
         if paths is not None:
             for chunk in batched(paths, batch):
-                rc = _pipe_plain(_zizmor_cmd("plain", list(chunk)), fh)
+                proc = subprocess.Popen(
+                    _zizmor_cmd("plain", list(chunk)),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+                if proc.stdout is None:
+                    return 1
+                fh.write(proc.stdout.read())
+                rc = proc.wait()
                 if rc == 1:
                     print("zizmor crashed; see output above.", file=sys.stderr)
                     return 1
@@ -140,21 +140,22 @@ def _plain(batch: int) -> int:
 
 
 def main(argv: list[str]) -> int:
-    prog = Path(argv[0]).name if argv else "run_zizmor.py"
-    p = argparse.ArgumentParser(prog=prog)
+    p = argparse.ArgumentParser(prog=Path(argv[0]).name if argv else "run_zizmor.py")
     sub = p.add_subparsers(dest="command", required=True)
-    ps = sub.add_parser("sarif", help="run zizmor with SARIF output")
+    ps = sub.add_parser("sarif")
     ps.add_argument("--batch-size", type=int, default=400)
     ps.add_argument("--out", type=Path, default=Path("results.sarif"))
-    pp = sub.add_parser("plain-github-output", help="append zizmor plain output to GITHUB_OUTPUT")
+    pp = sub.add_parser("plain-github-output")
     pp.add_argument("--batch-size", type=int, default=400)
     if len(argv) < 2:
         p.print_help(sys.stderr)
         return 2
+
     ns = p.parse_args(argv[1:])
+    paths = _scan_paths()
     if ns.command == "sarif":
-        return _sarif(ns.batch_size, ns.out)
-    return _plain(ns.batch_size)
+        return _run_sarif(paths, ns.batch_size, ns.out)
+    return _run_plain(paths, ns.batch_size)
 
 
 if __name__ == "__main__":

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -84,13 +84,13 @@ def _merge_sarif_parts(parts: list[Path], dst: Path) -> None:
 
 
 def _run_sarif(paths: list[str] | None, batch: int, out: Path) -> int:
+    out.parent.mkdir(parents=True, exist_ok=True)
     if paths is None:
         out.write_text(json.dumps(_EMPTY_SARIF), encoding="utf-8")
         return 0
 
     chunks = list(batched(paths, batch))
     if len(chunks) == 1:
-        out.parent.mkdir(parents=True, exist_ok=True)
         with out.open("wb") as fh:
             rc = subprocess.run(_zizmor_cmd("sarif", list(chunks[0])), stdout=fh, check=False).returncode
         return _zizmor_rc(rc)

--- a/actions/zizmor-collection-paths/run_zizmor.py
+++ b/actions/zizmor-collection-paths/run_zizmor.py
@@ -69,17 +69,32 @@ def _zizmor_rc(rc: int) -> int:
 
 def _merge_sarif_parts(parts: list[Path], dst: Path) -> None:
     docs = [json.loads(p.read_text(encoding="utf-8")) for p in parts]
-    if len(docs) == 1:
-        merged = docs[0]
-    else:
-        runs = []
-        for doc in docs:
-            runs.extend(doc.get("runs") or [])
-        merged = {
-            "$schema": docs[0].get("$schema"),
-            "version": docs[0].get("version"),
-            "runs": runs,
-        }
+    runs = [run for doc in docs for run in (doc.get("runs") or [])]
+    # Code scanning rejects multiple runs with the same tool and category:
+    # fold every batch into the first run, remapping ruleIndex.
+    if len(runs) > 1:
+        base = runs[0]
+        rules = base.setdefault("tool", {}).setdefault("driver", {}).setdefault("rules", [])
+        index_by_id = {r.get("id"): i for i, r in enumerate(rules)}
+        for run in runs[1:]:
+            run_rules = run.get("tool", {}).get("driver", {}).get("rules") or []
+            for result in run.get("results") or []:
+                rule_id = result.get("ruleId")
+                if rule_id is not None and rule_id not in index_by_id:
+                    old = result.get("ruleIndex")
+                    rule = run_rules[old] if old is not None and old < len(run_rules) else {"id": rule_id}
+                    index_by_id[rule_id] = len(rules)
+                    rules.append(rule)
+                if "ruleIndex" in result and rule_id in index_by_id:
+                    result["ruleIndex"] = index_by_id[rule_id]
+                base.setdefault("results", []).append(result)
+        runs = [base]
+    merged = {
+        "$schema": docs[0].get("$schema"),
+        "version": docs[0].get("version"),
+        "runs": runs,
+    }
+    dst.parent.mkdir(parents=True, exist_ok=True)
     dst.write_text(json.dumps(merged), encoding="utf-8")
 
 
@@ -118,25 +133,27 @@ def _run_plain(paths: list[str] | None, batch: int) -> int:
     with open(gh, "a", encoding="utf-8") as fh:
         fh.write("zizmor-results<<EOF\n")
         code = 0
-        if paths is not None:
-            for chunk in batched(paths, batch):
-                proc = subprocess.Popen(
-                    _zizmor_cmd("plain", list(chunk)),
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.STDOUT,
-                    text=True,
-                )
-                if proc.stdout is None:
-                    return 1
-                fh.write(proc.stdout.read())
-                rc = proc.wait()
-                if rc == 1:
-                    print("zizmor crashed; see output above.", file=sys.stderr)
-                    return 1
-                code = max(code, rc)
-        fh.write("EOF\n")
-        fh.write(f"zizmor-exit-code={code}\n")
-    return 0
+        crashed = False
+        try:
+            if paths is not None:
+                for chunk in batched(paths, batch):
+                    proc = subprocess.run(
+                        _zizmor_cmd("plain", list(chunk)),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        text=True,
+                        check=False,
+                    )
+                    fh.write(proc.stdout or "")
+                    if proc.returncode == 1:
+                        print("zizmor crashed; see output above.", file=sys.stderr)
+                        crashed = True
+                        break
+                    code = max(code, proc.returncode)
+        finally:
+            fh.write("EOF\n")
+            fh.write(f"zizmor-exit-code={1 if crashed else code}\n")
+    return 1 if crashed else 0
 
 
 def main(argv: list[str]) -> int:

--- a/actions/zizmor-collection-paths/test_collection_paths.py
+++ b/actions/zizmor-collection-paths/test_collection_paths.py
@@ -1,0 +1,208 @@
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import collection_paths
+
+
+class NormalizePrefixTests(unittest.TestCase):
+    def test_strips_glob_suffixes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet/vendor/**/*"), "ksonnet/vendor")
+        self.assertEqual(collection_paths.normalize_prefix_line("terraform/modules/foo/*"), "terraform/modules/foo")
+
+    def test_comments_and_blank(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line(""))
+        self.assertIsNone(collection_paths.normalize_prefix_line("  # ignore"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("# full line"))
+
+    def test_rejects_unescaped_glob(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/*/bar"))
+
+    def test_rejects_double_slash_segment(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("a//b"))
+
+    def test_normalizes_backslashes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet\\vendor"), "ksonnet/vendor")
+
+
+class ParsePrefixesTests(unittest.TestCase):
+    def test_parse_multiline(self) -> None:
+        text = """
+# skip vendor
+ksonnet/vendor
+
+terraform/modules/github.com/github-aws-runners/**/*
+"""
+        got = collection_paths.parse_prefixes_from_ignore(text)
+        self.assertEqual(got, ["ksonnet/vendor", "terraform/modules/github.com/github-aws-runners"])
+
+
+class CollectPathsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, rel: str, content: str = "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n") -> None:
+        p = self.tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def test_includes_first_party_workflow(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("./.github/workflows/ci.yml", body)
+
+    def test_skips_helper_checkout_tree(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        self._write(
+            "_shared-workflows-zizmor/actions/example/action.yaml",
+            "name: x\nruns:\n  using: composite\n  steps: []\n",
+        )
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("./.github/workflows/ci.yml", body)
+        self.assertNotIn("_shared-workflows-zizmor", body)
+        self.assertEqual(n, 1)
+
+    def test_skips_nested_workflow_under_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        self._write("ksonnet/vendor/pkg/.github/workflows/nested.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("nested.yml", body)
+        self.assertEqual(body.count("./"), 1)
+
+    def test_dependabot_at_root(self) -> None:
+        self._write(".github/dependabot.yml", "version: 2\nupdates: []\n")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        self.assertGreaterEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("dependabot.yml", body)
+
+    def test_dependabot_not_outside_dot_github(self) -> None:
+        self._write("vendor/dep/.github/dependabot.yml", "version: 2\nupdates: []\n")
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("dependabot", body)
+        self.assertIn("./.github/workflows/ci.yml", body)
+        self.assertEqual(n, 1)
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX path joining with absolute second operand")
+    def test_collect_paths_rejects_absolute_resolved_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        with self.assertRaises(ValueError) as ctx:
+            collection_paths.collect_paths(self.tmp, ["/etc"], out)
+        self.assertIn("outside repo root", str(ctx.exception).lower())
+
+
+class UnsafePrefixTests(unittest.TestCase):
+    def test_rejects_parent_segments(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("../foo"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/../bar"))
+
+    def test_rejects_absolute(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("/etc/passwd"))
+
+
+class CliTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_main_missing_ignore_file(self) -> None:
+        gh = self.tmp / "gh.txt"
+        root = self.tmp / "repo"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        paths_out = self.tmp / "paths.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_ignore_only_comments(self) -> None:
+        gh = self.tmp / "gh2.txt"
+        root = self.tmp / "repo2"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("# nothing\n\n", encoding="utf-8")
+        paths_out = self.tmp / "paths2.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_explicit_paths_when_prefix_skips_vendor(self) -> None:
+        gh = self.tmp / "gh3.txt"
+        root = self.tmp / "repo3"
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / ".github" / "workflows" / "ci.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        (root / "vendor" / ".github" / "workflows").mkdir(parents=True)
+        (root / "vendor" / ".github" / "workflows" / "nested.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("vendor\n", encoding="utf-8")
+        paths_out = self.tmp / "paths3.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        out_txt = gh.read_text(encoding="utf-8")
+        self.assertIn("use_explicit_paths=true", out_txt)
+        self.assertIn("paths_list=", out_txt)
+        listed = paths_out.read_text(encoding="utf-8")
+        self.assertIn("ci.yml", listed)
+        self.assertNotIn("nested", listed)

--- a/actions/zizmor-collection-paths/test_collection_paths.py
+++ b/actions/zizmor-collection-paths/test_collection_paths.py
@@ -1,0 +1,210 @@
+"""Tests for collection_paths."""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import collection_paths
+
+
+class NormalizePrefixTests(unittest.TestCase):
+    def test_strips_glob_suffixes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet/vendor/**/*"), "ksonnet/vendor")
+        self.assertEqual(collection_paths.normalize_prefix_line("terraform/modules/foo/*"), "terraform/modules/foo")
+
+    def test_comments_and_blank(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line(""))
+        self.assertIsNone(collection_paths.normalize_prefix_line("  # ignore"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("# full line"))
+
+    def test_rejects_unescaped_glob(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/*/bar"))
+
+    def test_rejects_double_slash_segment(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("a//b"))
+
+    def test_normalizes_backslashes(self) -> None:
+        self.assertEqual(collection_paths.normalize_prefix_line("ksonnet\\vendor"), "ksonnet/vendor")
+
+
+class ParsePrefixesTests(unittest.TestCase):
+    def test_parse_multiline(self) -> None:
+        text = """
+# skip vendor
+ksonnet/vendor
+
+terraform/modules/github.com/github-aws-runners/**/*
+"""
+        got = collection_paths.parse_prefixes_from_ignore(text)
+        self.assertEqual(got, ["ksonnet/vendor", "terraform/modules/github.com/github-aws-runners"])
+
+
+class CollectPathsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, rel: str, content: str = "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n") -> None:
+        p = self.tmp / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+
+    def test_includes_first_party_workflow(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("./.github/workflows/ci.yml", body)
+
+    def test_skips_helper_checkout_tree(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        self._write(
+            "_shared-workflows-zizmor/actions/example/action.yaml",
+            "name: x\nruns:\n  using: composite\n  steps: []\n",
+        )
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("./.github/workflows/ci.yml", body)
+        self.assertNotIn("_shared-workflows-zizmor", body)
+        self.assertEqual(n, 1)
+
+    def test_skips_nested_workflow_under_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        self._write("ksonnet/vendor/pkg/.github/workflows/nested.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, ["ksonnet/vendor"], out)
+        self.assertEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("nested.yml", body)
+        self.assertEqual(body.count("./"), 1)
+
+    def test_dependabot_at_root(self) -> None:
+        self._write(".github/dependabot.yml", "version: 2\nupdates: []\n")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        self.assertGreaterEqual(n, 1)
+        body = out.read_text(encoding="utf-8")
+        self.assertIn("dependabot.yml", body)
+
+    def test_dependabot_not_outside_dot_github(self) -> None:
+        self._write("vendor/dep/.github/dependabot.yml", "version: 2\nupdates: []\n")
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        n = collection_paths.collect_paths(self.tmp, [], out)
+        body = out.read_text(encoding="utf-8")
+        self.assertNotIn("dependabot", body)
+        self.assertIn("./.github/workflows/ci.yml", body)
+        self.assertEqual(n, 1)
+
+    @unittest.skipUnless(os.name == "posix", "requires POSIX path joining with absolute second operand")
+    def test_collect_paths_rejects_absolute_resolved_prefix(self) -> None:
+        self._write(".github/workflows/ci.yml")
+        out = self.tmp / "out.txt"
+        with self.assertRaises(ValueError) as ctx:
+            collection_paths.collect_paths(self.tmp, ["/etc"], out)
+        self.assertIn("outside repo root", str(ctx.exception).lower())
+
+
+class UnsafePrefixTests(unittest.TestCase):
+    def test_rejects_parent_segments(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("../foo"))
+        self.assertIsNone(collection_paths.normalize_prefix_line("foo/../bar"))
+
+    def test_rejects_absolute(self) -> None:
+        self.assertIsNone(collection_paths.normalize_prefix_line("/etc/passwd"))
+
+
+class CliTests(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_main_missing_ignore_file(self) -> None:
+        gh = self.tmp / "gh.txt"
+        root = self.tmp / "repo"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        paths_out = self.tmp / "paths.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_ignore_only_comments(self) -> None:
+        gh = self.tmp / "gh2.txt"
+        root = self.tmp / "repo2"
+        (root / ".github").mkdir(parents=True)
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("# nothing\n\n", encoding="utf-8")
+        paths_out = self.tmp / "paths2.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        self.assertIn("use_explicit_paths=false", gh.read_text(encoding="utf-8"))
+
+    def test_main_explicit_paths_when_prefix_skips_vendor(self) -> None:
+        gh = self.tmp / "gh3.txt"
+        root = self.tmp / "repo3"
+        (root / ".github" / "workflows").mkdir(parents=True)
+        (root / ".github" / "workflows" / "ci.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        (root / "vendor" / ".github" / "workflows").mkdir(parents=True)
+        (root / "vendor" / ".github" / "workflows" / "nested.yml").write_text(
+            "on: push\njobs: x: {runs-on: ubuntu-latest, steps: [{run: echo}]}\n",
+            encoding="utf-8",
+        )
+        ignore = root / ".github" / "zizmor-collection-ignore"
+        ignore.write_text("vendor\n", encoding="utf-8")
+        paths_out = self.tmp / "paths3.txt"
+        argv = [
+            "collection_paths.py",
+            "--repo-root",
+            str(root),
+            "--ignore-file",
+            str(ignore),
+            "--paths-out",
+            str(paths_out),
+        ]
+        with mock.patch.dict(os.environ, {"GITHUB_OUTPUT": str(gh)}, clear=False):
+            with mock.patch.object(sys, "argv", argv):
+                rc = collection_paths.main()
+        self.assertEqual(rc, 0)
+        out_txt = gh.read_text(encoding="utf-8")
+        self.assertIn("use_explicit_paths=true", out_txt)
+        self.assertIn("paths_list=", out_txt)
+        listed = paths_out.read_text(encoding="utf-8")
+        self.assertIn("ci.yml", listed)
+        self.assertNotIn("nested", listed)

--- a/actions/zizmor-collection-paths/test_collection_paths.py
+++ b/actions/zizmor-collection-paths/test_collection_paths.py
@@ -1,5 +1,3 @@
-"""Tests for collection_paths."""
-
 import os
 import shutil
 import sys

--- a/actions/zizmor-collection-paths/test_collection_paths.py
+++ b/actions/zizmor-collection-paths/test_collection_paths.py
@@ -61,19 +61,6 @@ class CollectPathsTests(unittest.TestCase):
         body = out.read_text(encoding="utf-8")
         self.assertIn("./.github/workflows/ci.yml", body)
 
-    def test_skips_helper_checkout_tree(self) -> None:
-        self._write(".github/workflows/ci.yml")
-        self._write(
-            "_shared-workflows-zizmor/actions/example/action.yaml",
-            "name: x\nruns:\n  using: composite\n  steps: []\n",
-        )
-        out = self.tmp / "out.txt"
-        n = collection_paths.collect_paths(self.tmp, [], out)
-        body = out.read_text(encoding="utf-8")
-        self.assertIn("./.github/workflows/ci.yml", body)
-        self.assertNotIn("_shared-workflows-zizmor", body)
-        self.assertEqual(n, 1)
-
     def test_skips_nested_workflow_under_prefix(self) -> None:
         self._write(".github/workflows/ci.yml")
         self._write("ksonnet/vendor/pkg/.github/workflows/nested.yml")

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -1,5 +1,3 @@
-"""Tests for run_zizmor."""
-
 import json
 import tempfile
 import unittest

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -1,0 +1,89 @@
+"""Tests for run_zizmor."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import run_zizmor
+
+
+class ZizmorCmdTests(unittest.TestCase):
+    def test_extra_args_use_shlex(self) -> None:
+        env = {
+            "ZIZMOR_VERSION": "1.24.1",
+            "MIN_SEVERITY": "low",
+            "MIN_CONFIDENCE": "low",
+            "ZIZMOR_CACHE_DIR": "/tmp/z",
+            "ZIZMOR_EXTRA_ARGS": '--audit "foo bar"',
+        }
+        with mock.patch.dict("os.environ", env, clear=False):
+            cmd = run_zizmor._zizmor_cmd("plain", [".github/workflows/ci.yml"])
+        self.assertIn("--audit", cmd)
+        idx = cmd.index("--audit")
+        self.assertEqual(cmd[idx + 1], "foo bar")
+
+
+class MergeSarifTests(unittest.TestCase):
+    def test_merge_two_parts(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            dpath = Path(d)
+            p1 = dpath / "a.sarif"
+            p2 = dpath / "b.sarif"
+            out = dpath / "out.sarif"
+            p1.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "a"}}}]}),
+                encoding="utf-8",
+            )
+            p2.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "b"}}}]}),
+                encoding="utf-8",
+            )
+            run_zizmor._merge_sarif_parts([p1, p2], out)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(len(doc["runs"]), 2)
+
+
+class SarifEmptyExplicitTests(unittest.TestCase):
+    def test_writes_minimal_sarif_when_explicit_paths_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "r.sarif"
+            env = {
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(Path(d) / "empty.txt"),
+                "RUNNER_TEMP": d,
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+                "ZIZMOR_CACHE_DIR": str(Path(d) / "cache"),
+            }
+            (Path(d) / "empty.txt").write_text("\n\n", encoding="utf-8")
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor._sarif(400, out)
+            self.assertEqual(rc, 0)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(doc.get("version"), "2.1.0")
+            self.assertEqual(doc.get("runs"), [])
+
+
+class PlainGithubOutputTests(unittest.TestCase):
+    def test_plain_github_output_empty_explicit_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            gh = Path(d) / "gh.txt"
+            empty = Path(d) / "empty.txt"
+            empty.write_text("\n\n", encoding="utf-8")
+            env = {
+                "GITHUB_OUTPUT": str(gh),
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(empty),
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+            }
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor.main(["run_zizmor.py", "plain-github-output", "--batch-size", "400"])
+            self.assertEqual(rc, 0)
+            body = gh.read_text(encoding="utf-8")
+            self.assertIn("zizmor-results<<EOF", body)
+            self.assertIn("zizmor-exit-code=0", body)

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -1,0 +1,87 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import run_zizmor
+
+
+class ZizmorCmdTests(unittest.TestCase):
+    def test_extra_args_use_shlex(self) -> None:
+        env = {
+            "ZIZMOR_VERSION": "1.24.1",
+            "MIN_SEVERITY": "low",
+            "MIN_CONFIDENCE": "low",
+            "ZIZMOR_CACHE_DIR": "/tmp/z",
+            "ZIZMOR_EXTRA_ARGS": '--audit "foo bar"',
+        }
+        with mock.patch.dict("os.environ", env, clear=False):
+            cmd = run_zizmor._zizmor_cmd("plain", [".github/workflows/ci.yml"])
+        self.assertIn("--audit", cmd)
+        idx = cmd.index("--audit")
+        self.assertEqual(cmd[idx + 1], "foo bar")
+
+
+class MergeSarifTests(unittest.TestCase):
+    def test_merge_two_parts(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            dpath = Path(d)
+            p1 = dpath / "a.sarif"
+            p2 = dpath / "b.sarif"
+            out = dpath / "out.sarif"
+            p1.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "a"}}}]}),
+                encoding="utf-8",
+            )
+            p2.write_text(
+                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "b"}}}]}),
+                encoding="utf-8",
+            )
+            run_zizmor._merge_sarif_parts([p1, p2], out)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(len(doc["runs"]), 2)
+
+
+class SarifEmptyExplicitTests(unittest.TestCase):
+    def test_writes_minimal_sarif_when_explicit_paths_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "r.sarif"
+            env = {
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(Path(d) / "empty.txt"),
+                "RUNNER_TEMP": d,
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+                "ZIZMOR_CACHE_DIR": str(Path(d) / "cache"),
+            }
+            (Path(d) / "empty.txt").write_text("\n\n", encoding="utf-8")
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor._run_sarif(None, 400, out)
+            self.assertEqual(rc, 0)
+            doc = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(doc.get("version"), "2.1.0")
+            self.assertEqual(doc.get("runs"), [])
+
+
+class PlainGithubOutputTests(unittest.TestCase):
+    def test_plain_github_output_empty_explicit_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            gh = Path(d) / "gh.txt"
+            empty = Path(d) / "empty.txt"
+            empty.write_text("\n\n", encoding="utf-8")
+            env = {
+                "GITHUB_OUTPUT": str(gh),
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(empty),
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+            }
+            with mock.patch.dict("os.environ", env, clear=False):
+                rc = run_zizmor.main(["run_zizmor.py", "plain-github-output", "--batch-size", "400"])
+            self.assertEqual(rc, 0)
+            body = gh.read_text(encoding="utf-8")
+            self.assertIn("zizmor-results<<EOF", body)
+            self.assertIn("zizmor-exit-code=0", body)

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -58,7 +58,7 @@ class SarifEmptyExplicitTests(unittest.TestCase):
             }
             (Path(d) / "empty.txt").write_text("\n\n", encoding="utf-8")
             with mock.patch.dict("os.environ", env, clear=False):
-                rc = run_zizmor._sarif(400, out)
+                rc = run_zizmor._run_sarif(None, 400, out)
             self.assertEqual(rc, 0)
             doc = json.loads(out.read_text(encoding="utf-8"))
             self.assertEqual(doc.get("version"), "2.1.0")

--- a/actions/zizmor-collection-paths/test_run_zizmor.py
+++ b/actions/zizmor-collection-paths/test_run_zizmor.py
@@ -24,23 +24,64 @@ class ZizmorCmdTests(unittest.TestCase):
 
 
 class MergeSarifTests(unittest.TestCase):
-    def test_merge_two_parts(self) -> None:
+    def test_merge_two_parts_single_run(self) -> None:
         with tempfile.TemporaryDirectory() as d:
             dpath = Path(d)
             p1 = dpath / "a.sarif"
             p2 = dpath / "b.sarif"
             out = dpath / "out.sarif"
             p1.write_text(
-                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "a"}}}]}),
+                json.dumps(
+                    {
+                        "version": "2.1.0",
+                        "$schema": "https://json.schemastore.org/sarif-2.1.0.json",
+                        "runs": [
+                            {
+                                "tool": {
+                                    "driver": {
+                                        "name": "zizmor",
+                                        "rules": [{"id": "template-injection"}],
+                                    }
+                                },
+                                "results": [
+                                    {"ruleId": "template-injection", "ruleIndex": 0, "message": {"text": "a"}}
+                                ],
+                            }
+                        ],
+                    }
+                ),
                 encoding="utf-8",
             )
             p2.write_text(
-                json.dumps({"version": "2.1.0", "runs": [{"tool": {"driver": {"name": "b"}}}]}),
+                json.dumps(
+                    {
+                        "version": "2.1.0",
+                        "runs": [
+                            {
+                                "tool": {
+                                    "driver": {
+                                        "name": "zizmor",
+                                        "rules": [{"id": "artipacked"}],
+                                    }
+                                },
+                                "results": [{"ruleId": "artipacked", "ruleIndex": 0, "message": {"text": "b"}}],
+                            }
+                        ],
+                    }
+                ),
                 encoding="utf-8",
             )
             run_zizmor._merge_sarif_parts([p1, p2], out)
             doc = json.loads(out.read_text(encoding="utf-8"))
-            self.assertEqual(len(doc["runs"]), 2)
+            self.assertEqual(len(doc["runs"]), 1)
+            run = doc["runs"][0]
+            rules = run["tool"]["driver"]["rules"]
+            self.assertEqual([r["id"] for r in rules], ["template-injection", "artipacked"])
+            results = run["results"]
+            self.assertEqual(len(results), 2)
+            by_id = {r["ruleId"]: r for r in results}
+            self.assertEqual(by_id["template-injection"]["ruleIndex"], 0)
+            self.assertEqual(by_id["artipacked"]["ruleIndex"], 1)
 
 
 class SarifEmptyExplicitTests(unittest.TestCase):
@@ -84,4 +125,33 @@ class PlainGithubOutputTests(unittest.TestCase):
             self.assertEqual(rc, 0)
             body = gh.read_text(encoding="utf-8")
             self.assertIn("zizmor-results<<EOF", body)
+            self.assertIn("EOF\n", body)
             self.assertIn("zizmor-exit-code=0", body)
+
+    def test_plain_closes_heredoc_on_crash(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            gh = Path(d) / "gh.txt"
+            paths = Path(d) / "paths.txt"
+            paths.write_text("./.github/workflows/ci.yml\n", encoding="utf-8")
+            env = {
+                "GITHUB_OUTPUT": str(gh),
+                "USE_EXPLICIT_PATHS": "true",
+                "PATHS_LIST": str(paths),
+                "ZIZMOR_VERSION": "1.24.1",
+                "MIN_SEVERITY": "low",
+                "MIN_CONFIDENCE": "low",
+                "ZIZMOR_CACHE_DIR": str(Path(d) / "cache"),
+            }
+
+            class FakeProc:
+                returncode = 1
+                stdout = "boom\n"
+
+            with mock.patch.dict("os.environ", env, clear=False):
+                with mock.patch("run_zizmor.subprocess.run", return_value=FakeProc()):
+                    rc = run_zizmor._run_plain(["./.github/workflows/ci.yml"], 400)
+            self.assertEqual(rc, 1)
+            body = gh.read_text(encoding="utf-8")
+            self.assertIn("zizmor-results<<EOF", body)
+            self.assertTrue(body.rstrip().endswith("zizmor-exit-code=1") or "zizmor-exit-code=1\n" in body)
+            self.assertIn("\nEOF\n", body)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -157,6 +157,11 @@
       "extra-files": ["README.md"],
       "initial-version": "0.1.0"
     },
+    "actions/zizmor-collection-paths": {
+      "package-name": "zizmor-collection-paths",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
     "actions/cleanup-branches": {
       "package-name": "cleanup-branches",
       "extra-files": ["README.md"],


### PR DESCRIPTION
## Summary

Repos can opt out of zizmor scanning under vendored trees (e.g. `ksonnet/vendor`) that ship upstream `.github/workflows/` copies we do not maintain.

Adds optional **`.github/zizmor-collection-ignore`** (one directory prefix per line). Wired in `reusable-zizmor.yml` via `actions/zizmor-collection-paths/`.

Tracking: https://github.com/grafana/security-appsec/issues/401

## Behavior

| Ignore file | What zizmor does |
|-------------|------------------|
| Missing, empty, or comments only | Scan `.` — **same as today** |
| Has valid prefixes | Scan only workflow-related paths **outside** ignored trees; merge SARIF from batched runs |

Prefix rules: no `..` or absolute paths; trailing `/**` / `/*` stripped. Details in `reusable-zizmor.md`.

Helper scripts run from the OIDC-pinned `shared-workflows` checkout (`_shared-workflows-zizmor/`); that checkout is never scanned.

## Tests

- **21 unit tests** — `actions/zizmor-collection-paths/` (`python3 -m unittest discover -v`)
- CI — `.github/workflows/test-zizmor-collection-paths.yml`

## E2E (no merge required)

Pilot pins this branch at `a0ded699096e4939468a229648b0268340a90c99` in `security-github-actions` `self-zizmor.yaml` (org ruleset uses the PR workflow when the PR is in that repo).

| | |
|---|---|
| PR | https://github.com/grafana/security-github-actions/pull/155 |
| Ruleset run | https://github.com/grafana/security-github-actions/actions/runs/26129732548 |

`vendor-fixture/` is in the ignore file; bait workflow under it was **not** scanned (`USE_EXPLICIT_PATHS=true` in logs).

## After merge

1. Bump `grafana/security-github-actions` `self-zizmor.yaml` to this merge SHA (org ruleset picks it up).
2. Repos add `.github/zizmor-collection-ignore` with their vendored prefixes when ready.