### PR TITLE
feat(create-github-app-token): revoke token in post-job step

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,10 @@ repos:
           - eslint
         entry: oven/bun:1.3.0@sha256:00cccad6e9c66bbacc250851f689168606aaea551ac473e908bbcf00a5645025
         files: \.[jt]s$
-        exclude: "create_github_token.js"
+        # The create-github-app-token action's JS files use Node.js globals
+        # (process, console, etc.) that the shared eslint config does not yet
+        # declare, so we exclude them.
+        exclude: "actions/create-github-app-token/.*\\.js$"
         language: docker_image
 
       - id: prettier

--- a/actions/create-github-app-token/README.md
+++ b/actions/create-github-app-token/README.md
@@ -2,6 +2,12 @@
 
 From a `grafana/` org repository, get a ephemeral GitHub API token from a GitHub App using Vault.
 
+The action automatically registers a post-job step that revokes the Vault
+lease backing the issued token, which invalidates the GitHub App token as soon
+as the job finishes (regardless of whether earlier steps succeeded or failed).
+If revocation fails for any reason, the token still expires naturally when its
+Vault lease TTL elapses.
+
 ## Inputs
 
 | Name             | Type   | Description                 | Default Value | Required |

--- a/actions/create-github-app-token/README.md
+++ b/actions/create-github-app-token/README.md
@@ -3,10 +3,11 @@
 From a `grafana/` org repository, get a ephemeral GitHub API token from a GitHub App using Vault.
 
 The action automatically registers a post-job step that revokes the Vault
-lease backing the issued token, which invalidates the GitHub App token as soon
-as the job finishes (regardless of whether earlier steps succeeded or failed).
-If revocation fails for any reason, the token still expires naturally when its
-Vault lease TTL elapses.
+token used to issue the GitHub App token. Revoking the Vault token
+cascade-revokes every lease it created, which invalidates the GitHub App token
+as soon as the job finishes (regardless of whether earlier steps succeeded or
+failed). If revocation fails for any reason, the token still expires naturally
+when its Vault lease TTL elapses.
 
 ## Inputs
 

--- a/actions/create-github-app-token/action.yaml
+++ b/actions/create-github-app-token/action.yaml
@@ -115,3 +115,7 @@ runs:
       with:
         vault_url: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net"
         vault_token: ${{ steps.auth-vault.outputs.vault_token }}
+        # The Vault instance sits behind a proxy that requires a GitHub OIDC
+        # JWT on every request. The post step mints a fresh JWT for this
+        # audience because the one captured here may have expired by then.
+        proxy_audience: "vault-github-actions-grafana-${{ inputs.vault_instance }}"

--- a/actions/create-github-app-token/action.yaml
+++ b/actions/create-github-app-token/action.yaml
@@ -86,3 +86,31 @@ runs:
         REF_SHA: ${{ steps.normalize-workflow-name.outputs.ref_sha }}
       run: |
         ${GITHUB_ACTION_PATH}/create_token.sh
+
+    # The remaining steps register a post-job step that revokes the Vault
+    # lease backing the GitHub App token, which invalidates the token. This
+    # uses a local JS sub-action because composite actions do not support a
+    # top-level `post` step. The sparse checkout makes the sub-action source
+    # available at a path resolvable by `uses: ./...`. We fall back to the
+    # caller repository / sha when `github.action_repository` is empty (which
+    # happens when this action is invoked locally for testing).
+    - name: Checkout cleanup sub-action
+      if: steps.generate-token.outputs.lease_id != ''
+      env:
+        action_repo: ${{ github.action_repository }}
+        action_ref: ${{ github.action_ref }}
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        repository: ${{ env.action_repo || github.repository }}
+        ref: ${{ env.action_ref || github.sha }}
+        path: _shared-workflows-create-github-app-token
+        sparse-checkout: actions/create-github-app-token/cleanup
+        persist-credentials: false
+
+    - name: Register post-job token cleanup
+      if: steps.generate-token.outputs.lease_id != ''
+      uses: ./_shared-workflows-create-github-app-token/actions/create-github-app-token/cleanup
+      with:
+        vault_url: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net"
+        vault_token: ${{ steps.auth-vault.outputs.vault_token }}
+        lease_id: ${{ steps.generate-token.outputs.lease_id }}

--- a/actions/create-github-app-token/action.yaml
+++ b/actions/create-github-app-token/action.yaml
@@ -88,14 +88,16 @@ runs:
         ${GITHUB_ACTION_PATH}/create_token.sh
 
     # The remaining steps register a post-job step that revokes the Vault
-    # lease backing the GitHub App token, which invalidates the token. This
-    # uses a local JS sub-action because composite actions do not support a
-    # top-level `post` step. The sparse checkout makes the sub-action source
-    # available at a path resolvable by `uses: ./...`. We fall back to the
-    # caller repository / sha when `github.action_repository` is empty (which
-    # happens when this action is invoked locally for testing).
+    # token used to issue the GitHub App token. Revoking the Vault token
+    # cascade-revokes every lease it created, which invalidates the GitHub
+    # App token as soon as the job finishes. This uses a local JS sub-action
+    # because composite actions do not support a top-level `post` step. The
+    # sparse checkout makes the sub-action source available at a path
+    # resolvable by `uses: ./...`. We fall back to the caller repository /
+    # sha when `github.action_repository` is empty (which happens when this
+    # action is invoked locally for testing).
     - name: Checkout cleanup sub-action
-      if: steps.generate-token.outputs.lease_id != ''
+      if: steps.auth-vault.outputs.vault_token != ''
       env:
         action_repo: ${{ github.action_repository }}
         action_ref: ${{ github.action_ref }}
@@ -108,9 +110,8 @@ runs:
         persist-credentials: false
 
     - name: Register post-job token cleanup
-      if: steps.generate-token.outputs.lease_id != ''
+      if: steps.auth-vault.outputs.vault_token != ''
       uses: ./_shared-workflows-create-github-app-token/actions/create-github-app-token/cleanup
       with:
         vault_url: "https://vault-github-actions.grafana-${{ inputs.vault_instance }}.net"
         vault_token: ${{ steps.auth-vault.outputs.vault_token }}
-        lease_id: ${{ steps.generate-token.outputs.lease_id }}

--- a/actions/create-github-app-token/cleanup/action.yaml
+++ b/actions/create-github-app-token/cleanup/action.yaml
@@ -11,6 +11,12 @@ inputs:
   vault_token:
     description: Vault token to revoke at the end of the job.
     required: true
+  proxy_audience:
+    description: |
+      GitHub OIDC audience for the proxy fronting Vault. The post step mints a
+      fresh ID token for this audience because the JWT used during the job may
+      have expired by the time post-job cleanup runs.
+    required: true
 runs:
   using: node20
   main: main.js

--- a/actions/create-github-app-token/cleanup/action.yaml
+++ b/actions/create-github-app-token/cleanup/action.yaml
@@ -1,0 +1,20 @@
+name: Cleanup GitHub App Token (internal)
+description: |
+  Internal helper for `create-github-app-token`. Registers a post-job step that
+  revokes the Vault lease backing the issued GitHub App installation token,
+  which in turn invalidates the token. Should not be invoked directly by users.
+inputs:
+  vault_url:
+    description: Vault base URL (e.g. https://vault-github-actions.grafana-ops.net).
+    required: true
+  vault_token:
+    description: Vault token authorized to revoke the lease.
+    required: true
+  lease_id:
+    description: The Vault lease ID associated with the GitHub App token.
+    required: true
+runs:
+  using: node20
+  main: main.js
+  post: post.js
+  post-if: always()

--- a/actions/create-github-app-token/cleanup/action.yaml
+++ b/actions/create-github-app-token/cleanup/action.yaml
@@ -1,17 +1,15 @@
 name: Cleanup GitHub App Token (internal)
 description: |
   Internal helper for `create-github-app-token`. Registers a post-job step that
-  revokes the Vault lease backing the issued GitHub App installation token,
-  which in turn invalidates the token. Should not be invoked directly by users.
+  revokes the Vault token used to issue the GitHub App installation token.
+  Revoking the Vault token cascade-revokes every lease it created, which
+  invalidates the GitHub App token. Should not be invoked directly by users.
 inputs:
   vault_url:
     description: Vault base URL (e.g. https://vault-github-actions.grafana-ops.net).
     required: true
   vault_token:
-    description: Vault token authorized to revoke the lease.
-    required: true
-  lease_id:
-    description: The Vault lease ID associated with the GitHub App token.
+    description: Vault token to revoke at the end of the job.
     required: true
 runs:
   using: node20

--- a/actions/create-github-app-token/cleanup/main.js
+++ b/actions/create-github-app-token/cleanup/main.js
@@ -1,5 +1,6 @@
-// Persist the Vault credentials and lease ID to job state so the post step can
-// revoke the lease after the user's job has finished using the token.
+// Persist the Vault credentials to job state so the post step can revoke the
+// Vault token after the user's job has finished. Revoking the token
+// cascade-revokes every lease it created, including the GitHub App token.
 //
 // Uses only Node.js built-ins so it can run as a self-contained action without
 // a bundled `node_modules`.
@@ -11,7 +12,6 @@ const fs = require("node:fs");
 const stateFile = process.env.GITHUB_STATE;
 const vaultUrl = process.env.INPUT_VAULT_URL || "";
 const vaultToken = process.env.INPUT_VAULT_TOKEN || "";
-const leaseId = process.env.INPUT_LEASE_ID || "";
 
 if (!stateFile) {
   console.log(
@@ -20,9 +20,9 @@ if (!stateFile) {
   process.exit(0);
 }
 
-if (!vaultUrl || !vaultToken || !leaseId) {
+if (!vaultUrl || !vaultToken) {
   console.log(
-    "Missing required input(s) (vault_url / vault_token / lease_id); " +
+    "Missing required input(s) (vault_url / vault_token); " +
       "post-step will be a no-op.",
   );
   process.exit(0);
@@ -34,8 +34,8 @@ if (!vaultUrl || !vaultToken || !leaseId) {
 console.log(`::add-mask::${vaultToken}`);
 
 // GITHUB_STATE supports the same heredoc format as GITHUB_ENV / GITHUB_OUTPUT.
-// Vault URLs, tokens and lease IDs do not contain newlines, but the heredoc
-// form is robust against unexpected characters such as `=`.
+// Vault URLs and tokens do not contain newlines, but the heredoc form is
+// robust against unexpected characters such as `=`.
 const delim = `ghacleanup_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 const writeState = (key, value) => {
   fs.appendFileSync(stateFile, `${key}<<${delim}\n${value}\n${delim}\n`);
@@ -43,6 +43,5 @@ const writeState = (key, value) => {
 
 writeState("vault_url", vaultUrl);
 writeState("vault_token", vaultToken);
-writeState("lease_id", leaseId);
 
-console.log("Registered Vault lease for post-job cleanup.");
+console.log("Registered Vault token for post-job revocation.");

--- a/actions/create-github-app-token/cleanup/main.js
+++ b/actions/create-github-app-token/cleanup/main.js
@@ -1,0 +1,48 @@
+// Persist the Vault credentials and lease ID to job state so the post step can
+// revoke the lease after the user's job has finished using the token.
+//
+// Uses only Node.js built-ins so it can run as a self-contained action without
+// a bundled `node_modules`.
+
+"use strict";
+
+const fs = require("node:fs");
+
+const stateFile = process.env.GITHUB_STATE;
+const vaultUrl = process.env.INPUT_VAULT_URL || "";
+const vaultToken = process.env.INPUT_VAULT_TOKEN || "";
+const leaseId = process.env.INPUT_LEASE_ID || "";
+
+if (!stateFile) {
+  console.log(
+    "GITHUB_STATE is not set; skipping registration of cleanup state.",
+  );
+  process.exit(0);
+}
+
+if (!vaultUrl || !vaultToken || !leaseId) {
+  console.log(
+    "Missing required input(s) (vault_url / vault_token / lease_id); " +
+      "post-step will be a no-op.",
+  );
+  process.exit(0);
+}
+
+// Re-mask the vault token in case any later log statement echoes the state
+// values. `auth_vault.sh` already masks it for the duration of the job, but
+// adding the mask again is harmless and defensive.
+console.log(`::add-mask::${vaultToken}`);
+
+// GITHUB_STATE supports the same heredoc format as GITHUB_ENV / GITHUB_OUTPUT.
+// Vault URLs, tokens and lease IDs do not contain newlines, but the heredoc
+// form is robust against unexpected characters such as `=`.
+const delim = `ghacleanup_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+const writeState = (key, value) => {
+  fs.appendFileSync(stateFile, `${key}<<${delim}\n${value}\n${delim}\n`);
+};
+
+writeState("vault_url", vaultUrl);
+writeState("vault_token", vaultToken);
+writeState("lease_id", leaseId);
+
+console.log("Registered Vault lease for post-job cleanup.");

--- a/actions/create-github-app-token/cleanup/main.js
+++ b/actions/create-github-app-token/cleanup/main.js
@@ -12,6 +12,7 @@ const fs = require("node:fs");
 const stateFile = process.env.GITHUB_STATE;
 const vaultUrl = process.env.INPUT_VAULT_URL || "";
 const vaultToken = process.env.INPUT_VAULT_TOKEN || "";
+const proxyAudience = process.env.INPUT_PROXY_AUDIENCE || "";
 
 if (!stateFile) {
   console.log(
@@ -20,9 +21,9 @@ if (!stateFile) {
   process.exit(0);
 }
 
-if (!vaultUrl || !vaultToken) {
+if (!vaultUrl || !vaultToken || !proxyAudience) {
   console.log(
-    "Missing required input(s) (vault_url / vault_token); " +
+    "Missing required input(s) (vault_url / vault_token / proxy_audience); " +
       "post-step will be a no-op.",
   );
   process.exit(0);
@@ -34,7 +35,7 @@ if (!vaultUrl || !vaultToken) {
 console.log(`::add-mask::${vaultToken}`);
 
 // GITHUB_STATE supports the same heredoc format as GITHUB_ENV / GITHUB_OUTPUT.
-// Vault URLs and tokens do not contain newlines, but the heredoc form is
+// The values stored here do not contain newlines, but the heredoc form is
 // robust against unexpected characters such as `=`.
 const delim = `ghacleanup_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 const writeState = (key, value) => {
@@ -43,5 +44,6 @@ const writeState = (key, value) => {
 
 writeState("vault_url", vaultUrl);
 writeState("vault_token", vaultToken);
+writeState("proxy_audience", proxyAudience);
 
 console.log("Registered Vault token for post-job revocation.");

--- a/actions/create-github-app-token/cleanup/post.js
+++ b/actions/create-github-app-token/cleanup/post.js
@@ -1,7 +1,14 @@
-// Revoke the Vault lease that backs the GitHub App installation token. This
-// runs as a post-job step, so it executes after the user's workflow has
+// Revoke the Vault token that issued the GitHub App installation token. Per
+// the Vault docs, revoking a token also revokes every dynamic secret created
+// with it, so the GitHub App token is invalidated as a side-effect:
+// https://developer.hashicorp.com/vault/api-docs/auth/token#revoke-a-token-self
+//
+// This runs as a post-job step, so it executes after the user's workflow has
 // finished using the token regardless of whether earlier steps succeeded or
 // failed (post-if: always()).
+//
+// `revoke-self` is part of Vault's built-in `default` policy, so it requires
+// no extra capability on the role.
 //
 // Uses only Node.js built-ins so it can run as a self-contained action without
 // a bundled `node_modules`.
@@ -16,12 +23,11 @@ const RETRY_BASE_DELAY_MS = 2000;
 
 const vaultUrl = process.env.STATE_vault_url || "";
 const vaultToken = process.env.STATE_vault_token || "";
-const leaseId = process.env.STATE_lease_id || "";
 
-if (!vaultUrl || !vaultToken || !leaseId) {
+if (!vaultUrl || !vaultToken) {
   console.log(
     "No cleanup state present (token creation likely failed); " +
-      "skipping Vault lease revocation.",
+      "skipping Vault token revocation.",
   );
   process.exit(0);
 }
@@ -31,24 +37,22 @@ console.log(`::add-mask::${vaultToken}`);
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const revokeLeaseOnce = () => {
+const revokeTokenOnce = () => {
   const endpoint = new URL(
-    "/v1/sys/leases/revoke",
+    "/v1/auth/token/revoke-self",
     vaultUrl.replace(/\/+$/, ""),
   );
-  const payload = JSON.stringify({ lease_id: leaseId });
 
   return new Promise((resolve) => {
     const req = https.request(
       {
-        method: "PUT",
+        method: "POST",
         hostname: endpoint.hostname,
         port: endpoint.port || 443,
         path: endpoint.pathname,
         headers: {
           "X-Vault-Token": vaultToken,
-          "Content-Type": "application/json",
-          "Content-Length": Buffer.byteLength(payload),
+          "Content-Length": 0,
         },
       },
       (res) => {
@@ -66,31 +70,29 @@ const revokeLeaseOnce = () => {
       resolve({ status: 0, body: err.message });
     });
 
-    req.write(payload);
     req.end();
   });
 };
 
-const revokeLease = async () => {
+const revokeToken = async () => {
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const { status, body } = await revokeLeaseOnce();
+    const { status, body } = await revokeTokenOnce();
 
     if (status >= 200 && status < 300) {
-      console.log(`Vault lease revoked (HTTP ${status}, lease_id=${leaseId}).`);
+      console.log(`Vault token revoked (HTTP ${status}).`);
       return;
     }
 
-    // 403 / 404 typically mean the token or lease is already gone; no point
-    // retrying.
+    // 403 / 404 typically mean the token is already gone; no point retrying.
     if (status === 403 || status === 404) {
       console.log(
-        `::warning::Vault lease revoke skipped (HTTP ${status}): ${body}`,
+        `::warning::Vault token revoke skipped (HTTP ${status}): ${body}`,
       );
       return;
     }
 
     console.log(
-      `::warning::Vault lease revoke attempt ${attempt}/${MAX_ATTEMPTS} ` +
+      `::warning::Vault token revoke attempt ${attempt}/${MAX_ATTEMPTS} ` +
         `failed (HTTP ${status}): ${body}`,
     );
 
@@ -100,13 +102,13 @@ const revokeLease = async () => {
   }
 
   console.log(
-    `::warning::Failed to revoke Vault lease after ${MAX_ATTEMPTS} attempts. ` +
-      "The token will still expire naturally when its TTL elapses.",
+    `::warning::Failed to revoke Vault token after ${MAX_ATTEMPTS} attempts. ` +
+      "The GitHub App token will still expire naturally when its TTL elapses.",
   );
 };
 
-revokeLease().catch((err) => {
+revokeToken().catch((err) => {
   // Never fail the post-step on cleanup errors — the token will expire on its
   // own and surfacing an error here would mask the real job result.
-  console.log(`::warning::Vault lease revoke errored: ${err.message}`);
+  console.log(`::warning::Vault token revoke errored: ${err.message}`);
 });

--- a/actions/create-github-app-token/cleanup/post.js
+++ b/actions/create-github-app-token/cleanup/post.js
@@ -10,6 +10,12 @@
 // `revoke-self` is part of Vault's built-in `default` policy, so it requires
 // no extra capability on the role.
 //
+// The Vault instance is fronted by a proxy that requires a GitHub OIDC JWT
+// in the `Proxy-Authorization-Token` header on every request. We mint a fresh
+// JWT here rather than reusing the one minted at job start, because GitHub
+// OIDC tokens are short-lived (~5 minutes) and may have expired by the time
+// the post step runs.
+//
 // Uses only Node.js built-ins so it can run as a self-contained action without
 // a bundled `node_modules`.
 
@@ -23,11 +29,23 @@ const RETRY_BASE_DELAY_MS = 2000;
 
 const vaultUrl = process.env.STATE_vault_url || "";
 const vaultToken = process.env.STATE_vault_token || "";
+const proxyAudience = process.env.STATE_proxy_audience || "";
+const oidcRequestUrl = process.env.ACTIONS_ID_TOKEN_REQUEST_URL || "";
+const oidcRequestToken = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN || "";
 
-if (!vaultUrl || !vaultToken) {
+if (!vaultUrl || !vaultToken || !proxyAudience) {
   console.log(
     "No cleanup state present (token creation likely failed); " +
       "skipping Vault token revocation.",
+  );
+  process.exit(0);
+}
+
+if (!oidcRequestUrl || !oidcRequestToken) {
+  console.log(
+    "::warning::ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN not set; cannot mint " +
+      "proxy JWT for Vault revoke-self. The Vault token will expire " +
+      "naturally when its TTL elapses.",
   );
   process.exit(0);
 }
@@ -37,7 +55,61 @@ console.log(`::add-mask::${vaultToken}`);
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const revokeTokenOnce = () => {
+const fetchProxyJwt = () => {
+  const url = new URL(oidcRequestUrl);
+  url.searchParams.set("audience", proxyAudience);
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      {
+        method: "GET",
+        hostname: url.hostname,
+        port: url.port || 443,
+        path: `${url.pathname}${url.search}`,
+        headers: {
+          Authorization: `Bearer ${oidcRequestToken}`,
+          Accept: "application/json",
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+            try {
+              const parsed = JSON.parse(body);
+              if (parsed.value) {
+                resolve(parsed.value);
+              } else {
+                reject(new Error("OIDC response did not contain a token"));
+              }
+            } catch (err) {
+              reject(
+                new Error(`Failed to parse OIDC response: ${err.message}`),
+              );
+            }
+          } else {
+            reject(
+              new Error(
+                `OIDC mint failed (HTTP ${res.statusCode || 0}): ${body}`,
+              ),
+            );
+          }
+        });
+      },
+    );
+
+    req.on("error", (err) => {
+      reject(err);
+    });
+
+    req.end();
+  });
+};
+
+const revokeTokenOnce = (proxyJwt) => {
   const endpoint = new URL(
     "/v1/auth/token/revoke-self",
     vaultUrl.replace(/\/+$/, ""),
@@ -52,6 +124,7 @@ const revokeTokenOnce = () => {
         path: endpoint.pathname,
         headers: {
           "X-Vault-Token": vaultToken,
+          "Proxy-Authorization-Token": `Bearer ${proxyJwt}`,
           "Content-Length": 0,
         },
       },
@@ -75,8 +148,21 @@ const revokeTokenOnce = () => {
 };
 
 const revokeToken = async () => {
+  let proxyJwt;
+  try {
+    proxyJwt = await fetchProxyJwt();
+  } catch (err) {
+    console.log(
+      `::warning::Failed to mint proxy JWT for Vault revoke-self: ${err.message}. ` +
+        "The Vault token will expire naturally when its TTL elapses.",
+    );
+    return;
+  }
+  // Mask the JWT so it never appears verbatim in subsequent log lines.
+  console.log(`::add-mask::${proxyJwt}`);
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const { status, body } = await revokeTokenOnce();
+    const { status, body } = await revokeTokenOnce(proxyJwt);
 
     if (status >= 200 && status < 300) {
       console.log(`Vault token revoked (HTTP ${status}).`);

--- a/actions/create-github-app-token/cleanup/post.js
+++ b/actions/create-github-app-token/cleanup/post.js
@@ -1,0 +1,112 @@
+// Revoke the Vault lease that backs the GitHub App installation token. This
+// runs as a post-job step, so it executes after the user's workflow has
+// finished using the token regardless of whether earlier steps succeeded or
+// failed (post-if: always()).
+//
+// Uses only Node.js built-ins so it can run as a self-contained action without
+// a bundled `node_modules`.
+
+"use strict";
+
+const https = require("node:https");
+const { URL } = require("node:url");
+
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_DELAY_MS = 2000;
+
+const vaultUrl = process.env.STATE_vault_url || "";
+const vaultToken = process.env.STATE_vault_token || "";
+const leaseId = process.env.STATE_lease_id || "";
+
+if (!vaultUrl || !vaultToken || !leaseId) {
+  console.log(
+    "No cleanup state present (token creation likely failed); " +
+      "skipping Vault lease revocation.",
+  );
+  process.exit(0);
+}
+
+// Re-mask the vault token defensively in case any log line echoes it.
+console.log(`::add-mask::${vaultToken}`);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const revokeLeaseOnce = () => {
+  const endpoint = new URL(
+    "/v1/sys/leases/revoke",
+    vaultUrl.replace(/\/+$/, ""),
+  );
+  const payload = JSON.stringify({ lease_id: leaseId });
+
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        method: "PUT",
+        hostname: endpoint.hostname,
+        port: endpoint.port || 443,
+        path: endpoint.pathname,
+        headers: {
+          "X-Vault-Token": vaultToken,
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(payload),
+        },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () => {
+          resolve({ status: res.statusCode || 0, body });
+        });
+      },
+    );
+
+    req.on("error", (err) => {
+      resolve({ status: 0, body: err.message });
+    });
+
+    req.write(payload);
+    req.end();
+  });
+};
+
+const revokeLease = async () => {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const { status, body } = await revokeLeaseOnce();
+
+    if (status >= 200 && status < 300) {
+      console.log(`Vault lease revoked (HTTP ${status}, lease_id=${leaseId}).`);
+      return;
+    }
+
+    // 403 / 404 typically mean the token or lease is already gone; no point
+    // retrying.
+    if (status === 403 || status === 404) {
+      console.log(
+        `::warning::Vault lease revoke skipped (HTTP ${status}): ${body}`,
+      );
+      return;
+    }
+
+    console.log(
+      `::warning::Vault lease revoke attempt ${attempt}/${MAX_ATTEMPTS} ` +
+        `failed (HTTP ${status}): ${body}`,
+    );
+
+    if (attempt < MAX_ATTEMPTS) {
+      await sleep(RETRY_BASE_DELAY_MS * attempt);
+    }
+  }
+
+  console.log(
+    `::warning::Failed to revoke Vault lease after ${MAX_ATTEMPTS} attempts. ` +
+      "The token will still expire naturally when its TTL elapses.",
+  );
+};
+
+revokeLease().catch((err) => {
+  // Never fail the post-step on cleanup errors — the token will expire on its
+  // own and surfacing an error here would mask the real job result.
+  console.log(`::warning::Vault lease revoke errored: ${err.message}`);
+});

--- a/actions/create-github-app-token/create_token.sh
+++ b/actions/create-github-app-token/create_token.sh
@@ -22,7 +22,9 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
         TOKEN=$(jq -r '.data.token' "${TEMP_FILE}")
+        LEASE_ID=$(jq -r '.lease_id // empty' "${TEMP_FILE}")
         echo "github_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
+        echo "lease_id=${LEASE_ID}" >> "${GITHUB_OUTPUT}"
         echo "Create GitHub Token done!"
         exit 0
     else

--- a/actions/create-github-app-token/create_token.sh
+++ b/actions/create-github-app-token/create_token.sh
@@ -22,9 +22,7 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
         TOKEN=$(jq -r '.data.token' "${TEMP_FILE}")
-        LEASE_ID=$(jq -r '.lease_id // empty' "${TEMP_FILE}")
         echo "github_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
-        echo "lease_id=${LEASE_ID}" >> "${GITHUB_OUTPUT}"
         echo "Create GitHub Token done!"
         exit 0
     else


### PR DESCRIPTION
Add a post-job step that revokes the Vault token, which invalidates the token as soon as the job finishes. If revocation fails, the token still expires naturally via its Vault lease TTL. This invalidates the Github token in cascade.

Validation here: https://github.com/grafana/deployment_tools/pull/592570