### PR TITLE
fix(create-github-app-token): remove runtime dependency on jq

### DIFF
--- a/actions/create-github-app-token/auth_vault.sh
+++ b/actions/create-github-app-token/auth_vault.sh
@@ -19,7 +19,13 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
         }" || true)
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
-        TOKEN=$(jq -r '.auth.client_token' "${TEMP_FILE}")
+        # Avoid jq so this works inside minimal containers that don't ship it (e.g. grafana/docs-base).
+        # The Vault response shape is stable and client_token never contains quotes.
+        TOKEN=$(sed -n 's/.*"client_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${TEMP_FILE}" | head -n1)
+        if [[ -z "${TOKEN}" ]]; then
+            echo "Failed to parse client_token from Vault response"
+            exit 1
+        fi
         echo "::add-mask::$TOKEN"
         echo "vault_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
         echo "Vault auth done!"

--- a/actions/create-github-app-token/create_token.sh
+++ b/actions/create-github-app-token/create_token.sh
@@ -21,7 +21,14 @@ for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
         -H "Proxy-Authorization-Token: Bearer ${GITHUB_JWT_PROXY}" || true)
 
     if [[ "${RESPONSE}" -eq 200 ]]; then
-        TOKEN=$(jq -r '.data.token' "${TEMP_FILE}")
+        # Avoid jq so this works inside minimal containers that don't ship it (e.g. grafana/docs-base).
+        # The Vault response shape is stable and the token never contains quotes.
+        TOKEN=$(sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${TEMP_FILE}" | head -n1)
+        if [[ -z "${TOKEN}" ]]; then
+            echo "Failed to parse token from Vault response"
+            exit 1
+        fi
+        echo "::add-mask::$TOKEN"
         echo "github_token=${TOKEN}" >> "${GITHUB_OUTPUT}"
         echo "Create GitHub Token done!"
         exit 0


### PR DESCRIPTION
## Summary

The composite action shells out to `jq` to parse Vault responses, which breaks any caller running it inside a container without `jq`. Replaces the two `jq` calls with narrow `sed` extractions.

## Failure example

[`publish-docs` in `grafana/business-calendar`](https://github.com/grafana/business-calendar/actions/runs/26241500119/job/77229416295) (and any other plugin using `grafana/plugin-ci-workflows`'s `cd.yml` since v8.0.0) runs inside `grafana/docs-base:latest`, which is alpine + node and has no `jq`:

```
/__w/_actions/grafana/shared-workflows/.../actions/create-github-app-token/auth_vault.sh: line 22: jq: command not found
##[error]Process completed with exit code 127.
```

Repro:
```
docker run --rm grafana/docs-base:latest sh -c 'command -v jq || echo "no jq"'
# -> no jq
```

## Test plan

- [ ] `test-create-github-app-token.yaml` still passes on `ubuntu-latest` for both `dev` and `ops` vault instances
- [ ] `publish-docs` succeeds end-to-end on a plugin repo once the new tag is consumed