### PR TITLE
feat(validate-zizmor-config): align with shared release patterns

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -23,6 +23,7 @@
     "actions/run-capslock": "0.2.2",
     "actions/azure-trusted-signing": "1.0.2",
     "actions/validate-renovate-config": "0.1.3",
+    "actions/validate-zizmor-config": "0.1.0",
     "actions/cleanup-branches": "0.2.1",
     "actions/docker-build-push-image": "0.3.3",
     "actions/docker-export-digest": "0.1.3",

--- a/actions/validate-zizmor-config/README.md
+++ b/actions/validate-zizmor-config/README.md
@@ -1,26 +1,61 @@
 # validate-zizmor-config
 
-Composite action that enforces Grafana policy on a **repo-local** `zizmor.yml` / `.github/zizmor.yml` before running zizmor.
+Validates a repo-local [zizmor](https://docs.zizmor.sh/) configuration file (`zizmor.yml` or `.github/zizmor.yml`) against Grafana policy before running zizmor.
 
-Intended to be called from [`.github/workflows/reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml).
+Intended to be called from [`.github/workflows/reusable-zizmor.yml`](../../.github/workflows/reusable-zizmor.yml), but usable as a standalone validation step.
 
 ## Inputs
 
-| Name           | Required | Description                                                                 |
-| -------------- | -------- | --------------------------------------------------------------------------- |
-| `config_path`  | yes      | Path to the config file relative to the workspace                           |
-| `sarif_output` | no       | When set, write a SARIF report to this path if validation fails (for Bench) |
+- `config_path`: Path to the zizmor config file relative to the workspace (e.g. `zizmor.yml`). Required.
+- `sarif_output`: Optional path for a SARIF report written when validation fails (used by reusable-zizmor so Grafana Bench and Loki ingestion still receive results).
 
 ## Requirements
 
-The calling job must run **`setup-uv`** (or otherwise provide `uv`) before this action, and the workspace must contain the file at `config_path`.
+The calling job must run [`astral-sh/setup-uv`](https://github.com/astral-sh/setup-uv) (or otherwise provide `uv`) before this action, and the workspace must contain the file at `config_path`.
+
+## Example workflow
+
+<!-- x-release-please-start-version -->
+
+```yaml
+name: Validate zizmor config
+
+on:
+  pull_request:
+    paths:
+      - "zizmor.yml"
+      - ".github/zizmor.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "zizmor.yml"
+      - ".github/zizmor.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+      - name: Validate zizmor config
+        uses: grafana/shared-workflows/actions/validate-zizmor-config@validate-zizmor-config/v0.1.0
+        with:
+          config_path: .github/zizmor.yml
+```
+
+<!-- x-release-please-end-version -->
 
 ## Tests
 
 From the repository root:
 
 ```bash
-cd actions/validate-zizmor-config && uv run --with pyyaml==6.0.2 python3 -m unittest discover -v
+cd actions/validate-zizmor-config && uv run --with pyyaml==6.0.3 python3 -m unittest discover -v
 ```
 
 CI: [`.github/workflows/test-validate-zizmor-config.yml`](../../.github/workflows/test-validate-zizmor-config.yml).

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -152,6 +152,11 @@
       "extra-files": ["README.md"],
       "initial-version": "0.1.0"
     },
+    "actions/validate-zizmor-config": {
+      "package-name": "validate-zizmor-config",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
     "actions/cleanup-branches": {
       "package-name": "cleanup-branches",
       "extra-files": ["README.md"],


### PR DESCRIPTION
Register `actions/validate-zizmor-config` with release-please and refresh its README to follow the conventions used by other validate-* actions (e.g. `validate-renovate-config`, `validate-policy-bot-config`) so it participates in the standard tagging and version-bump flow.

Key changes:

- Add the action to `release-please-config.json` and `.release-please-manifest.json` (initial version `0.1.0`).
- Rewrite the README around the standard layout — top-level description, `## Inputs`, `## Requirements`, and a complete `## Example workflow` block wrapped in `<!-- x-release-please-start-version -->` markers so release-please can bump the pinned version on each release.
- Bump the `pyyaml` version referenced in the README test command to match `action.yml` (`6.0.3`).

The action's behavior, `action.yml`, and Python sources are unchanged. The first release-please run will create the initial `CHANGELOG.md` and tag `validate-zizmor-config/v0.1.0`.

Follow-up to #1877 (which added the action) and #1947.