### PR TITLE
chore(reusable-zizmor): pin validate-zizmor-config to v0.2.0

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -395,7 +395,7 @@ jobs:
         id: validate-config
         continue-on-error: true
         if: ${{ inputs.always-use-default-config == false && steps.setup-config.outputs.zizmor-config == '' && steps.setup-config.outputs['repo-local-zizmor-config'] != '' }}
-        uses: grafana/shared-workflows/actions/validate-zizmor-config@c2b99bc7ec69e11c1c4e4cba5cbc9197f794b683
+        uses: grafana/shared-workflows/actions/validate-zizmor-config@84a7e1d935b2240eb5dcc3ee4dc0a6692057e94d # validate-zizmor-config/v0.2.0
         with:
           config_path: ${{ steps.setup-config.outputs['repo-local-zizmor-config'] }}
           sarif_output: results.sarif


### PR DESCRIPTION
Replace the unreleased SHA pin for `validate-zizmor-config` in `reusable-zizmor.yml` with the tagged `validate-zizmor-config/v0.2.0` release, now that the action is registered with release-please.

The full commit SHA is kept per the repo's action-pinning policy; the version comment makes the pin readable and trackable by Renovate.

Follow-up to the release-please registration of `validate-zizmor-config`.