### PR TITLE
feat(wait-for-docker-publish): add action to wait for image to appear in a registry

### DIFF
--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -1,0 +1,87 @@
+name: Test wait-for-docker-publish action
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - actions/wait-for-docker-publish/**
+      - .github/workflows/test-wait-for-docker-publish.yml
+
+  pull_request:
+    paths:
+      - actions/wait-for-docker-publish/**
+      - .github/workflows/test-wait-for-docker-publish.yml
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  success-after-retry:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Pre-pull a small base image
+        run: docker pull hello-world:latest
+
+      - name: Tag image for local registry
+        env:
+          TARGET: localhost:5000/test:run-${{ github.run_id }}
+        run: docker tag hello-world:latest "${TARGET}"
+
+      - name: Schedule a delayed push to the local registry
+        env:
+          TARGET: localhost:5000/test:run-${{ github.run_id }}
+        run: |
+          # Push begins at t≈20s, after the action's first two backoff sleeps
+          # (5s + 10s = 15s elapsed). Forces at least two failed attempts
+          # before success.
+          ( sleep 20 && docker push "${TARGET}" ) &
+          echo "$!" > /tmp/pusher.pid
+
+      - name: Record start time
+        id: start
+        run: echo "epoch=$(date +%s)" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for the image
+        id: wait
+        uses: ./actions/wait-for-docker-publish
+        with:
+          image: localhost:5000/test:run-${{ github.run_id }}
+          timeout: 2m
+
+      - name: Assert retry behaviour
+        env:
+          START: ${{ steps.start.outputs.epoch }}
+          OUTCOME: ${{ steps.wait.outcome }}
+        run: |
+          elapsed=$(( $(date +%s) - START ))
+          echo "elapsed=${elapsed}s outcome=${OUTCOME}"
+          [ "${OUTCOME}" = "success" ] || { echo "expected success, got ${OUTCOME}"; exit 1; }
+          # 5s + 10s = 15s of backoff before the push lands at t=20s.
+          # Allow 13s lower bound to absorb small scheduling skew.
+          [ "${elapsed}" -ge 13 ] || { echo "exited too quickly (${elapsed}s) — loop did not retry"; exit 1; }
+          [ "${elapsed}" -le 90 ] || { echo "took too long (${elapsed}s) — loop is misbehaving"; exit 1; }
+
+      - name: Stop background pusher
+        if: always()
+        run: kill "$(cat /tmp/pusher.pid)" 2>/dev/null || true

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -40,12 +40,12 @@ jobs:
 
       - name: Tag image for ttl.sh
         env:
-          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
+          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}-${{ github.run_attempt }}:1h
         run: docker tag hello-world:latest "${TARGET}"
 
       - name: Schedule a delayed push to ttl.sh
         env:
-          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
+          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}-${{ github.run_attempt }}:1h
         run: |
           # 20s delay forces the action past its first two backoff sleeps (5s+10s).
           # setsid -f detaches the pusher so it survives this step exit — GHA
@@ -63,7 +63,7 @@ jobs:
         id: wait
         uses: ./actions/wait-for-docker-publish
         with:
-          image: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
+          image: ttl.sh/wait-for-docker-publish-${{ github.run_id }}-${{ github.run_attempt }}:1h
           timeout: 2m
 
       - name: Assert retry behaviour
@@ -105,7 +105,7 @@ jobs:
         continue-on-error: true
         uses: ./actions/wait-for-docker-publish
         with:
-          image: library/hello-world:never-real-${{ github.run_id }}
+          image: library/hello-world:never-real-${{ github.run_id }}-${{ github.run_attempt }}
           timeout: 20s
 
       - name: Assert timeout behaviour

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -89,3 +89,39 @@ jobs:
       - name: Show pusher log
         if: always()
         run: cat /tmp/pusher.log 2>/dev/null || echo "no pusher log"
+
+  timeout-path:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Record start time
+        id: start
+        run: echo "epoch=$(date +%s)" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait for image that will never appear
+        id: wait
+        continue-on-error: true
+        uses: ./actions/wait-for-docker-publish
+        with:
+          image: library/hello-world:never-real-${{ github.run_id }}
+          timeout: 20s
+
+      - name: Assert timeout behaviour
+        env:
+          START: ${{ steps.start.outputs.epoch }}
+          OUTCOME: ${{ steps.wait.outcome }}
+        run: |
+          elapsed=$(( $(date +%s) - START ))
+          echo "elapsed=${elapsed}s outcome=${OUTCOME}"
+          [ "${OUTCOME}" = "failure" ] || { echo "expected failure, got ${OUTCOME}"; exit 1; }
+          [ "${elapsed}" -ge 18 ] || { echo "exited too quickly: ${elapsed}s"; exit 1; }
+          [ "${elapsed}" -le 35 ] || { echo "took way too long: ${elapsed}s"; exit 1; }

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -24,11 +24,6 @@ permissions:
 jobs:
   success-after-retry:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
@@ -43,14 +38,14 @@ jobs:
       - name: Pre-pull a small base image
         run: docker pull hello-world:latest
 
-      - name: Tag image for local registry
+      - name: Tag image for ttl.sh
         env:
-          TARGET: localhost:5000/test:run-${{ github.run_id }}
+          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
         run: docker tag hello-world:latest "${TARGET}"
 
-      - name: Schedule a delayed push to the local registry
+      - name: Schedule a delayed push to ttl.sh
         env:
-          TARGET: localhost:5000/test:run-${{ github.run_id }}
+          TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
         run: |
           # Push begins at t≈20s, after the action's first two backoff sleeps
           # (5s + 10s = 15s elapsed). Forces at least two failed attempts
@@ -58,7 +53,12 @@ jobs:
           #
           # A plain backgrounded subshell would be killed when this step exits
           # (GHA terminates the step's process group). `setsid -f` forks and
-          # puts the child in its own session/process group, so it survives.
+          # puts the child in its own session, so it survives.
+          #
+          # ttl.sh is an anonymous, HTTPS-served, ephemeral OCI registry — the
+          # image expires after the tag's TTL. Used because `docker manifest
+          # inspect` defaults to HTTPS and doesn't fall back to HTTP for
+          # localhost registries like `docker push` does.
           setsid -f bash -c "sleep 20 && docker push '${TARGET}'" \
             </dev/null >/tmp/pusher.log 2>&1
 
@@ -70,7 +70,7 @@ jobs:
         id: wait
         uses: ./actions/wait-for-docker-publish
         with:
-          image: localhost:5000/test:run-${{ github.run_id }}
+          image: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
           timeout: 2m
 
       - name: Assert retry behaviour

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -47,18 +47,11 @@ jobs:
         env:
           TARGET: ttl.sh/wait-for-docker-publish-${{ github.run_id }}:1h
         run: |
-          # Push begins at t≈20s, after the action's first two backoff sleeps
-          # (5s + 10s = 15s elapsed). Forces at least two failed attempts
-          # before success.
-          #
-          # A plain backgrounded subshell would be killed when this step exits
-          # (GHA terminates the step's process group). `setsid -f` forks and
-          # puts the child in its own session, so it survives.
-          #
-          # ttl.sh is an anonymous, HTTPS-served, ephemeral OCI registry — the
-          # image expires after the tag's TTL. Used because `docker manifest
-          # inspect` defaults to HTTPS and doesn't fall back to HTTP for
-          # localhost registries like `docker push` does.
+          # 20s delay forces the action past its first two backoff sleeps (5s+10s).
+          # setsid -f detaches the pusher so it survives this step exit — GHA
+          # kills backgrounded subshells. ttl.sh is used (instead of registry:2
+          # on localhost) because `docker manifest inspect` defaults to HTTPS
+          # and won't fall back to HTTP.
           setsid -f bash -c "sleep 20 && docker push '${TARGET}'" \
             </dev/null >/tmp/pusher.log 2>&1
 

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -125,3 +125,42 @@ jobs:
           [ "${OUTCOME}" = "failure" ] || { echo "expected failure, got ${OUTCOME}"; exit 1; }
           [ "${elapsed}" -ge 18 ] || { echo "exited too quickly: ${elapsed}s"; exit 1; }
           [ "${elapsed}" -le 35 ] || { echo "took way too long: ${elapsed}s"; exit 1; }
+
+  rejects-untagged-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Record start time
+        id: start
+        run: echo "epoch=$(date +%s)" >> "${GITHUB_OUTPUT}"
+
+      - name: Wait with untagged image
+        id: wait
+        continue-on-error: true
+        uses: ./actions/wait-for-docker-publish
+        with:
+          image: grafana/grafana
+          # Big timeout so a broken implementation that ignores validation
+          # would visibly hang past our assertion's upper bound.
+          timeout: 5m
+
+      - name: Assert fast-fail
+        env:
+          START: ${{ steps.start.outputs.epoch }}
+          OUTCOME: ${{ steps.wait.outcome }}
+        run: |
+          elapsed=$(( $(date +%s) - START ))
+          echo "elapsed=${elapsed}s outcome=${OUTCOME}"
+          [ "${OUTCOME}" = "failure" ] || { echo "expected failure, got ${OUTCOME}"; exit 1; }
+          # Validation must fire in well under a second; allow 5s for harness overhead.
+          [ "${elapsed}" -le 5 ] || { echo "validation did not fast-fail (${elapsed}s)"; exit 1; }
+

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -163,4 +163,3 @@ jobs:
           [ "${OUTCOME}" = "failure" ] || { echo "expected failure, got ${OUTCOME}"; exit 1; }
           # Validation must fire in well under a second; allow 5s for harness overhead.
           [ "${elapsed}" -le 5 ] || { echo "validation did not fast-fail (${elapsed}s)"; exit 1; }
-

--- a/.github/workflows/test-wait-for-docker-publish.yml
+++ b/.github/workflows/test-wait-for-docker-publish.yml
@@ -55,8 +55,12 @@ jobs:
           # Push begins at t≈20s, after the action's first two backoff sleeps
           # (5s + 10s = 15s elapsed). Forces at least two failed attempts
           # before success.
-          ( sleep 20 && docker push "${TARGET}" ) &
-          echo "$!" > /tmp/pusher.pid
+          #
+          # A plain backgrounded subshell would be killed when this step exits
+          # (GHA terminates the step's process group). `setsid -f` forks and
+          # puts the child in its own session/process group, so it survives.
+          setsid -f bash -c "sleep 20 && docker push '${TARGET}'" \
+            </dev/null >/tmp/pusher.log 2>&1
 
       - name: Record start time
         id: start
@@ -82,6 +86,6 @@ jobs:
           [ "${elapsed}" -ge 13 ] || { echo "exited too quickly (${elapsed}s) — loop did not retry"; exit 1; }
           [ "${elapsed}" -le 90 ] || { echo "took too long (${elapsed}s) — loop is misbehaving"; exit 1; }
 
-      - name: Stop background pusher
+      - name: Show pusher log
         if: always()
-        run: kill "$(cat /tmp/pusher.pid)" 2>/dev/null || true
+        run: cat /tmp/pusher.log 2>/dev/null || echo "no pusher log"

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -31,5 +31,6 @@
     "actions/component-change-detection": "1.0.1",
     "actions/socket-export-sbom": "0.1.1",
     "actions/issues-update-project-status": "0.2.0",
-    "actions/go-flaky-tests": "0.1.0"
+    "actions/go-flaky-tests": "0.1.0",
+    "actions/wait-for-docker-publish": "0.1.0"
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -31,5 +31,6 @@
     "actions/component-change-detection": "1.0.1",
     "actions/socket-export-sbom": "0.1.1",
     "actions/issues-update-project-status": "0.1.1",
-    "actions/go-flaky-tests": "0.1.0"
+    "actions/go-flaky-tests": "0.1.0",
+    "actions/wait-for-docker-publish": "0.1.0"
 }

--- a/actions/wait-for-docker-publish/CHANGELOG.md
+++ b/actions/wait-for-docker-publish/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -1,13 +1,11 @@
 # wait-for-docker-publish
 
-Composite action that polls an OCI registry until the given image reference is
-published, or fails after a timeout. Used to bridge Grafana's async
-GAR→DockerHub mirror: after pushing to Google Artifact Registry with a
-short-lived OIDC token, downstream consumers use this action to wait for the
-mirror service to replicate the image to DockerHub before pulling.
-
-The action is registry-agnostic — it just calls `docker manifest inspect` in a
-retry loop — but the load-bearing use case is the GAR→DockerHub mirror.
+Polls an OCI registry until the given image reference is published, or fails
+after a timeout. The load-bearing use case is Grafana's async GAR→DockerHub
+mirror: after pushing to GAR with a short-lived OIDC token, downstream
+consumers use this action to wait for the mirror to replicate the image to
+DockerHub before pulling. Mechanism is `docker manifest inspect` in a retry
+loop, so the action works against any OCI-conformant registry.
 
 ## Inputs
 

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -1,0 +1,5 @@
+# wait-for-docker-publish
+
+Composite action that polls an OCI registry until the given image reference is published, or fails after a timeout.
+
+(Full docs added in Task 8.)

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -43,6 +43,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
     steps:
       - id: push
         uses: grafana/shared-workflows/actions/docker-build-push-image@docker-build-push-image/v0.3.3

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -9,12 +9,12 @@ loop, so the action works against any OCI-conformant registry.
 
 ## Inputs
 
-| Name               | Required | Default | Description                                                                                                                                                                                                                                        |
-| ------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `image`            | yes      | —       | OCI image reference. **Must include a `:tag` or an `@sha256:…` digest** (or both). No implicit `:latest`. Accepted shapes: `repo:tag`, `repo@sha256:…`, `repo:tag@sha256:…`. Digest-pinned refs are recommended for the GAR→DockerHub mirror flow. |
-| `timeout`          | no       | `10m`   | Total wall-clock budget. Accepts `s`/`m`/`h` suffixes.                                                                                                                                                                                             |
-| `initial-interval` | no       | `5s`    | First sleep after a miss.                                                                                                                                                                                                                          |
-| `max-interval`     | no       | `60s`   | Upper bound on the exponential backoff.                                                                                                                                                                                                            |
+| Name               | Required | Default | Description                                                                        |
+| ------------------ | -------- | ------- | ---------------------------------------------------------------------------------- |
+| `image`            | yes      | —       | OCI image reference. **Must include a `:tag` or an `@sha256:…` digest** (or both). |
+| `timeout`          | no       | `10m`   | Total wall-clock budget. Accepts `s`/`m`/`h` suffixes.                             |
+| `initial-interval` | no       | `5s`    | First sleep after a miss.                                                          |
+| `max-interval`     | no       | `60s`   | Upper bound on the exponential backoff.                                            |
 
 ## Outputs
 
@@ -23,12 +23,7 @@ None. The step exits 0 on success and 1 on timeout.
 ## Behaviour
 
 - Polling cadence: `initial-interval`, then doubling each miss up to `max-interval` (default `5s, 10s, 20s, 40s, 60s, 60s, …`).
-- Every error mode that isn't success simply causes another retry until the timeout — including transient DNS, registry 5xx, and even an unauthenticated lookup of a private repo. A typo will eat the full timeout budget.
 - Auth is delegated to the Docker CLI's normal credential lookup (`~/.docker/config.json` + credential helpers). Run `grafana/shared-workflows/actions/dockerhub-login` or `docker/login-action` before this step for private images.
-
-## Requirements
-
-- Docker CLI on the runner. The action does not install it; every existing docker-using action in this repo assumes it is present.
 
 ## Usage
 
@@ -61,9 +56,6 @@ jobs:
       - name: Wait for DockerHub mirror
         uses: grafana/shared-workflows/actions/wait-for-docker-publish@wait-for-docker-publish/v0.1.0
         with:
-          # Digest-pinned ref: the mirror replicates content addressably,
-          # so as soon as this digest is reachable on DockerHub the mirror
-          # has caught up to the GAR push.
           image: grafana/myrepo@${{ needs.publish.outputs.digest }}
 ```
 
@@ -81,6 +73,5 @@ Tag-only example (sufficient when tags are not reused):
 
 ## Non-goals
 
-- Verifying that a moving tag now points to a specific digest. Pinning by digest in the `image` input checks digest _reachability_, not the tag→digest binding. Sufficient for the mirror case (the mirror replicates tag binding and content together) but not for general "wait for `:latest` to be repointed" scenarios.
+- Verifying that a moving tag now points to a specific digest. Pinning by digest in the `image` input checks digest _reachability_, but not that tag now points at a specific digest.
 - Verifying that a manifest list contains all expected platforms.
-- Running on runners without a Docker CLI.

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -11,12 +11,12 @@ retry loop — but the load-bearing use case is the GAR→DockerHub mirror.
 
 ## Inputs
 
-| Name | Required | Default | Description |
-| --- | --- | --- | --- |
-| `image` | yes | — | OCI image reference. **Must include a `:tag` or an `@sha256:…` digest** (or both). No implicit `:latest`. Accepted shapes: `repo:tag`, `repo@sha256:…`, `repo:tag@sha256:…`. Digest-pinned refs are recommended for the GAR→DockerHub mirror flow. |
-| `timeout` | no | `10m` | Total wall-clock budget. Accepts `s`/`m`/`h` suffixes. |
-| `initial-interval` | no | `5s` | First sleep after a miss. |
-| `max-interval` | no | `60s` | Upper bound on the exponential backoff. |
+| Name               | Required | Default | Description                                                                                                                                                                                                                                        |
+| ------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`            | yes      | —       | OCI image reference. **Must include a `:tag` or an `@sha256:…` digest** (or both). No implicit `:latest`. Accepted shapes: `repo:tag`, `repo@sha256:…`, `repo:tag@sha256:…`. Digest-pinned refs are recommended for the GAR→DockerHub mirror flow. |
+| `timeout`          | no       | `10m`   | Total wall-clock budget. Accepts `s`/`m`/`h` suffixes.                                                                                                                                                                                             |
+| `initial-interval` | no       | `5s`    | First sleep after a miss.                                                                                                                                                                                                                          |
+| `max-interval`     | no       | `60s`   | Upper bound on the exponential backoff.                                                                                                                                                                                                            |
 
 ## Outputs
 
@@ -81,6 +81,6 @@ Tag-only example (sufficient when tags are not reused):
 
 ## Non-goals
 
-- Verifying that a moving tag now points to a specific digest. Pinning by digest in the `image` input checks digest *reachability*, not the tag→digest binding. Sufficient for the mirror case (the mirror replicates tag binding and content together) but not for general "wait for `:latest` to be repointed" scenarios.
+- Verifying that a moving tag now points to a specific digest. Pinning by digest in the `image` input checks digest _reachability_, not the tag→digest binding. Sufficient for the mirror case (the mirror replicates tag binding and content together) but not for general "wait for `:latest` to be repointed" scenarios.
 - Verifying that a manifest list contains all expected platforms.
 - Running on runners without a Docker CLI.

--- a/actions/wait-for-docker-publish/README.md
+++ b/actions/wait-for-docker-publish/README.md
@@ -1,5 +1,86 @@
 # wait-for-docker-publish
 
-Composite action that polls an OCI registry until the given image reference is published, or fails after a timeout.
+Composite action that polls an OCI registry until the given image reference is
+published, or fails after a timeout. Used to bridge Grafana's async
+GAR→DockerHub mirror: after pushing to Google Artifact Registry with a
+short-lived OIDC token, downstream consumers use this action to wait for the
+mirror service to replicate the image to DockerHub before pulling.
 
-(Full docs added in Task 8.)
+The action is registry-agnostic — it just calls `docker manifest inspect` in a
+retry loop — but the load-bearing use case is the GAR→DockerHub mirror.
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `image` | yes | — | OCI image reference. **Must include a `:tag` or an `@sha256:…` digest** (or both). No implicit `:latest`. Accepted shapes: `repo:tag`, `repo@sha256:…`, `repo:tag@sha256:…`. Digest-pinned refs are recommended for the GAR→DockerHub mirror flow. |
+| `timeout` | no | `10m` | Total wall-clock budget. Accepts `s`/`m`/`h` suffixes. |
+| `initial-interval` | no | `5s` | First sleep after a miss. |
+| `max-interval` | no | `60s` | Upper bound on the exponential backoff. |
+
+## Outputs
+
+None. The step exits 0 on success and 1 on timeout.
+
+## Behaviour
+
+- Polling cadence: `initial-interval`, then doubling each miss up to `max-interval` (default `5s, 10s, 20s, 40s, 60s, 60s, …`).
+- Every error mode that isn't success simply causes another retry until the timeout — including transient DNS, registry 5xx, and even an unauthenticated lookup of a private repo. A typo will eat the full timeout budget.
+- Auth is delegated to the Docker CLI's normal credential lookup (`~/.docker/config.json` + credential helpers). Run `grafana/shared-workflows/actions/dockerhub-login` or `docker/login-action` before this step for private images.
+
+## Requirements
+
+- Docker CLI on the runner. The action does not install it; every existing docker-using action in this repo assumes it is present.
+
+## Usage
+
+Primary use case — waiting for a GAR-pushed image to be mirrored to DockerHub:
+
+<!-- x-release-please-start-version -->
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - id: push
+        uses: grafana/shared-workflows/actions/docker-build-push-image@docker-build-push-image/v0.3.3
+        with:
+          registries: "gar"
+          push: true
+          tags: |
+            ${{ github.sha }}
+
+  wait-for-mirror:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for DockerHub mirror
+        uses: grafana/shared-workflows/actions/wait-for-docker-publish@wait-for-docker-publish/v0.1.0
+        with:
+          # Digest-pinned ref: the mirror replicates content addressably,
+          # so as soon as this digest is reachable on DockerHub the mirror
+          # has caught up to the GAR push.
+          image: grafana/myrepo@${{ needs.publish.outputs.digest }}
+```
+
+Tag-only example (sufficient when tags are not reused):
+
+```yaml
+- name: Wait for DockerHub mirror
+  uses: grafana/shared-workflows/actions/wait-for-docker-publish@wait-for-docker-publish/v0.1.0
+  with:
+    image: grafana/myrepo:${{ github.sha }}
+    timeout: 15m
+```
+
+<!-- x-release-please-end-version -->
+
+## Non-goals
+
+- Verifying that a moving tag now points to a specific digest. Pinning by digest in the `image` input checks digest *reachability*, not the tag→digest binding. Sufficient for the mirror case (the mirror replicates tag binding and content together) but not for general "wait for `:latest` to be repointed" scenarios.
+- Verifying that a manifest list contains all expected platforms.
+- Running on runners without a Docker CLI.

--- a/actions/wait-for-docker-publish/action.yaml
+++ b/actions/wait-for-docker-publish/action.yaml
@@ -1,0 +1,34 @@
+name: Wait for Docker publish
+description: >-
+  Poll an OCI registry until the given image reference is published, or fail
+  after a timeout. Designed for waiting on the DockerHub side of Grafana's
+  async GAR→DockerHub mirror.
+
+inputs:
+  image:
+    description: >-
+      Full image reference. Must include a :tag or @sha256:... digest (e.g.
+      grafana/grafana:11.0.0 or grafana/grafana@sha256:...). No implicit
+      :latest; fails fast if both are missing.
+    required: true
+  timeout:
+    description: Total wall-clock budget (e.g. 10m, 600s, 1h).
+    default: "10m"
+  initial-interval:
+    description: First sleep after a miss (e.g. 5s).
+    default: "5s"
+  max-interval:
+    description: Upper bound on the backoff (e.g. 60s).
+    default: "60s"
+
+runs:
+  using: composite
+  steps:
+    - name: Wait for image
+      shell: bash
+      env:
+        IMAGE: ${{ inputs.image }}
+        TIMEOUT: ${{ inputs.timeout }}
+        INITIAL_INTERVAL: ${{ inputs.initial-interval }}
+        MAX_INTERVAL: ${{ inputs.max-interval }}
+      run: ${{ github.action_path }}/wait.sh

--- a/actions/wait-for-docker-publish/action.yaml
+++ b/actions/wait-for-docker-publish/action.yaml
@@ -7,9 +7,7 @@ description: >-
 inputs:
   image:
     description: >-
-      Full image reference. Must include a :tag or @sha256:... digest (e.g.
-      grafana/grafana:11.0.0 or grafana/grafana@sha256:...). No implicit
-      :latest; fails fast if both are missing.
+      Full image reference. Must include a :tag or @sha256:... digest
     required: true
   timeout:
     description: Total wall-clock budget (e.g. 10m, 600s, 1h).

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -56,5 +56,39 @@ timeout_s=$(parse_duration "$TIMEOUT")
 initial_s=$(parse_duration "$INITIAL_INTERVAL")
 max_s=$(parse_duration "$MAX_INTERVAL")
 
-echo "wait-for-docker-publish: parsed timeout=${timeout_s}s initial=${initial_s}s max=${max_s}s (polling loop not yet implemented)"
-exit 1
+start=$SECONDS
+deadline=$(( start + timeout_s ))
+interval=$initial_s
+attempt=1
+err_file="$(mktemp)"
+trap 'rm -f "$err_file"' EXIT
+
+echo "wait-for-docker-publish: polling for ${IMAGE} (timeout ${timeout_s}s)"
+
+while true; do
+  : > "$err_file"
+  if docker manifest inspect "$IMAGE" >/dev/null 2>"$err_file"; then
+    echo "image found after $(( SECONDS - start ))s on attempt ${attempt}"
+    exit 0
+  fi
+
+  last_err="$(tr '\n' ' ' < "$err_file")"
+  remaining=$(( deadline - SECONDS ))
+  if (( remaining <= 0 )); then
+    echo "::error::timed out after ${TIMEOUT} waiting for ${IMAGE}; last error: ${last_err}"
+    exit 1
+  fi
+
+  sleep_for=$interval
+  if (( sleep_for > remaining )); then
+    sleep_for=$remaining
+  fi
+  echo "attempt ${attempt}: not yet available, sleeping ${sleep_for}s (elapsed $(( SECONDS - start ))s / ${timeout_s}s); last error: ${last_err}"
+  sleep "$sleep_for"
+
+  interval=$(( interval * 2 ))
+  if (( interval > max_s )); then
+    interval=$max_s
+  fi
+  attempt=$(( attempt + 1 ))
+done

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "::error::wait-for-docker-publish: not yet implemented"
+exit 1

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -51,6 +51,17 @@ timeout_s=$(parse_duration "$TIMEOUT")
 initial_s=$(parse_duration "$INITIAL_INTERVAL")
 max_s=$(parse_duration "$MAX_INTERVAL")
 
+# Guard against hot-polling. A zero interval would make sleep a no-op and
+# spin the loop until the timeout.
+if (( initial_s < 1 )); then
+  echo "::error::initial-interval must be at least 1s; got '${INITIAL_INTERVAL}'"
+  exit 1
+fi
+if (( max_s < 1 )); then
+  echo "::error::max-interval must be at least 1s; got '${MAX_INTERVAL}'"
+  exit 1
+fi
+
 start=$SECONDS
 deadline=$(( start + timeout_s ))
 interval=$initial_s

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -51,8 +51,6 @@ timeout_s=$(parse_duration "$TIMEOUT")
 initial_s=$(parse_duration "$INITIAL_INTERVAL")
 max_s=$(parse_duration "$MAX_INTERVAL")
 
-# Guard against hot-polling. A zero interval would make sleep a no-op and
-# spin the loop until the timeout.
 if (( initial_s < 1 )); then
   echo "::error::initial-interval must be at least 1s; got '${INITIAL_INTERVAL}'"
   exit 1

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -1,5 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "::error::wait-for-docker-publish: not yet implemented"
+: "${IMAGE:?IMAGE env var is required}"
+
+validate_image() {
+  local image="$1"
+
+  # Has @sha256:... digest? Accept.
+  if [[ "$image" == *"@sha256:"* ]]; then
+    return 0
+  fi
+
+  # For refs with a registry path like 'localhost:5000/repo:tag', strip up to
+  # the last '/' so we look for the tag colon, not the registry port. Bare
+  # refs without a slash (e.g. 'localhost:5000') are left as-is and treated
+  # as name:tag — matching Docker CLI's own ref parser, which is intentionally
+  # lenient at this layer; bad refs surface as docker errors during polling.
+  local after_slash="${image##*/}"
+
+  # Has ':tag' after the last slash? Accept.
+  if [[ "$after_slash" == *":"* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+if ! validate_image "$IMAGE"; then
+  echo "::error::IMAGE must include a tag (repo:tag) or digest (repo@sha256:...); got '${IMAGE}'"
+  exit 1
+fi
+
+# Loop not yet implemented.
+echo "::error::wait-for-docker-publish: polling loop not yet implemented"
 exit 1

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -31,6 +31,30 @@ if ! validate_image "$IMAGE"; then
   exit 1
 fi
 
-# Loop not yet implemented.
-echo "::error::wait-for-docker-publish: polling loop not yet implemented"
+parse_duration() {
+  local v="$1"
+  local n="${v%[smh]}"
+
+  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+    echo "::error::duration '${v}' is not a valid number with optional s/m/h suffix" >&2
+    return 1
+  fi
+
+  case "$v" in
+    *h) echo "$(( n * 3600 ))" ;;
+    *m) echo "$(( n * 60 ))" ;;
+    *s) echo "$n" ;;
+    *)  echo "$n" ;;  # bare number = seconds
+  esac
+}
+
+: "${TIMEOUT:=10m}"
+: "${INITIAL_INTERVAL:=5s}"
+: "${MAX_INTERVAL:=60s}"
+
+timeout_s=$(parse_duration "$TIMEOUT")
+initial_s=$(parse_duration "$INITIAL_INTERVAL")
+max_s=$(parse_duration "$MAX_INTERVAL")
+
+echo "wait-for-docker-publish: parsed timeout=${timeout_s}s initial=${initial_s}s max=${max_s}s (polling loop not yet implemented)"
 exit 1

--- a/actions/wait-for-docker-publish/wait.sh
+++ b/actions/wait-for-docker-publish/wait.sh
@@ -6,19 +6,14 @@ set -euo pipefail
 validate_image() {
   local image="$1"
 
-  # Has @sha256:... digest? Accept.
   if [[ "$image" == *"@sha256:"* ]]; then
     return 0
   fi
 
-  # For refs with a registry path like 'localhost:5000/repo:tag', strip up to
-  # the last '/' so we look for the tag colon, not the registry port. Bare
-  # refs without a slash (e.g. 'localhost:5000') are left as-is and treated
-  # as name:tag — matching Docker CLI's own ref parser, which is intentionally
-  # lenient at this layer; bad refs surface as docker errors during polling.
+  # Strip up to the last '/' so a registry port (e.g. localhost:5000) isn't
+  # mistaken for a tag.
   local after_slash="${image##*/}"
 
-  # Has ':tag' after the last slash? Accept.
   if [[ "$after_slash" == *":"* ]]; then
     return 0
   fi
@@ -44,7 +39,7 @@ parse_duration() {
     *h) echo "$(( n * 3600 ))" ;;
     *m) echo "$(( n * 60 ))" ;;
     *s) echo "$n" ;;
-    *)  echo "$n" ;;  # bare number = seconds
+    *)  echo "$n" ;;
   esac
 }
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -196,6 +196,11 @@
       "package-name": "issues-update-project-status",
       "extra-files": ["README.md"],
       "initial-version": "0.1.0"
+    },
+    "actions/wait-for-docker-publish": {
+      "package-name": "wait-for-docker-publish",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
     }
   },
   "release-type": "simple",


### PR DESCRIPTION
Wait for an image to appear in an OCI registry, or fail after a timeout. Used to bridge the async GAR→DockerHub mirror, consumers can gate downstream work on the DockerHub side catching up.

Polls \`docker manifest inspect\` with exponential backoff until success or timeout.