### PR TITLE
feat(get-vault-secrets)!: remove export_env option, use JSON output always

### DIFF
--- a/.github/workflows/check-drone-signature.yaml
+++ b/.github/workflows/check-drone-signature.yaml
@@ -94,7 +94,8 @@ jobs:
           path: _shared-workflows-check-drone-signature
           persist-credentials: false
 
-      - name: Retrieve drone-signature-checker token
+      - id: get-secrets
+        name: Retrieve drone-signature-checker token
         uses: ./_shared-workflows-check-drone-signature/actions/get-vault-secrets
         with:
           common_secrets: |
@@ -116,6 +117,7 @@ jobs:
         env:
           DRONE_CONFIG_PATH: ${{ inputs.drone_config_path }}
           DRONE_SERVER: ${{ inputs.drone_server }}
+          DRONE_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).DRONE_TOKEN }}
         run: |
           # Run drone sign command
           drone sign --save ${{ github.repository }} "${DRONE_CONFIG_PATH}"

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -632,7 +632,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get Prometheus secrets from Vault
+      - id: get-secrets
+        name: Get Prometheus secrets from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@4e6a096e033d00f25363adb1dc75b7e56ecdb7c6
         with:
           common_secrets: |
@@ -652,6 +653,9 @@ jobs:
           BENCH_SERVICE_VERSION: ${{ github.sha }}
           # renovate: datasource=github-releases packageName=grafana/grafana-bench
           BENCH_VERSION: "v1.0.10"
+          PROMETHEUS_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_URL }}
+          PROMETHEUS_USER: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_USER }}
+          PROMETHEUS_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_PASSWORD }}
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)

--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -592,7 +592,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Get Prometheus secrets from Vault
+      - id: get-secrets
+        name: Get Prometheus secrets from Vault
         uses: grafana/shared-workflows/actions/get-vault-secrets@4e6a096e033d00f25363adb1dc75b7e56ecdb7c6
         with:
           common_secrets: |
@@ -612,6 +613,9 @@ jobs:
           BENCH_SERVICE_VERSION: ${{ github.sha }}
           # renovate: datasource=github-releases packageName=grafana/grafana-bench
           BENCH_VERSION: "v1.0.10"
+          PROMETHEUS_URL: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_URL }}
+          PROMETHEUS_USER: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_USER }}
+          PROMETHEUS_PASSWORD: ${{ fromJSON(steps.get-secrets.outputs.secrets).PROMETHEUS_PASSWORD }}
         run: |
           BENCH_IMAGE="ghcr.io/grafana/grafana-bench:${BENCH_VERSION}"
           SARIF_FILE=$(find . -name "*.sarif" -type f | head -n 1)

--- a/.github/workflows/test-get-vault-secrets.yaml
+++ b/.github/workflows/test-get-vault-secrets.yaml
@@ -72,7 +72,7 @@ jobs:
             exit 1
           fi
         env:
-          INSTANCE: ${{ env.INSTANCE }}
+          INSTANCE: ${{ fromJSON(steps.test-vault-action.outputs.secrets).INSTANCE }}
 
       - name: Ensure 'invalid' errored
         if: matrix.instance == 'invalid' && steps.test-vault-action.outcome != 'failure'

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -29,5 +29,5 @@ runs:
     - name: Log in to Docker Hub
       uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
-        username: ${{ env.DOCKERHUB_USERNAME }}
-        password: ${{ env.DOCKERHUB_PASSWORD }}
+        username: ${{ fromJSON(steps.get-secrets.outputs.secrets).DOCKERHUB_USERNAME }}
+        password: ${{ fromJSON(steps.get-secrets.outputs.secrets).DOCKERHUB_PASSWORD }}

--- a/actions/get-vault-secrets/README.md
+++ b/actions/get-vault-secrets/README.md
@@ -8,48 +8,9 @@ The secret format is defined here: <https://github.com/hashicorp/vault-action>
 
 ## Examples
 
-### Using Environment Variables (default)
+To access the secrets, you need to read from the JSON `secrets` output of the action: `${{ fromJSON(steps.get-secrets.outputs.secrets).SECRET1 }}`.
 
-<!-- x-release-please-start-version -->
-
-```yaml
-name: CI
-on:
-  pull_request:
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    # These permissions are needed to assume roles from Github's OIDC.
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.3.2
-        with:
-          # Secrets placed in the ci/common/<path> path in Vault
-          common_secrets: |
-            ENVVAR1=test-secret:testing
-          # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
-          repo_secrets: |
-            ENVVAR2=test-secret:key1
-
-      # Use the secrets
-      # You can use the envvars directly in scripts
-      - name: echo
-        run: |
-          echo "$ENVVAR1"
-          echo "${ENVVAR2}"
-```
-
-<!-- x-release-please-end-version -->
-
-### Using Outputs
-
-You can also use the action with `export_env: false` to get secrets as outputs instead of environment variables:
+_Secrets are no longer automatically exposed as environment variables, as these are accessible to all steps and can easily be leaked by malicious code. Instead, secrets should be exposed as environment variables only to the trusted steps that require them._
 
 <!-- x-release-please-start-version -->
 
@@ -77,8 +38,6 @@ jobs:
           # Secrets placed in the ci/repo/grafana/<repo>/<path> path in Vault
           repo_secrets: |
             SECRET2=test-secret:key1
-          # Set to false to get secrets as outputs instead of environment variables
-          export_env: false
 
       # Use the secrets from the JSON output in the env block
       - name: echo
@@ -91,5 +50,3 @@ jobs:
 ```
 
 <!-- x-release-please-end-version -->
-
-This approach is useful when you need to pass secrets to other actions or reusable workflows as inputs, while keeping them secure. It's also beneficial when you want to limit which steps have access to the secrets, as environment variables are available to all subsequent steps in a job, whereas outputs require explicit passing to each step that needs them.

--- a/actions/get-vault-secrets/action.yaml
+++ b/actions/get-vault-secrets/action.yaml
@@ -27,11 +27,6 @@ inputs:
       The Vault instance to use (`dev` or `ops`). Defaults to `ops`.
     default: ops
 
-  export_env:
-    description: |
-      Whether to export secrets as environment variables, making them available to all subsequent steps. Defaults to `true`.
-    default: "true"
-
   ignore_missing:
     description: |
       When set to true, prevents the action from failing when a secret does not exist.
@@ -123,5 +118,5 @@ runs:
           Proxy-Authorization-Token: Bearer ${{ steps.get-github-jwt-token.outputs.github-jwt }}
         secrets: |
           ${{ steps.translate-secrets.outputs.secrets }}
-        exportEnv: ${{ inputs.export_env }}
+        exportEnv: false # Never expose secrets as environment variables, as they can be stolen by malicious code
         ignoreNotFound: ${{ inputs.ignore_missing }}

--- a/actions/issues-update-project-status/action.yaml
+++ b/actions/issues-update-project-status/action.yaml
@@ -44,7 +44,8 @@ runs:
         path: _shared-workflows-issues-update-project-status
         persist-credentials: false
 
-    - name: Get vault secrets
+    - id: get-secrets
+      name: Get vault secrets
       uses: ./_shared-workflows-issues-update-project-status/actions/get-vault-secrets
       with:
         common_secrets: |
@@ -59,8 +60,8 @@ runs:
     - id: get-token
       uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
       with:
-        app-id: ${{ env.APP_ID }}
-        private-key: ${{ env.PRIVATE_KEY }}
+        app-id: ${{ fromJSON(steps.get-secrets.outputs.secrets).APP_ID }}
+        private-key: ${{ fromJSON(steps.get-secrets.outputs.secrets).PRIVATE_KEY }}
         owner: ${{ github.repository_owner }}
 
     - name: Update project item status

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -39,11 +39,13 @@ runs:
         path: _shared-workflows-slack
         persist-credentials: false
 
-    - name: Get a Slack token
+    - id: get-secrets
+      name: Get a Slack token
       uses: ./_shared-workflows-slack/actions/get-vault-secrets
       with:
         common_secrets: |
           SLACK_BOT_TOKEN=slack-notifications:oauth-token
+
     - name: Send Slack Message
       id: send-slack-message
       uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
@@ -51,7 +53,7 @@ runs:
         payload-templated: ${{ inputs.payload-templated }}
         method: ${{ inputs.method }}
         payload: ${{ inputs.payload }}
-        token: ${{ env.SLACK_BOT_TOKEN }}
+        token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SLACK_BOT_TOKEN }}
 
     # Cleanup checkout directory
     - name: Cleanup shared workflows checkout

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -107,7 +107,7 @@ runs:
       id: run
       shell: bash
       env:
-        ARGO_TOKEN: ${{ env.ARGO_TOKEN }}
+        ARGO_TOKEN: ${{ fromJSON(steps.get-argo-token.outputs.secrets).ARGO_TOKEN }}
         EXTRA_ARGS: ${{ inputs.extra_args }}
         INSTANCE: ${{ inputs.instance }}
         LOG_LEVEL: ${{ inputs.log_level }}


### PR DESCRIPTION
`${{ env.MY_SECRET }}` -> `${{ fromJSON(steps.get-secrets.outputs.secrets).MY_SECRET }}`

To provide some extra protection against the risk of malicious code running in a step (e.g., during dependency installation) and dumping all environment variables, force folks to rely on the JSON output for getting secrets and only exposing them to specific steps that need them, rather than all steps.