### PR TITLE
feat(cleanup-branches): add "skip-regex" input to skip branches matching a regex

### DIFF
--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -4,11 +4,12 @@ Composite action (step) to query for branches that are not in an open PR, and de
 
 ## Inputs
 
-| Name       | Type     | Description                                                                                                                                                                        | Default Value         | Required |
-| ---------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
-| `token`    | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`) | `${{ github.token }}` | true     |
-| `dry-run`  | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                           | `'true'`              | true     |
-| `max-date` | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                          | `"2 weeks ago"`       | false    |
+| Name          | Type     | Description                                                                                                                                                                        | Default Value         | Required |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
+| `token`       | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`) | `${{ github.token }}` | true     |
+| `dry-run`     | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                           | `'true'`              | true     |
+| `max-date`    | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                          | `"2 weeks ago"`       | false    |
+| `skip-regex`  | `string` | Branches matching this regex pattern will be skipped and not deleted. Leave empty to disable.                                                                                      | `""`                  | false    |
 
 ## Examples
 

--- a/actions/cleanup-branches/README.md
+++ b/actions/cleanup-branches/README.md
@@ -4,12 +4,12 @@ Composite action (step) to query for branches that are not in an open PR, and de
 
 ## Inputs
 
-| Name          | Type     | Description                                                                                                                                                                        | Default Value         | Required |
-| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
-| `token`       | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`) | `${{ github.token }}` | true     |
-| `dry-run`     | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                           | `'true'`              | true     |
-| `max-date`    | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                          | `"2 weeks ago"`       | false    |
-| `skip-regex`  | `string` | Branches matching this regex pattern will be skipped and not deleted. Leave empty to disable.                                                                                      | `""`                  | false    |
+| Name         | Type     | Description                                                                                                                                                                        | Default Value         | Required |
+| ------------ | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------- |
+| `token`      | `string` | GitHub token used to authenticate with `gh`. Requires permission to query for protected branches and delete branches (`contents: write`) and pull requests (`pull_requests: read`) | `${{ github.token }}` | true     |
+| `dry-run`    | `bool`   | If `'true'`, then the action will print branches to be deleted, but will not delete them                                                                                           | `'true'`              | true     |
+| `max-date`   | `string` | Value passed to `date -d`; a human readable date string. Maximum date of the head ref of a branch in order to be deleted.                                                          | `"2 weeks ago"`       | false    |
+| `skip-regex` | `string` | Branches matching this regex pattern will be skipped and not deleted. Leave empty to disable.                                                                                      | `""`                  | false    |
 
 ## Examples
 

--- a/actions/cleanup-branches/action.yml
+++ b/actions/cleanup-branches/action.yml
@@ -15,6 +15,9 @@ inputs:
       Value provided to `date -d={}. From `man date`: "The --date=STRING is a mostly free format human readable date string such as "Sun, 29 Feb 2004 16:21:42 -0800" or "2004-02-29 16:21:42" or even "next Thursday".  A date string may
        contain items indicating calendar date, time of day, time zone, day of week, relative time, relative date, and numbers.  An empty string indicates the beginning of the day.  The
        date string format is more complex than is easily documented here but is fully described in the info documentation."
+  skip-regex:
+    default: ""
+    description: "Branches matching this regex pattern will be skipped and not deleted. Leave empty to disable."
 runs:
   using: composite
   steps:
@@ -24,6 +27,7 @@ runs:
         GH_TOKEN: ${{ inputs.token }}
         DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         MAX_DATE: ${{ inputs.max-date }}
+        SKIP_REGEX: ${{ inputs.skip-regex }}
       run: |
         #!/usr/bin/env bash
         # Fetch all branches from remote. This is basically `git fetch --unshallow` but also fetches branches.
@@ -56,6 +60,9 @@ runs:
                 break
               fi
             done
+          fi
+          if [ "$found" != 1 ] && [ -n "$SKIP_REGEX" ] && [[ "$branch" =~ $SKIP_REGEX ]]; then
+            found=1
           fi
           if [ "$found" != 1 ]; then
             to_delete+=("$branch")


### PR DESCRIPTION
## Description

Added a new input parameter for the `cleanup-branches` workflow to skip certain branches that match a Regex. Useful for PoCs/Hackathon that you want to keep for a while.