### PR TITLE
fix(zizmor): support pull_request events in auto-delete job

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -692,8 +692,8 @@ jobs:
       always() &&
       inputs.auto-delete-dangerous-branches &&
       needs.analysis.outputs.has-dangerous-triggers == 'true' &&
-      github.event_name == 'push' &&
-      github.ref != format('refs/heads/{0}', github.event.repository.default_branch)
+      (github.event_name == 'push' || github.event_name == 'pull_request') &&
+      (github.event_name != 'push' || github.ref != format('refs/heads/{0}', github.event.repository.default_branch))
     runs-on: ${{ inputs.runs-on }}
     permissions:
       contents: write
@@ -713,7 +713,7 @@ jobs:
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
-          REF: ${{ github.ref }}
+          REF: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.head_ref) || github.ref }}
           REPO: ${{ github.repository }}
         run: |
           gh api -X DELETE "repos/${REPO}/git/${REF}"
@@ -722,8 +722,8 @@ jobs:
         id: slack-payload
         env:
           REPO: ${{ github.repository }}
-          REF_NAME: ${{ github.ref_name }}
-          ACTOR: ${{ github.actor }}
+          REF_NAME: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          ACTOR: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login || github.actor }}
           SHA: ${{ github.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SLACK_CHANNEL_ID: ${{ inputs.auto-delete-slack-channel-id }}


### PR DESCRIPTION
## Summary

- Org-required workflows deployed via rulesets only fire `pull_request` events, not `push`. The auto-delete job was skipped in those repos because it required `github.event_name == 'push'`.
- Extend the condition to also accept `pull_request` events, and resolve the correct branch ref (`github.head_ref`) and actor (`github.event.pull_request.user.login`) for PR events.

## Test plan

- Trigger auto-delete via a push event to a non-default branch with a dangerous-triggers finding (existing behavior).
- Trigger auto-delete via a pull_request event from an org-required workflow ruleset with a dangerous-triggers finding.
- Verify Slack notification shows the correct branch name and actor in both cases.