### PR TITLE
fix(zizmor): pass payload-templated: false to send-slack-message

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -798,6 +798,7 @@ jobs:
         with:
           method: chat.postMessage
           payload: ${{ steps.slack-payload.outputs.payload }}
+          payload-templated: false
 
       - name: Fail if branch deletion failed
         if: steps.delete-branch.outcome == 'failure'


### PR DESCRIPTION
## Summary

- The `send-slack-message` action passes `payload-templated` through to `slackapi/slack-github-action`, which expects a YAML boolean. Omitting it sends an empty string, causing the action to fail with: `Input does not meet YAML 1.2 "Core Schema" specification: payload-templated`.
- Explicitly set `payload-templated: false` in the `delete-vulnerable-branch` job's Slack notification step.

Fixes the failure seen in https://github.com/grafana/sigil/actions/runs/26596504712.

## Test plan

- [ ] Verify the `delete-vulnerable-branch` job's Slack step no longer fails with the YAML boolean error.