### PR TITLE
fix(send-slack-message): v1 back-compat shim for new get-vault-secrets

### DIFF
--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -32,6 +32,7 @@ runs:
   using: composite
   steps:
     - name: Get a Slack token
+      id: get-secrets
       uses: grafana/shared-workflows/actions/get-vault-secrets@main
       with:
         common_secrets: |
@@ -45,4 +46,4 @@ runs:
         slack-message: ${{ inputs.slack-message }}
         update-ts: ${{ inputs.update-ts }}
       env:
-        SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        SLACK_BOT_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Branched off v1.0.0. Reads `SLACK_BOT_TOKEN` from get-vault-secrets' JSON output instead of env so v1-pinned consumers keep working after #1957. No input changes.

Do not merge — will be tagged as `send-slack-message/v1.0.1` for v1 consumers to SHA-bump to. PR is for audit only.