### PR TITLE
fix(send-slack-message): default payload-templated to false

### DIFF
--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -11,6 +11,7 @@ inputs:
   payload-templated:
     description: "To replace templated variables provided from the step env or default GitHub event context and payload, set the payload-templated variable to true"
     required: false
+    default: "false"
 outputs:
   time:
     value: ${{ steps.send-slack-message.outputs.time }}


### PR DESCRIPTION
slackapi/slack-github-action v3 calls `core.getBooleanInput` on `payload-templated` and errors on the empty string the wrapper emits when consumers don't set the input. Setting `default: "false"` so the input is optional in practice.