### PR TITLE
fix: reference sibling actions directly instead of checkout

### DIFF
--- a/actions/argo-lint/action.yaml
+++ b/actions/argo-lint/action.yaml
@@ -15,22 +15,8 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout
-      env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-argo-lint
-        persist-credentials: false
-
     - name: Setup Argo
-      uses: ./_shared-workflows-argo-lint/actions/setup-argo
+      uses: grafana/shared-workflows/actions/setup-argo@f02682926bde2aa45a1a8b74409c94508d8952ec # setup-argo/v1.2.0
       with:
         version: ${{ inputs.argo-version }}
 

--- a/actions/dockerhub-login/action.yaml
+++ b/actions/dockerhub-login/action.yaml
@@ -4,23 +4,9 @@ description: Using the shared Grafana Labs DockerHub credentials, log in to Dock
 runs:
   using: composite
   steps:
-    - name: Checkout shared workflows
-      env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-dockerhub-login
-        persist-credentials: false
-
     - name: Get secrets for DockerHub login
       id: get-secrets
-      uses: ./_shared-workflows-dockerhub-login/actions/get-vault-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
       with:
         common_secrets: |
           DOCKERHUB_USERNAME=dockerhub:username

--- a/actions/issues-update-project-status/action.yaml
+++ b/actions/issues-update-project-status/action.yaml
@@ -30,27 +30,11 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Checkout shared workflows
-      env:
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-issues-update-project-status
-        persist-credentials: false
-
     - id: get-token
-      uses: ./_shared-workflows-issues-update-project-status/actions/create-github-app-token
+      uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
       with:
         github_app: ${{ inputs.github-app }}
         permission_set: ${{ inputs.permission-set }}
-
-    - name: Remove shared workflows checkout
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: rm -rf _shared-workflows-issues-update-project-status
 
     - name: Update project item status
       shell: bash

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -59,16 +59,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout
-      env:
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-push-to-gcs
-        persist-credentials: false
     - name: Resolve GCP project
       id: resolve-project
       shell: bash
@@ -86,7 +76,7 @@ runs:
         echo "project=${PROJECT}" | tee -a ${GITHUB_OUTPUT}
     - name: Login to GCS
       id: login-to-gcs
-      uses: ./_shared-workflows-push-to-gcs/actions/login-to-gcs
+      uses: grafana/shared-workflows/actions/login-to-gcs@6a97ef28077dbb66da3582aad604aef980cd1787 # login-to-gcs/v0.3.0
       with:
         bucket: ${{ inputs.bucket }}
         environment: ${{ inputs.environment }}
@@ -115,17 +105,6 @@ runs:
         predefinedAcl: ${{ inputs.use_wif_auth == 'true' && ' ' || inputs.predefinedAcl }} # when using WIF auth, we cannot use predefinedAcl
         gzip: ${{ inputs.gzip }}
         process_gcloudignore: false
-
-    - name: Cleanup checkout directory
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: |
-        # Check that the directory looks OK before removing it
-        if ! [ -d "_shared-workflows-push-to-gcs/.git" ]; then
-          echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
-          exit 0
-        fi
-        rm -rf _shared-workflows-push-to-gcs
 
     - name: Delete Google Application Credentials file
       if: ${{ inputs.delete_credentials_file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}

--- a/actions/send-slack-message/action.yaml
+++ b/actions/send-slack-message/action.yaml
@@ -29,20 +29,9 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout shared workflows
-      env:
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-slack
-        persist-credentials: false
-
     - id: get-secrets
       name: Get a Slack token
-      uses: ./_shared-workflows-slack/actions/get-vault-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
       with:
         common_secrets: |
           SLACK_BOT_TOKEN=slack-notifications:oauth-token
@@ -55,15 +44,3 @@ runs:
         method: ${{ inputs.method }}
         payload: ${{ inputs.payload }}
         token: ${{ fromJSON(steps.get-secrets.outputs.secrets).SLACK_BOT_TOKEN }}
-
-    # Cleanup checkout directory
-    - name: Cleanup shared workflows checkout
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: |
-        # Check that the directory looks OK before removing it
-        if ! [ -d "_shared-workflows-slack/.git" ]; then
-          echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
-          exit 0
-        fi
-        rm -rf _shared-workflows-slack


### PR DESCRIPTION
Several composite actions checked out the entire shared-workflows repository just to reference a sibling action via a local path, adding checkout and cleanup steps to every run.

This replaces those checkouts with direct pinned references (`uses: grafana/shared-workflows/actions/<name>@<sha> # <name>/vX.Y.Z`), pinned to the full commit SHA of each action's latest release:

- `send-slack-message` → `get-vault-secrets/v2.0.0`
- `dockerhub-login` → `get-vault-secrets/v2.0.0`
- `argo-lint` → `setup-argo/v1.2.0`
- `issues-update-project-status` → `create-github-app-token/v0.3.1`
- `push-to-gcs` → `login-to-gcs/v0.3.0`

Actions that need the repository contents for source code or scripts (`trigger-argo-workflow`, `docker-build-push-image`, `docker-import-digests-push-manifest`, `lint-pr-title`) keep their checkout.

Note: forks of shared-workflows previously resolved sibling actions from the fork at the calling ref (`github.action_repository`/`github.action_ref`); these actions now always use the pinned upstream release.