### PR TITLE
fix: remove shared-workflows checkout from composite actions

### DIFF
--- a/actions/docker-build-push-image/action.yaml
+++ b/actions/docker-build-push-image/action.yaml
@@ -170,17 +170,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout shared-workflows
-      env:
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-docker-build-push-image
-        persist-credentials: false
-
     - name: Set registries
       id: registries
       shell: bash
@@ -207,8 +196,7 @@ runs:
         REGISTRY: ${{ inputs.gar-registry }}
         GH_REPO: ${{ github.repository }}
       run: |
-        chmod +x ./_shared-workflows-docker-build-push-image/actions/docker-build-push-image/gar-setup-project-vars.sh
-        ./_shared-workflows-docker-build-push-image/actions/docker-build-push-image/gar-setup-project-vars.sh
+        bash "${GITHUB_ACTION_PATH}/gar-setup-project-vars.sh"
 
     - name: Setup DockerHub variables
       if: ${{ steps.registries.outputs.include-dockerhub == 'true' }}
@@ -218,8 +206,7 @@ runs:
         DOCKERHUB_IMAGE: ${{ inputs.dockerhub-repository }}
         DOCKERHUB_REGISTRY: ${{ inputs.dockerhub-registry }}
       run: |
-        chmod +x ./_shared-workflows-docker-build-push-image/actions/docker-build-push-image/dockerhub-setup-project-vars.sh
-        ./_shared-workflows-docker-build-push-image/actions/docker-build-push-image/dockerhub-setup-project-vars.sh
+        bash "${GITHUB_ACTION_PATH}/dockerhub-setup-project-vars.sh"
 
     - name: Finalize build vars
       id: setup-vars
@@ -266,11 +253,11 @@ runs:
 
     - name: Login to GAR
       if: ${{ inputs.push == 'true' && steps.registries.outputs.include-gar == 'true' }}
-      uses: ./_shared-workflows-docker-build-push-image/actions/login-to-gar
+      uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
 
     - name: Login to DockerHub
       if: ${{ inputs.push == 'true' && steps.registries.outputs.include-dockerhub == 'true' }}
-      uses: ./_shared-workflows-docker-build-push-image/actions/dockerhub-login
+      uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
@@ -371,18 +358,6 @@ runs:
         ssh: ${{ inputs.ssh }}
         tags: ${{ inputs.include-tags-in-push == 'true' && steps.meta.outputs.tags || steps.setup-vars.outputs.images }}
         target: ${{ inputs.target }}
-
-    - name: Cleanup checkout directory
-      if: ${{ !cancelled() }}
-      shell: bash
-      run: |
-        # Check that the directory looks OK before removing it
-        if ! [ -d "_shared-workflows-docker-build-push-image/.git" ]; then
-          echo "::warning Not removing shared workflows directory: doesn't look like a git repository"
-          exit 0
-        fi
-
-        rm -rf _shared-workflows-docker-build-push-image
 
     - name: Delete Google Application Credentials file
       if: ${{ always() && inputs.gar-delete-credentials-file == 'true' && env.GOOGLE_APPLICATION_CREDENTIALS != '' }}

--- a/actions/docker-import-digests-push-manifest/action.yaml
+++ b/actions/docker-import-digests-push-manifest/action.yaml
@@ -35,17 +35,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Checkout shared-workflows
-      env:
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-docker-import-digests-push-manifest
-        persist-credentials: false
-
     - name: Download digests
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
@@ -110,11 +99,11 @@ runs:
 
     - name: Login to GAR
       if: ${{ steps.prepare-vars.outputs.include-gar == 'true' }}
-      uses: ./_shared-workflows-docker-import-digests-push-manifest/actions/login-to-gar
+      uses: grafana/shared-workflows/actions/login-to-gar@12c87e5aa323694c820c1ff3d8e47e8237e05136 # login-to-gar/v1.0.2
 
     - name: Login to DockerHub
       if: ${{ steps.prepare-vars.outputs.include-dockerhub == 'true' }}
-      uses: ./_shared-workflows-docker-import-digests-push-manifest/actions/dockerhub-login
+      uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
 
     - name: Extract metadata (tags, labels) for Docker
       id: meta
@@ -172,7 +161,7 @@ runs:
       with:
         go-version: "1.25"
         cache: true
-        cache-dependency-path: _shared-workflows-docker-import-digests-push-manifest/actions/docker-import-digests-push-manifest/go.sum
+        cache-dependency-path: ${{ github.action_path }}/go.sum
 
     - name: Generate manifest summary
       id: summary
@@ -181,7 +170,9 @@ runs:
       run: |
         set -euo pipefail
 
-        cd _shared-workflows-docker-import-digests-push-manifest/actions/docker-import-digests-push-manifest
+        # The runner downloads the full action repository into its actions
+        # cache; GITHUB_ACTION_PATH points at this action's directory there.
+        cd "${GITHUB_ACTION_PATH}"
 
         mapfile -t TAGS < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
 

--- a/actions/lint-pr-title/action.yml
+++ b/actions/lint-pr-title/action.yml
@@ -15,31 +15,23 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout shared-workflows repository
-      env:
-        action_repo: "${{ github.action_repository || 'grafana/shared-workflows' }}"
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-lint-pr-title
-        persist-credentials: false
-
+    # The runner downloads the full action repository into its actions cache;
+    # github.action_path points at this action's directory there, so the
+    # workspace repository root is two levels up.
     - name: Install bun package manager
       uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
       with:
-        bun-version-file: _shared-workflows-lint-pr-title/.bun-version
+        bun-version-file: ${{ github.action_path }}/../../.bun-version
 
     - name: Install dependencies
       shell: sh
-      working-directory: _shared-workflows-lint-pr-title
+      working-directory: ${{ github.action_path }}/../..
       run: |
         bun install --frozen-lockfile --production --filter lint-pr-title
 
     - name: Lint PR title
       shell: sh
-      working-directory: _shared-workflows-lint-pr-title/actions/lint-pr-title
+      working-directory: ${{ github.action_path }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
         INPUT_CONFIG_PATH: ${{ inputs.config-path }}

--- a/actions/trigger-argo-workflow/action.yaml
+++ b/actions/trigger-argo-workflow/action.yaml
@@ -45,30 +45,16 @@ runs:
   using: composite
 
   steps:
-    - name: Checkout
-      env:
-        # In a composite action, these two need to be indirected via the
-        # environment, as per the GitHub actions documentation:
-        # https://docs.github.com/en/actions/learn-github-actions/contexts
-        action_repo: ${{ github.action_repository }}
-        action_ref: ${{ github.action_ref }}
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      with:
-        repository: ${{ env.action_repo }}
-        ref: ${{ env.action_ref }}
-        path: _shared-workflows-trigger-argo-workflow
-        persist-credentials: false
-
     - name: Setup argo
-      uses: ./_shared-workflows-trigger-argo-workflow/actions/setup-argo
+      uses: grafana/shared-workflows/actions/setup-argo@f02682926bde2aa45a1a8b74409c94508d8952ec # setup-argo/v1.2.0
 
     - name: Setup go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         check-latest: true
         cache-dependency-path: |
-          actions/trigger-argo-workflow/go.sum
-        go-version-file: "_shared-workflows-trigger-argo-workflow/actions/trigger-argo-workflow/go.mod"
+          ${{ github.action_path }}/go.sum
+        go-version-file: ${{ github.action_path }}/go.mod
 
     - name: Map cluster and vault instance from Argo WF instance
       id: argo-instance
@@ -97,7 +83,7 @@ runs:
 
     - name: Get Argo Token
       id: get-argo-token
-      uses: ./_shared-workflows-trigger-argo-workflow/actions/get-vault-secrets
+      uses: grafana/shared-workflows/actions/get-vault-secrets@e46fe1e9a2bf9e618bcf8d8d32f3a7381b45c06d # get-vault-secrets/v2.0.0
       with:
         vault_instance: ${{ steps.argo-instance.outputs.vault-instance }}
         repo_secrets: |
@@ -115,7 +101,9 @@ runs:
         PARAMETERS: ${{ inputs.parameters }}
         WORKFLOW_TEMPLATE: ${{ inputs.workflow_template }}
       run: |
-        cd _shared-workflows-trigger-argo-workflow/actions/trigger-argo-workflow
+        # The runner downloads the full action repository into its actions
+        # cache; GITHUB_ACTION_PATH points at this action's directory there.
+        cd "${GITHUB_ACTION_PATH}"
 
         # Split the parameters into an array and pass them to the action as --parameter PARAM
         parameters=()


### PR DESCRIPTION
Follow-up to #2032. The remaining composite actions still checked out the shared-workflows repository into the caller's workspace, which polluted the working tree and caused unexpected side effects on git operations.

The checkout was only ever needed for two things, and neither requires it:

- **Sibling action `uses:` references** now use direct pinned references (`grafana/shared-workflows/actions/<name>@<sha> # <name>/vX.Y.Z`), as in #2032.
- **Repository files** (Go source, setup scripts, bun workspace) are read from `GITHUB_ACTION_PATH` instead — the runner already downloads the full action repository into its actions cache when resolving the action, at exactly the calling ref, so fork semantics are preserved. This is the same pattern `run-capslock` already uses.

Changes per action:

- `trigger-argo-workflow`: direct refs for `setup-argo/v1.2.0` and `get-vault-secrets/v2.0.0`; Go CLI runs from `GITHUB_ACTION_PATH`
- `lint-pr-title`: bun install and lint run from `github.action_path`
- `docker-import-digests-push-manifest`: direct refs for `login-to-gar/v1.0.2` and `dockerhub-login/v1.0.4`; Go summary tool runs from `GITHUB_ACTION_PATH`
- `docker-build-push-image`: direct refs for `login-to-gar/v1.0.2` and `dockerhub-login/v1.0.4`; setup scripts run from `GITHUB_ACTION_PATH`; cleanup step removed

Note: `dockerhub-login/v1.0.4` predates #2032 and still performs its own checkout; pending releases #1997 (dockerhub-login 2.0.0) and #1998 (login-to-gar 1.0.3) will pick up the fix and Renovate will bump the pins afterwards.