### PR TITLE
feat(check-ref-protection): add WIF ref-protection gate for prod publishing

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -34,6 +34,15 @@ on:
         required: false
         default: "false"
         type: string
+      enforce-ref-protection:
+        description: |
+          Gate publishing on ref protection. When "true", the build is blocked
+          unless the ref being published from meets the protection bar
+          (see actions/check-ref-protection). When "false" (default), the gate
+          runs in warn-only mode and never blocks.
+        required: false
+        default: "false"
+        type: string
 
       # The following inputs are identical to the inputs
       # found in `shared-workflows/actions/docker-build-push-image`
@@ -308,8 +317,19 @@ jobs:
           echo "runner-type-arm64=$ARM64_OUT" | tee -a "${GITHUB_OUTPUT}"
           echo "runner-type-manifest=$MANIFEST_OUT" | tee -a "${GITHUB_OUTPUT}"
 
+  ref-protection-gate:
+    runs-on: ${{ inputs.runner-type == 'self-hosted' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    permissions:
+      contents: read # enough to read the ref's ruleset rules
+    steps:
+      # TODO: pin to a released version (check-ref-protection/vX.Y.Z) before merge.
+      - name: Verify ref protection
+        uses: grafana/shared-workflows/actions/check-ref-protection@nickange/wif-ref-protection-gate # zizmor: ignore[unpinned-uses]
+        with:
+          enforce: ${{ inputs.enforce-ref-protection }}
+
   build-and-push:
-    needs: prepare-matrix
+    needs: [prepare-matrix, ref-protection-gate]
     strategy:
       fail-fast: false
       matrix:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -20,6 +20,7 @@
     "actions/dependabot-auto-triage": "1.1.3",
     "actions/get-latest-workflow-artifact": "0.2.3",
     "actions/create-github-app-token": "0.3.1",
+    "actions/check-ref-protection": "0.1.0",
     "actions/run-capslock": "0.2.3",
     "actions/azure-trusted-signing": "1.0.3",
     "actions/validate-renovate-config": "0.1.4",

--- a/actions/check-ref-protection/CHANGELOG.md
+++ b/actions/check-ref-protection/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/check-ref-protection/README.md
+++ b/actions/check-ref-protection/README.md
@@ -1,0 +1,94 @@
+# check-ref-protection
+
+Composite GitHub Action that gates prod publishing on **ref protection**. It
+checks whether the ref a workflow is publishing from (a branch) is actually
+protected — reviewed and tamper-resistant — and not merely a ref where the
+`ref_protected` boolean happens to be `true`.
+
+It reads the protection that applies to the ref and checks it against a minimum
+bar defined in [`policy.json`](./policy.json).
+
+> [!NOTE]
+> **Branches only for now.** Tags are not yet supported — GitHub has no
+> `/rules/tags/{tag}` endpoint, so tag protection needs a different approach
+> (ruleset enumeration or a commit-ancestry check). The action exits with an
+> error for tags rather than reporting a misleading result.
+
+## How it works
+
+The action merges **two sources** of protection into one normalized rule set:
+
+1. **Rulesets** — `GET /repos/{repo}/rules/branches/{branch}` (org + repo).
+2. **Legacy branch protection** — `GET /repos/{repo}/branches/{branch}/protection`,
+   normalized into the same shape (e.g. legacy `dismiss_stale_reviews` →
+   `dismiss_stale_reviews_on_push`, `allow_force_pushes: false` →
+   `non_fast_forward`).
+
+A check passes if **either** source satisfies it — GitHub enforces both and the
+most-restrictive wins, so presence in either source means it is enforced. The
+output reports which source(s) protect the ref, both at the top and per check.
+
+## Behaviour
+
+- `enforce: false` (default) — **disabled / warn-only.** Prints the result but
+  never fails the step. Safe to add without changing a workflow's outcome.
+- `enforce: true` — **blocking.** Fails (exit 1) when the ref does not meet the
+  bar, so no token is minted and nothing is published.
+
+<!-- x-release-please-start-version -->
+
+```yaml
+name: Publish
+on:
+  push:
+    branches: [main, "release-*"]
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # enough for the rulesets source
+    steps:
+      - uses: grafana/shared-workflows/actions/check-ref-protection@check-ref-protection/v0.1.0
+        with:
+          enforce: "true"
+```
+
+<!-- x-release-please-end-version -->
+
+## Inputs
+
+| Name           | Description                                                                           | Default                    |
+| -------------- | ------------------------------------------------------------------------------------- | -------------------------- |
+| `repository`   | `owner/repo` to check.                                                                | `${{ github.repository }}` |
+| `ref-type`     | `branch` or `tag`. Auto-detected from `github.ref` when empty.                        | _(auto)_                   |
+| `ref-name`     | Ref name to check. Auto-detected from `github.ref` when empty.                        | _(auto)_                   |
+| `policy`       | Path to a `policy.json`. Defaults to the policy bundled with this action.             | _(bundled)_                |
+| `enforce`      | `true` to fail on insufficient protection; `false` to warn-only.                      | `"false"`                  |
+| `github-token` | Token with read access to the repo's rules.                                           | `${{ github.token }}`      |
+
+## Tokens / permissions
+
+- **Rulesets source** (`/rules/branches/...`) needs only `contents: read` — the
+  default `GITHUB_TOKEN` works.
+- **Legacy source** (`/branches/.../protection`) needs **Administration: read**.
+  The default `GITHUB_TOKEN` cannot read it, so in CI the legacy source is
+  skipped with a warning (a branch protected only by legacy rules would then
+  look unprotected). To include the legacy source in CI, pass a GitHub App
+  token (GATB) with Administration: read via `github-token`.
+
+## Policy
+
+`policy.json` lists the required rules per ref type. Each entry is a rule check:
+
+| Field         | Meaning                                                  |
+| ------------- | -------------------------------------------------------- |
+| `id`          | Short identifier shown in the output.                    |
+| `severity`    | `required` (fails the bar) or `optional` (warning only). |
+| `description` | Human-readable description.                              |
+| `ruleType`    | The GitHub ruleset rule `type` (e.g. `pull_request`).    |
+| `param`       | Optional parameter inside the rule to inspect.           |
+| `min`         | Require `param >= min` (numeric).                        |
+| `equals`      | Require `param == equals` (exact match).                 |
+
+To change the bar, edit `policy.json` — the script is generic and is not touched.

--- a/actions/check-ref-protection/action.yaml
+++ b/actions/check-ref-protection/action.yaml
@@ -1,0 +1,79 @@
+name: Check ref protection
+description: |
+  Gate for prod publishing. Verifies the ref a workflow is publishing from meets
+  a minimum branch/tag protection bar (defined in policy.json) by reading the
+  GitHub ruleset rules that apply to that ref.
+
+  Disabled by default: with `enforce: false` it only reports (warn-only) and
+  never fails the job. Set `enforce: true` to block — the step fails when the
+  ref does not meet the bar.
+
+inputs:
+  repository:
+    description: "owner/repo to check. Defaults to the current repository."
+    default: ${{ github.repository }}
+  ref-type:
+    description: "'branch' or 'tag'. Auto-detected from github.ref when empty."
+    default: ""
+  ref-name:
+    description: "Ref name to check. Auto-detected from github.ref when empty."
+    default: ""
+  policy:
+    description: "Path to a policy.json. Defaults to the policy bundled with this action."
+    default: ""
+  enforce:
+    description: |
+      When 'true', the gate fails the job if the ref does not meet the bar.
+      When 'false' (default), it reports the result but never fails (warn-only).
+    default: "false"
+  github-token:
+    description: |
+      Token with read access to the repo's rules. The default GITHUB_TOKEN with
+      `contents: read` is sufficient for the rules-only checks.
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check ref protection
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPOSITORY: ${{ inputs.repository }}
+        REF_TYPE_IN: ${{ inputs.ref-type }}
+        REF_NAME_IN: ${{ inputs.ref-name }}
+        POLICY_IN: ${{ inputs.policy }}
+        ENFORCE: ${{ inputs.enforce }}
+      run: |
+        set -euo pipefail
+
+        # Auto-detect ref type/name from GITHUB_REF when not provided explicitly.
+        ref_type="$REF_TYPE_IN"
+        ref_name="$REF_NAME_IN"
+        if [ -z "$ref_type" ] || [ -z "$ref_name" ]; then
+          case "$GITHUB_REF" in
+            refs/tags/*)  ref_type="${ref_type:-tag}";    ref_name="${ref_name:-${GITHUB_REF#refs/tags/}}" ;;
+            refs/heads/*) ref_type="${ref_type:-branch}"; ref_name="${ref_name:-${GITHUB_REF#refs/heads/}}" ;;
+            *) echo "::error::cannot determine ref from '$GITHUB_REF'; pass ref-type and ref-name"; exit 2 ;;
+          esac
+        fi
+
+        policy="${POLICY_IN:-$GITHUB_ACTION_PATH/policy.json}"
+
+        set +e
+        "$GITHUB_ACTION_PATH/check-ref-protection.sh" "$REPOSITORY" "$ref_type" "$ref_name" "$policy"
+        rc=$?
+        set -e
+
+        case "$rc" in
+          0) exit 0 ;;
+          1)
+            if [ "$ENFORCE" = "true" ]; then
+              echo "::error::ref-protection gate ENABLED and '$ref_name' failed the bar — blocking publish."
+              exit 1
+            fi
+            echo "::warning::ref-protection gate DISABLED (enforce=false): '$ref_name' would have been blocked — continuing."
+            exit 0
+            ;;
+          *) echo "::error::ref-protection check errored (exit $rc)"; exit "$rc" ;;
+        esac

--- a/actions/check-ref-protection/check-ref-protection.sh
+++ b/actions/check-ref-protection/check-ref-protection.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+#
+# check-ref-protection.sh — gate for prod-publish (WIF ref-protection).
+#
+# Reads the protection that applies to a single ref and checks it against the
+# bar in policy.json. It merges TWO sources into one normalized rule set:
+#   1. Rulesets        — GET /repos/{repo}/rules/{branches|tags}/{ref}
+#   2. Legacy branch   — GET /repos/{repo}/branches/{branch}/protection
+#      protection         (branches only; normalized into ruleset-shaped entries)
+#
+# A check passes if EITHER source satisfies it (GitHub enforces both and the
+# most-restrictive wins, so presence in either source means it is enforced).
+#
+#   exit 0  all required checks pass  ->  safe to mint a prod token / push
+#   exit 1  a required check failed   ->  caller must abort before publishing
+#   exit 2  usage / setup error
+#
+# Auth: uses `gh` ($GH_TOKEN / $GITHUB_TOKEN).
+#   - /rules/...            needs only `contents: read`.
+#   - /branches/.../protection needs Administration: read (admin). When the
+#     token can't read it, legacy protection is skipped with a warning.
+#
+# Usage: ./check-ref-protection.sh <owner/repo> <branch|tag> <ref-name> [policy.json]
+
+set -euo pipefail
+
+US=$'\037' # unit separator: a non-whitespace field delimiter (see read loop)
+
+# --- arguments ---------------------------------------------------------------
+REPO="${1:?usage: <owner/repo> <branch|tag> <ref-name> [policy.json]}"
+REF_TYPE="${2:?ref type must be 'branch' or 'tag'}"
+REF_NAME="${3:?ref name required}"
+POLICY="${4:-"$(dirname "$0")/policy.json"}"
+
+case "$REF_TYPE" in
+  branch|tag) ;;
+  *) echo "::error::ref type must be 'branch' or 'tag', got '$REF_TYPE'"; exit 2 ;;
+esac
+[ -f "$POLICY" ] || { echo "::error::policy file not found: $POLICY"; exit 2; }
+
+echo "==> $REPO · $REF_TYPE · $REF_NAME"
+
+# Tags are not supported yet: GitHub has no /rules/tags/{tag} endpoint, so tag
+# rules can't be read the same way as branches. Supporting tags needs either
+# ruleset enumeration (/rulesets + /rulesets/{id}, Administration: read) or a
+# commit-ancestry check. Fail closed rather than report a misleading result.
+if [ "$REF_TYPE" = tag ]; then
+  echo "::error::tag protection checks are not implemented yet (no /rules/tags endpoint)."
+  echo "  See README for the planned tag approach (ruleset enumeration / ancestry)."
+  exit 2
+fi
+
+# --- source 1: ruleset rules -------------------------------------------------
+# Tag each rule with its source so the output can show where protection came from.
+raw="$(gh api "/repos/$REPO/rules/branches/$REF_NAME" 2>/dev/null)" || raw='[]'
+RULES="$(jq -c 'if type == "array" then map(. + {_src: "rulesets"}) else [] end' <<<"$raw")"
+
+# --- source 2: legacy branch protection (branches only) ----------------------
+# Normalize the legacy protection object into ruleset-shaped entries so the
+# same checks apply to both. Field names are mapped to the ruleset equivalents
+# (e.g. legacy `dismiss_stale_reviews` -> `dismiss_stale_reviews_on_push`).
+if [ "$REF_TYPE" = branch ]; then
+  legacy=""
+  if legacy="$(gh api "/repos/$REPO/branches/$REF_NAME/protection" 2>/tmp/crp_err.$$)"; then
+    : # read ok
+  elif grep -qi 'not protected\|not found' /tmp/crp_err.$$; then
+    legacy="" # genuinely no legacy protection on this branch
+  else
+    echo "::warning::could not read legacy branch protection (token likely needs Administration: read) — skipping legacy source"
+    legacy=""
+  fi
+  rm -f /tmp/crp_err.$$
+
+  if [ -n "$legacy" ]; then
+    legacy_rules="$(jq -c '
+      [
+        (if .required_pull_request_reviews then
+          { type: "pull_request", parameters: {
+              required_approving_review_count: (.required_pull_request_reviews.required_approving_review_count // 0),
+              dismiss_stale_reviews_on_push:   (.required_pull_request_reviews.dismiss_stale_reviews // false),
+              require_last_push_approval:      (.required_pull_request_reviews.require_last_push_approval // false)
+          }} else empty end),
+        (if .allow_force_pushes.enabled == false then { type: "non_fast_forward" } else empty end),
+        (if .allow_deletions.enabled  == false then { type: "deletion" } else empty end),
+        (if .required_signatures.enabled == true then { type: "required_signatures" } else empty end),
+        (if .required_status_checks then { type: "required_status_checks" } else empty end)
+      ] | map(. + {_src: "legacy"})' <<<"$legacy")"
+    RULES="$(jq -c -n --argjson a "$RULES" --argjson b "$legacy_rules" '$a + $b')"
+  fi
+fi
+
+# --- report which source(s) protect this ref --------------------------------
+if [ "$(jq 'length' <<<"$RULES")" -eq 0 ]; then
+  echo "    Protection source(s): none — no protection applies to this ref"
+else
+  echo "    Protection source(s): $(jq -r '
+    [.[]._src] | unique
+    | map(if . == "legacy" then "legacy branch protection" else "rulesets" end)
+    | join(" + ")' <<<"$RULES")"
+fi
+
+# --- evaluate one policy entry against the merged rules ----------------------
+# Passes if ANY matching rule satisfies the check. Sets REASON. 0=pass / 1=fail.
+REASON=""
+check_rule() {
+  local rule_type="$1" param="$2" min="$3" equals="$4" best
+
+  if ! jq -e --arg t "$rule_type" 'any(.[]; .type == $t)' <<<"$RULES" >/dev/null; then
+    REASON="no '$rule_type' rule applies to this ref"
+    return 1
+  fi
+
+  # presence-only check
+  if [ -z "$param" ]; then
+    src="$(jq -r --arg t "$rule_type" \
+      'map(select(.type == $t)._src) | unique | join("+")' <<<"$RULES")"
+    REASON="'$rule_type' rule is present [$src]"
+    return 0
+  fi
+
+  # numeric threshold: pass if any matching rule has param >= min
+  if [ -n "$min" ]; then
+    best="$(jq -r --arg t "$rule_type" --arg p "$param" \
+      'map(select(.type == $t) | .parameters[$p] // 0) | max' <<<"$RULES")"
+    if [ "$best" -ge "$min" ] 2>/dev/null; then
+      src="$(jq -r --arg t "$rule_type" --arg p "$param" \
+        'map(select(.type == $t)) | max_by(.parameters[$p] // 0)._src' <<<"$RULES")"
+      REASON="$param = $best (>= $min) [$src]"; return 0
+    fi
+    REASON="$param = $best, need >= $min"; return 1
+  fi
+
+  # exact match: pass if any matching rule has param == equals
+  if jq -e --arg t "$rule_type" --arg p "$param" --arg v "$equals" \
+       'any(.[]; .type == $t and ((.parameters[$p]) | tostring) == $v)' <<<"$RULES" >/dev/null; then
+    src="$(jq -r --arg t "$rule_type" --arg p "$param" --arg v "$equals" \
+      'map(select(.type == $t and ((.parameters[$p]) | tostring) == $v)) | .[0]._src' <<<"$RULES")"
+    REASON="$param = $equals [$src]"; return 0
+  fi
+  best="$(jq -r --arg t "$rule_type" --arg p "$param" \
+    'map(select(.type == $t) | .parameters[$p]) | .[0] | tostring' <<<"$RULES")"
+  REASON="$param = $best, need $equals"; return 1
+}
+
+# --- run every policy entry for this ref type, render, tally -----------------
+declare -i req_total=0 req_passed=0 failed=0
+missing=()
+
+printf '\n'
+while IFS="$US" read -r id severity description rule_type param min equals; do
+  if check_rule "$rule_type" "$param" "$min" "$equals"; then ok=1; else ok=0; fi
+
+  if [ "$severity" = required ]; then
+    req_total+=1
+    if [ "$ok" -eq 1 ]; then req_passed+=1; else failed=1; missing+=("$description — $REASON"); fi
+  fi
+
+  if   [ "$ok" -eq 1 ];            then mark='\033[32m✓\033[0m'
+  elif [ "$severity" = required ]; then mark='\033[31m✗\033[0m'
+  else                                  mark='\033[33m⚠\033[0m'
+  fi
+  printf '  %b  %-18s %s\n'       "$mark" "$id" "$description"
+  printf '       \033[2m↳ %s\033[0m\n' "$REASON"
+done < <(jq -r --arg t "$REF_TYPE" --arg us "$US" '
+  .[$t][] | [
+    .id, .severity, .description, (.ruleType // ""),
+    (.param // ""),
+    (if has("min")    then (.min    | tostring) else "" end),
+    (if has("equals") then (.equals | tostring) else "" end)
+  ] | join($us)
+' "$POLICY")
+
+# --- verdict -----------------------------------------------------------------
+printf '\n  Required: %d/%d passed\n' "$req_passed" "$req_total"
+
+if [ "$failed" -eq 0 ]; then
+  echo "  RESULT: PASS — $REF_TYPE '$REF_NAME' meets the bar. OK to publish."
+  exit 0
+fi
+
+printf '\n  Missing required protections:\n'
+for m in "${missing[@]}"; do echo "    • $m"; done
+printf '\n'
+echo "::error::$REF_TYPE '$REF_NAME' does NOT meet the prod-publish bar ($req_passed/$req_total required passed)."
+echo "  RESULT: FAIL — refusing to publish."
+exit 1

--- a/actions/check-ref-protection/policy.json
+++ b/actions/check-ref-protection/policy.json
@@ -1,0 +1,60 @@
+{
+  "branch": [
+    {
+      "id": "requires-pr",
+      "severity": "required",
+      "description": "Requires a pull request before merging",
+      "ruleType": "pull_request"
+    },
+    {
+      "id": "min-approvals",
+      "severity": "required",
+      "description": "Requires >= 1 approving review",
+      "ruleType": "pull_request",
+      "param": "required_approving_review_count",
+      "min": 1
+    },
+    {
+      "id": "dismiss-stale",
+      "severity": "required",
+      "description": "Dismisses stale approvals when new commits are pushed",
+      "ruleType": "pull_request",
+      "param": "dismiss_stale_reviews_on_push",
+      "equals": true
+    },
+    {
+      "id": "no-self-approve",
+      "severity": "required",
+      "description": "Requires approval of the most recent push (no self-approve)",
+      "ruleType": "pull_request",
+      "param": "require_last_push_approval",
+      "equals": true
+    },
+    {
+      "id": "block-force-push",
+      "severity": "required",
+      "description": "Blocks force-push",
+      "ruleType": "non_fast_forward"
+    },
+    {
+      "id": "block-deletion",
+      "severity": "required",
+      "description": "Blocks branch deletion",
+      "ruleType": "deletion"
+    }
+  ],
+  "tag": [
+    {
+      "id": "restrict-creation",
+      "severity": "required",
+      "description": "Restricts tag creation to bypass actors only",
+      "ruleType": "creation"
+    },
+    {
+      "id": "block-force-push",
+      "severity": "required",
+      "description": "Blocks force-push on the tag",
+      "ruleType": "non_fast_forward"
+    }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -147,6 +147,11 @@
       "package-name": "create-github-app-token",
       "extra-files": ["README.md"]
     },
+    "actions/check-ref-protection": {
+      "package-name": "check-ref-protection",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
     "actions/validate-renovate-config": {
       "package-name": "validate-renovate-config",
       "extra-files": ["README.md"],


### PR DESCRIPTION
## Summary

Adds a composite action **`actions/check-ref-protection`** that gates prod publishing on whether the ref being published from is *actually* protected

This is the first slice of the WIF prod-publish standardisation work (branches only; tags handled separately).

### How it works

At publish time the gate inspects **only the single ref being published from** and merges **two sources** of protection into one normalized rule set:

1. **Rulesets** — `GET /repos/{repo}/rules/branches/{branch}` (org + repo).
2. **Legacy branch protection** — `GET /repos/{repo}/branches/{branch}/protection`, normalized into the same shape (e.g. legacy `dismiss_stale_reviews` → `dismiss_stale_reviews_on_push`, `allow_force_pushes: false` → `non_fast_forward`).

### Locally

```
cd shared-workflows
S=./actions/check-ref-protection/check-ref-protection.sh

$S grafana/<some-repo> branch main
```

### Integration

Added to docker-build-push-multiarch.yml with a new enforce-ref-protection input. Off by default.
  - Off (default): the gate just reports the result, never blocks. Nothing changes for current users.
  - On: if the branch isn't protected enough, the build is skipped

### Tokens / permissions

- Rulesets source needs only `contents: read` (default `GITHUB_TOKEN`).
- Legacy source needs `Administration: read`; the default `GITHUB_TOKEN` can't read it, so in CI the legacy source is skipped with a warning. Pass a GitHub App (GATB) token with `Administration: read` to include it.

### Not in this PR (follow-ups)

- **Tags** — no `/rules/tags/{tag}` endpoint exists; needs ruleset enumeration or (better) a commit-ancestry check. The action exits cleanly for tags rather than reporting a misleading result.
- **Bypass-actor checking** — parked; also requires `Administration: read`.

## Test

- `shellcheck` and `actionlint` clean.
- Ran locally against:
  - `grafana/mimir` — `main` 6/6 PASS, `r147` / `r000` 4/6 FAIL (as above).
  - `grafana/nangelopoulos-test-repo` — `main` FAILs (protected boolean `true`, but only visibility/trufflehog/zizmor rules apply).

## Issue

https://github.com/grafana/deployment_tools/issues/554020