### PR TITLE
feat(check-ref-protection): add  WIF ref-protection gate

### DIFF
--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -34,6 +34,15 @@ on:
         required: false
         default: "false"
         type: string
+      enforce-ref-protection:
+        description: |
+          Gate publishing on ref protection. When "true", the build is blocked
+          unless the ref being published from meets the protection bar
+          (see actions/check-ref-protection). When "false" (default), the gate
+          runs in warn-only mode and never blocks.
+        required: false
+        default: "false"
+        type: string
 
       # The following inputs are identical to the inputs
       # found in `shared-workflows/actions/docker-build-push-image`
@@ -308,8 +317,19 @@ jobs:
           echo "runner-type-arm64=$ARM64_OUT" | tee -a "${GITHUB_OUTPUT}"
           echo "runner-type-manifest=$MANIFEST_OUT" | tee -a "${GITHUB_OUTPUT}"
 
+  ref-protection-gate:
+    runs-on: ${{ inputs.runner-type == 'self-hosted' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
+    permissions:
+      contents: read # enough to read the ref's ruleset rules
+    steps:
+      # TODO: pin to a released version (check-ref-protection/vX.Y.Z) before merge.
+      - name: Verify ref protection
+        uses: grafana/shared-workflows/actions/check-ref-protection@nickange/check-ref-protection-go # zizmor: ignore[unpinned-uses]
+        with:
+          enforce: ${{ inputs.enforce-ref-protection }}
+
   build-and-push:
-    needs: prepare-matrix
+    needs: [prepare-matrix, ref-protection-gate]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -34,14 +34,14 @@ on:
         required: false
         default: "false"
         type: string
-      enforce-ref-protection:
+      ref-protection:
         description: |
-          Gate publishing on ref protection. When "true", the build is blocked
-          unless the ref being published from meets the protection bar
-          (see actions/check-ref-protection). When "false" (default), the gate
-          runs in warn-only mode and never blocks.
+          Gate publishing on ref protection (see actions/check-ref-protection):
+            "off"     (default) the gate does not run.
+            "warn"    the gate runs and reports, but never blocks the build.
+            "enforce" the build is blocked unless the ref meets the protection bar.
         required: false
-        default: "false"
+        default: "off"
         type: string
 
       # The following inputs are identical to the inputs
@@ -318,6 +318,8 @@ jobs:
           echo "runner-type-manifest=$MANIFEST_OUT" | tee -a "${GITHUB_OUTPUT}"
 
   ref-protection-gate:
+    # Only gate prod publishes (matches the WIF CEL, which only restricts prod).
+    if: ${{ inputs.ref-protection != 'off' && inputs.gar-environment == 'prod' }}
     runs-on: ${{ inputs.runner-type == 'self-hosted' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -327,10 +329,13 @@ jobs:
       - name: Verify ref protection
         uses: grafana/shared-workflows/actions/check-ref-protection@nickange/check-ref-protection-go # zizmor: ignore[unpinned-uses]
         with:
-          enforce: ${{ inputs.enforce-ref-protection }}
+          enforce: ${{ inputs.ref-protection == 'enforce' }}
 
   build-and-push:
     needs: [prepare-matrix, ref-protection-gate]
+    # Proceed when the gate passed OR was skipped (ref-protection: off); a gate
+    # failure (enforce mode) propagates as failure() and blocks the build.
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker-build-push-multiarch.yml
+++ b/.github/workflows/docker-build-push-multiarch.yml
@@ -320,7 +320,8 @@ jobs:
   ref-protection-gate:
     runs-on: ${{ inputs.runner-type == 'self-hosted' && 'ubuntu-x64-small' || 'ubuntu-latest' }}
     permissions:
-      contents: read # enough to read the ref's ruleset rules
+      contents: read
+      id-token: write
     steps:
       # TODO: pin to a released version (check-ref-protection/vX.Y.Z) before merge.
       - name: Verify ref protection

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -20,6 +20,7 @@
     "actions/dependabot-auto-triage": "1.1.3",
     "actions/get-latest-workflow-artifact": "0.2.3",
     "actions/create-github-app-token": "0.3.1",
+    "actions/check-ref-protection": "0.1.0",
     "actions/run-capslock": "0.2.3",
     "actions/azure-trusted-signing": "1.0.3",
     "actions/validate-renovate-config": "0.1.4",

--- a/actions/check-ref-protection/CHANGELOG.md
+++ b/actions/check-ref-protection/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/actions/check-ref-protection/README.md
+++ b/actions/check-ref-protection/README.md
@@ -1,0 +1,53 @@
+# check-ref-protection
+
+Composite action that gates prod publishing on **ref protection**. It verifies
+the ref a workflow publishes from is actually protected (reviewed and
+tamper-resistant) by checking the protection that applies to it against [`policy.json`](./policy.json).
+
+- **Branches** merge ruleset rules and legacy branch protection; a check passes
+  if either satisfies it.
+- **Tags** evaluate the **active** tag rulesets matching the tag (rulesets in
+  `evaluate`/`disabled` mode are reported but never counted).
+
+The ref identity comes from a trusted source (runner env or the signed OIDC
+token), never caller inputs, so the gate can't be pointed at a different ref.
+
+<!-- x-release-please-start-version -->
+
+```yaml
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: grafana/shared-workflows/actions/check-ref-protection@check-ref-protection/v0.1.0
+        with:
+          enforce: "true" # false (default) = warn-only, never blocks
+```
+
+<!-- x-release-please-end-version -->
+
+## Inputs
+
+| Name           | Description                                                      | Default                |
+| -------------- | ---------------------------------------------------------------- | ---------------------- |
+| `enforce`      | `true` to fail on insufficient protection; `false` = warn-only. | `"false"`              |
+| `identity`     | Ref identity source: `env` or `oidc`.                           | `"env"`                |
+| `policy`       | Path to a `policy.json`. Defaults to the bundled policy.        | _(bundled)_            |
+| `github-token` | Token with read access to the repo's rules.                     | `${{ github.token }}`  |
+
+## Permissions
+
+- Branch rulesets need only `contents: read`.
+- Legacy branch protection and tag ruleset enumeration need **Administration:
+  read** — otherwise those sources are skipped (fail-closed) with a warning;
+  pass a GATB app token via `github-token` to include them.
+- `identity: oidc` also requires `id-token: write` on the job.
+
+## Policy
+
+Edit [`policy.json`](./policy.json) to change the bar — the Go code is generic.
+Each entry has: `id`, `severity` (`required`|`optional`), `description`,
+`ruleType`, and an optional match — `param` with `min` (`param >= min`) or
+`equals` (`param == equals`), or presence-only when omitted.

--- a/actions/check-ref-protection/README.md
+++ b/actions/check-ref-protection/README.md
@@ -31,12 +31,12 @@ jobs:
 
 ## Inputs
 
-| Name           | Description                                                      | Default                |
-| -------------- | ---------------------------------------------------------------- | ---------------------- |
-| `enforce`      | `true` to fail on insufficient protection; `false` = warn-only. | `"false"`              |
-| `identity`     | Ref identity source: `oidc` (signed token) or `args` (testing). | `"oidc"`               |
-| `policy`       | Path to a `policy.json`. Defaults to the bundled policy.        | _(bundled)_            |
-| `github-token` | Token with read access to the repo's rules.                     | `${{ github.token }}`  |
+| Name           | Description                                                     | Default               |
+| -------------- | --------------------------------------------------------------- | --------------------- |
+| `enforce`      | `true` to fail on insufficient protection; `false` = warn-only. | `"false"`             |
+| `identity`     | Ref identity source: `oidc` (signed token) or `args` (testing). | `"oidc"`              |
+| `policy`       | Path to a `policy.json`. Defaults to the bundled policy.        | _(bundled)_           |
+| `github-token` | Token with read access to the repo's rules.                     | `${{ github.token }}` |
 
 ## Permissions
 

--- a/actions/check-ref-protection/README.md
+++ b/actions/check-ref-protection/README.md
@@ -9,8 +9,8 @@ tamper-resistant) by checking the protection that applies to it against [`policy
 - **Tags** evaluate the **active** tag rulesets matching the tag (rulesets in
   `evaluate`/`disabled` mode are reported but never counted).
 
-The ref identity comes from a trusted source (runner env or the signed OIDC
-token), never caller inputs, so the gate can't be pointed at a different ref.
+The ref identity comes from the signed OIDC token, never caller inputs, so the
+gate can't be pointed at a different ref.
 
 <!-- x-release-please-start-version -->
 
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # default identity=oidc reads the signed OIDC token
     steps:
       - uses: grafana/shared-workflows/actions/check-ref-protection@check-ref-protection/v0.1.0
         with:
@@ -33,17 +34,18 @@ jobs:
 | Name           | Description                                                      | Default                |
 | -------------- | ---------------------------------------------------------------- | ---------------------- |
 | `enforce`      | `true` to fail on insufficient protection; `false` = warn-only. | `"false"`              |
-| `identity`     | Ref identity source: `env` or `oidc`.                           | `"env"`                |
+| `identity`     | Ref identity source: `oidc` (signed token) or `args` (testing). | `"oidc"`               |
 | `policy`       | Path to a `policy.json`. Defaults to the bundled policy.        | _(bundled)_            |
 | `github-token` | Token with read access to the repo's rules.                     | `${{ github.token }}`  |
 
 ## Permissions
 
+- The default `identity: oidc` requires **`id-token: write`** on the job (to
+  read the signed GitHub OIDC token).
 - Branch rulesets need only `contents: read`.
 - Legacy branch protection and tag ruleset enumeration need **Administration:
   read** — otherwise those sources are skipped (fail-closed) with a warning;
   pass a GATB app token via `github-token` to include them.
-- `identity: oidc` also requires `id-token: write` on the job.
 
 ## Policy
 

--- a/actions/check-ref-protection/action.yaml
+++ b/actions/check-ref-protection/action.yaml
@@ -14,9 +14,9 @@ inputs:
     default: "false"
   identity:
     description: |
-      Where the ref identity comes from: "env" (GITHUB_* vars, needs no extra
-      permission) or "oidc" (signed token, needs id-token: write on the job).
-    default: "env"
+      Where the ref identity comes from. "oidc" (default) reads the signed
+      GitHub OIDC token and requires id-token: write on the calling job.
+    default: "oidc"
   policy:
     description: "Path to a policy.json. Defaults to the policy bundled with this action."
     default: ""

--- a/actions/check-ref-protection/action.yaml
+++ b/actions/check-ref-protection/action.yaml
@@ -1,0 +1,51 @@
+name: Check ref protection
+description: |
+  Gate for prod publishing. Verifies the ref a workflow publishes from meets a
+  minimum branch/tag protection bar (policy.json). Identity is derived from the
+  signed OIDC token or the runner environment — never from caller inputs — so it
+  cannot be pointed at a different (protected) ref than the one running.
+
+  Disabled by default: with enforce=false it only reports (warn-only). Set
+  enforce=true to block — the step fails when the ref does not meet the bar.
+
+inputs:
+  enforce:
+    description: "true to fail the job when the ref does not meet the bar; false = warn-only."
+    default: "false"
+  identity:
+    description: |
+      Where the ref identity comes from: "env" (GITHUB_* vars, needs no extra
+      permission) or "oidc" (signed token, needs id-token: write on the job).
+    default: "env"
+  policy:
+    description: "Path to a policy.json. Defaults to the policy bundled with this action."
+    default: ""
+  github-token:
+    description: "Token with read access to the repo's rules (Administration: read for tags/legacy)."
+    default: ${{ github.token }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version-file: ${{ github.action_path }}/go.mod
+        cache: false # stdlib-only module, no go.sum to cache
+
+    - name: Build
+      shell: bash
+      run: go build -C "$GITHUB_ACTION_PATH" -o "$RUNNER_TEMP/check-ref-protection" ./cmd/check-ref-protection
+
+    - name: Check ref protection
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        policy="${{ inputs.policy }}"
+        policy="${policy:-$GITHUB_ACTION_PATH/policy.json}"
+
+        args=(-identity "${{ inputs.identity }}" -policy "$policy")
+        [ "${{ inputs.enforce }}" = "true" ] && args+=(-enforce)
+
+        "$RUNNER_TEMP/check-ref-protection" "${args[@]}"

--- a/actions/check-ref-protection/action.yaml
+++ b/actions/check-ref-protection/action.yaml
@@ -38,14 +38,18 @@ runs:
 
     - name: Check ref protection
       shell: bash
+      # Inputs are passed via env (not ${{ }} interpolation in the script) to
+      # avoid template-injection: a value reaches the shell as data, not code.
       env:
         GH_TOKEN: ${{ inputs.github-token }}
+        POLICY: ${{ inputs.policy }}
+        IDENTITY: ${{ inputs.identity }}
+        ENFORCE: ${{ inputs.enforce }}
       run: |
         set -euo pipefail
-        policy="${{ inputs.policy }}"
-        policy="${policy:-$GITHUB_ACTION_PATH/policy.json}"
+        policy="${POLICY:-$GITHUB_ACTION_PATH/policy.json}"
 
-        args=(-identity "${{ inputs.identity }}" -policy "$policy")
-        [ "${{ inputs.enforce }}" = "true" ] && args+=(-enforce)
+        args=(-identity "$IDENTITY" -policy "$policy")
+        [ "$ENFORCE" = "true" ] && args+=(-enforce)
 
         "$RUNNER_TEMP/check-ref-protection" "${args[@]}"

--- a/actions/check-ref-protection/cmd/check-ref-protection/main.go
+++ b/actions/check-ref-protection/cmd/check-ref-protection/main.go
@@ -16,6 +16,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	rp "github.com/grafana/shared-workflows/actions/check-ref-protection/pkg/refprotection"
 )
@@ -136,7 +137,7 @@ func reportSources(rules []rp.Rule, nonActive []rp.NonActiveRuleset) {
 	if len(nonActive) > 0 {
 		fmt.Printf("    %sNot hard-enforced%s (matching rulesets with enforcement != active — ignored for the bar):\n", yellow, reset)
 		for _, na := range nonActive {
-			fmt.Printf("      ⚠ %s [enforcement=%s] → rules: %s\n", na.Name, na.Enforcement, join(na.Rules))
+			fmt.Printf("      ⚠ %s [enforcement=%s] → rules: %s\n", na.Name, na.Enforcement, strings.Join(na.Rules, ", "))
 		}
 	}
 }
@@ -166,15 +167,4 @@ func render(results []rp.Result) (reqTotal, reqPassed int, failed bool) {
 		fmt.Printf("       %s↳ %s%s\n", dim, r.Reason, reset)
 	}
 	return reqTotal, reqPassed, failed
-}
-
-func join(s []string) string {
-	out := ""
-	for i, v := range s {
-		if i > 0 {
-			out += ", "
-		}
-		out += v
-	}
-	return out
 }

--- a/actions/check-ref-protection/cmd/check-ref-protection/main.go
+++ b/actions/check-ref-protection/cmd/check-ref-protection/main.go
@@ -40,7 +40,7 @@ func run() int {
 	var (
 		policyPath = flag.String("policy", "policy.json", "path to policy.json")
 		enforce    = flag.Bool("enforce", false, "fail (exit 1) when the ref does not meet the bar")
-		identity   = flag.String("identity", "args", `identity source: "args" | "env" | "oidc"`)
+		identity   = flag.String("identity", "oidc", `identity source: "oidc" (default) | "args" (local testing)`)
 	)
 	flag.Parse()
 
@@ -103,8 +103,8 @@ func run() int {
 	return 0
 }
 
-// resolveIdentity picks the identity source. "oidc" and "env" derive a
-// non-spoofable identity from GitHub; "args" takes positional <repo> <type>
+// resolveIdentity picks the identity source. "oidc" derives a non-spoofable
+// identity from the signed GitHub token; "args" takes positional <repo> <type>
 // <name> for local/testing use only (never trust these in enforcement).
 func resolveIdentity(source string, args []string) (*rp.Identity, error) {
 	switch source {
@@ -114,18 +114,16 @@ func resolveIdentity(source string, args []string) (*rp.Identity, error) {
 			return nil, err
 		}
 		return rp.IdentityFromJWT(tok)
-	case "env":
-		return rp.IdentityFromEnv()
 	case "args":
 		if len(args) != 3 {
-			return nil, fmt.Errorf("usage: check-ref-protection [-identity oidc|env] | <owner/repo> <branch|tag> <ref-name>")
+			return nil, fmt.Errorf("usage: check-ref-protection [-identity oidc] | -identity args <owner/repo> <branch|tag> <ref-name>")
 		}
 		if args[1] != "branch" && args[1] != "tag" {
 			return nil, fmt.Errorf("ref type must be 'branch' or 'tag', got %q", args[1])
 		}
 		return &rp.Identity{Repository: args[0], RefType: args[1], RefName: args[2], Source: "args"}, nil
 	default:
-		return nil, fmt.Errorf("unknown identity source %q (use args|env|oidc)", source)
+		return nil, fmt.Errorf("unknown identity source %q (use oidc|args)", source)
 	}
 }
 

--- a/actions/check-ref-protection/cmd/check-ref-protection/main.go
+++ b/actions/check-ref-protection/cmd/check-ref-protection/main.go
@@ -1,0 +1,182 @@
+// Command check-ref-protection gates prod publishing on ref protection.
+//
+// It derives the publishing ref's identity (preferably from a GitHub-signed
+// OIDC token, never from caller input in the enforcement path), reads the
+// protection that actually applies to that ref, and checks it against
+// policy.json.
+//
+// Exit codes:
+//
+//	0  the ref meets the bar (or a failure was downgraded by -enforce=false)
+//	1  the ref fails the bar and -enforce is set
+//	2  usage / setup error
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	rp "github.com/grafana/shared-workflows/actions/check-ref-protection/pkg/refprotection"
+)
+
+// oidcAudience labels the OIDC token we request in identity=oidc mode, marking
+// it as scoped to this gate (distinct from the token the GCP auth step mints).
+const oidcAudience = "wif-ref-protection"
+
+const (
+	green  = "\033[32m"
+	red    = "\033[31m"
+	yellow = "\033[33m"
+	dim    = "\033[2m"
+	reset  = "\033[0m"
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	var (
+		policyPath = flag.String("policy", "policy.json", "path to policy.json")
+		enforce    = flag.Bool("enforce", false, "fail (exit 1) when the ref does not meet the bar")
+		identity   = flag.String("identity", "args", `identity source: "args" | "env" | "oidc"`)
+	)
+	flag.Parse()
+
+	id, err := resolveIdentity(*identity, flag.Args())
+	if err != nil {
+		fmt.Printf("::error::%v\n", err)
+		return 2
+	}
+
+	policy, err := rp.LoadPolicy(*policyPath)
+	if err != nil {
+		fmt.Printf("::error::%v\n", err)
+		return 2
+	}
+
+	fmt.Printf("==> %s · %s · %s  (identity: %s)\n", id.Repository, id.RefType, id.RefName, id.Source)
+
+	api := rp.NewHTTPClient()
+	var rules []rp.Rule
+	var nonActive []rp.NonActiveRuleset
+
+	switch id.RefType {
+	case "branch":
+		rules, err = rp.CollectBranchRules(api, id.Repository, id.RefName)
+	case "tag":
+		rules, nonActive, err = rp.CollectTagRules(api, id.Repository, id.RefName)
+	default:
+		fmt.Printf("::error::unsupported ref type %q\n", id.RefType)
+		return 2
+	}
+	if err != nil {
+		fmt.Printf("::error::reading protection: %v\n", err)
+		return 2
+	}
+
+	reportSources(rules, nonActive)
+
+	results := rp.Evaluate(policy.Checks(id.RefType), rules)
+	reqTotal, reqPassed, failed := render(results)
+
+	fmt.Printf("\n  Required: %d/%d passed\n", reqPassed, reqTotal)
+	if !failed {
+		fmt.Printf("  RESULT: PASS — %s '%s' meets the bar. OK to publish.\n", id.RefType, id.RefName)
+		return 0
+	}
+
+	fmt.Printf("\n  Missing required protections:\n")
+	for _, r := range results {
+		if r.Check.Severity == "required" && !r.Pass {
+			fmt.Printf("    • %s — %s\n", r.Check.Description, r.Reason)
+		}
+	}
+	if *enforce {
+		fmt.Printf("::error::%s '%s' does NOT meet the prod-publish bar (%d/%d required passed).\n",
+			id.RefType, id.RefName, reqPassed, reqTotal)
+		fmt.Printf("  RESULT: FAIL — refusing to publish.\n")
+		return 1
+	}
+	fmt.Printf("::warning::ref-protection gate DISABLED (enforce=false): '%s' would have been blocked — continuing.\n", id.RefName)
+	return 0
+}
+
+// resolveIdentity picks the identity source. "oidc" and "env" derive a
+// non-spoofable identity from GitHub; "args" takes positional <repo> <type>
+// <name> for local/testing use only (never trust these in enforcement).
+func resolveIdentity(source string, args []string) (*rp.Identity, error) {
+	switch source {
+	case "oidc":
+		tok, err := rp.FetchOIDCToken(oidcAudience)
+		if err != nil {
+			return nil, err
+		}
+		return rp.IdentityFromJWT(tok)
+	case "env":
+		return rp.IdentityFromEnv()
+	case "args":
+		if len(args) != 3 {
+			return nil, fmt.Errorf("usage: check-ref-protection [-identity oidc|env] | <owner/repo> <branch|tag> <ref-name>")
+		}
+		if args[1] != "branch" && args[1] != "tag" {
+			return nil, fmt.Errorf("ref type must be 'branch' or 'tag', got %q", args[1])
+		}
+		return &rp.Identity{Repository: args[0], RefType: args[1], RefName: args[2], Source: "args"}, nil
+	default:
+		return nil, fmt.Errorf("unknown identity source %q (use args|env|oidc)", source)
+	}
+}
+
+func reportSources(rules []rp.Rule, nonActive []rp.NonActiveRuleset) {
+	if len(rules) == 0 {
+		fmt.Println("    Protection source(s): none — no protection applies to this ref")
+	} else {
+		fmt.Printf("    Protection source(s): %s\n", rp.SourcesLabel(rules))
+	}
+	if len(nonActive) > 0 {
+		fmt.Printf("    %sNot hard-enforced%s (matching rulesets with enforcement != active — ignored for the bar):\n", yellow, reset)
+		for _, na := range nonActive {
+			fmt.Printf("      ⚠ %s [enforcement=%s] → rules: %s\n", na.Name, na.Enforcement, join(na.Rules))
+		}
+	}
+}
+
+func render(results []rp.Result) (reqTotal, reqPassed int, failed bool) {
+	fmt.Println()
+	for _, r := range results {
+		required := r.Check.Severity == "required"
+		if required {
+			reqTotal++
+			if r.Pass {
+				reqPassed++
+			} else {
+				failed = true
+			}
+		}
+		var mark string
+		switch {
+		case r.Pass:
+			mark = green + "✓" + reset
+		case required:
+			mark = red + "✗" + reset
+		default:
+			mark = yellow + "⚠" + reset
+		}
+		fmt.Printf("  %s  %-18s %s\n", mark, r.Check.ID, r.Check.Description)
+		fmt.Printf("       %s↳ %s%s\n", dim, r.Reason, reset)
+	}
+	return reqTotal, reqPassed, failed
+}
+
+func join(s []string) string {
+	out := ""
+	for i, v := range s {
+		if i > 0 {
+			out += ", "
+		}
+		out += v
+	}
+	return out
+}

--- a/actions/check-ref-protection/go.mod
+++ b/actions/check-ref-protection/go.mod
@@ -1,0 +1,3 @@
+module github.com/grafana/shared-workflows/actions/check-ref-protection
+
+go 1.24

--- a/actions/check-ref-protection/go.mod
+++ b/actions/check-ref-protection/go.mod
@@ -1,3 +1,3 @@
 module github.com/grafana/shared-workflows/actions/check-ref-protection
 
-go 1.24
+go 1.26.0

--- a/actions/check-ref-protection/pkg/refprotection/github.go
+++ b/actions/check-ref-protection/pkg/refprotection/github.go
@@ -1,0 +1,140 @@
+package refprotection
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// HTTPClient is the real GitHubAPI backed by api.github.com. Branch rulesets
+// need `contents: read`; legacy protection and ruleset enumeration need
+// `Administration: read`.
+type HTTPClient struct {
+	Token   string
+	BaseURL string
+	HTTP    *http.Client
+}
+
+func NewHTTPClient() *HTTPClient {
+	token := os.Getenv("GH_TOKEN")
+	if token == "" {
+		token = os.Getenv("GITHUB_TOKEN")
+	}
+	return &HTTPClient{Token: token, BaseURL: "https://api.github.com", HTTP: http.DefaultClient}
+}
+
+// get returns the status code so callers can treat 403/404 as "no data" (fail
+// closed) rather than an error.
+func (c *HTTPClient) get(path string, v any) (int, []byte, error) {
+	req, err := http.NewRequest(http.MethodGet, c.BaseURL+path, nil)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if c.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.Token)
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode == http.StatusOK && v != nil {
+		if err := json.Unmarshal(body, v); err != nil {
+			return resp.StatusCode, body, fmt.Errorf("decode %s: %w", path, err)
+		}
+	}
+	return resp.StatusCode, body, nil
+}
+
+func (c *HTTPClient) BranchRules(repo, branch string) ([]Rule, error) {
+	var raw []struct {
+		Type       string         `json:"type"`
+		Parameters map[string]any `json:"parameters"`
+	}
+	code, _, err := c.get(fmt.Sprintf("/repos/%s/rules/branches/%s", repo, url.PathEscape(branch)), &raw)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, nil // no readable rules -> fail closed
+	}
+	rules := make([]Rule, 0, len(raw))
+	for _, r := range raw {
+		rules = append(rules, Rule{Type: r.Type, Parameters: r.Parameters})
+	}
+	return rules, nil
+}
+
+func (c *HTTPClient) LegacyProtection(repo, branch string) (*LegacyProtection, error) {
+	var lp LegacyProtection
+	code, _, err := c.get(fmt.Sprintf("/repos/%s/branches/%s/protection", repo, url.PathEscape(branch)), &lp)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		// 404 = not protected; 403 = token lacks Administration: read. Either
+		// way we have no legacy data — treat as none (fail closed).
+		return nil, nil
+	}
+	return &lp, nil
+}
+
+var linkNextRe = regexp.MustCompile(`<([^>]+)>;\s*rel="next"`)
+
+func (c *HTTPClient) ListRulesets(repo string) ([]RulesetSummary, error) {
+	path := fmt.Sprintf("/repos/%s/rulesets?includes_parents=true&per_page=100", repo)
+	var all []RulesetSummary
+	for path != "" {
+		var page []RulesetSummary
+		req, err := http.NewRequest(http.MethodGet, c.BaseURL+path, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/vnd.github+json")
+		req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+		if c.Token != "" {
+			req.Header.Set("Authorization", "Bearer "+c.Token)
+		}
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			// Most likely the token lacks Administration: read — no rulesets
+			// visible. Fail closed by returning what we have (possibly none).
+			return all, nil
+		}
+		if err := json.Unmarshal(body, &page); err != nil {
+			return nil, fmt.Errorf("decode rulesets: %w", err)
+		}
+		all = append(all, page...)
+
+		path = ""
+		if m := linkNextRe.FindStringSubmatch(resp.Header.Get("Link")); m != nil {
+			path = strings.TrimPrefix(m[1], c.BaseURL)
+		}
+	}
+	return all, nil
+}
+
+func (c *HTTPClient) GetRuleset(repo string, id int64) (*Ruleset, error) {
+	var rs Ruleset
+	code, _, err := c.get(fmt.Sprintf("/repos/%s/rulesets/%d", repo, id), &rs)
+	if err != nil {
+		return nil, err
+	}
+	if code != http.StatusOK {
+		return nil, nil
+	}
+	return &rs, nil
+}

--- a/actions/check-ref-protection/pkg/refprotection/identity.go
+++ b/actions/check-ref-protection/pkg/refprotection/identity.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Identity answers "what ref, in what repo, is publishing?" In the enforcement
-// path it must come from a signed OIDC token or the runner's GITHUB_* env,
-// never from caller input, so it can't be spoofed onto a different ref.
+// path it must come from the signed OIDC token, never from caller input, so it
+// can't be spoofed onto a different ref.
 type Identity struct {
 	Repository     string
 	RepositoryID   string
@@ -23,7 +23,7 @@ type Identity struct {
 	EventName      string
 	JobWorkflowRef string
 	RefProtected   bool
-	Source         string // "oidc" | "env" | "args"
+	Source         string // "oidc" | "args"
 }
 
 // GitHub sends some claims (including ref_protected) as strings.
@@ -64,22 +64,6 @@ func IdentityFromJWT(jwt string) (*Identity, error) {
 		Source:         "oidc",
 	}
 	if err := id.setRef(c.Ref); err != nil {
-		return nil, err
-	}
-	return id, nil
-}
-
-// IdentityFromEnv builds identity from the runner's GITHUB_* variables.
-func IdentityFromEnv() (*Identity, error) {
-	id := &Identity{
-		Repository:     os.Getenv("GITHUB_REPOSITORY"),
-		RepositoryID:   os.Getenv("GITHUB_REPOSITORY_ID"),
-		SHA:            os.Getenv("GITHUB_SHA"),
-		EventName:      os.Getenv("GITHUB_EVENT_NAME"),
-		JobWorkflowRef: os.Getenv("GITHUB_WORKFLOW_REF"),
-		Source:         "env",
-	}
-	if err := id.setRef(os.Getenv("GITHUB_REF")); err != nil {
 		return nil, err
 	}
 	return id, nil

--- a/actions/check-ref-protection/pkg/refprotection/identity.go
+++ b/actions/check-ref-protection/pkg/refprotection/identity.go
@@ -1,0 +1,136 @@
+package refprotection
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// Identity answers "what ref, in what repo, is publishing?" In the enforcement
+// path it must come from a signed OIDC token or the runner's GITHUB_* env,
+// never from caller input, so it can't be spoofed onto a different ref.
+type Identity struct {
+	Repository     string
+	RepositoryID   string
+	RefType        string // "branch" | "tag"
+	RefName        string
+	SHA            string
+	EventName      string
+	JobWorkflowRef string
+	RefProtected   bool
+	Source         string // "oidc" | "env" | "args"
+}
+
+// GitHub sends some claims (including ref_protected) as strings.
+type oidcClaims struct {
+	Repository     string `json:"repository"`
+	RepositoryID   string `json:"repository_id"`
+	Ref            string `json:"ref"`
+	SHA            string `json:"sha"`
+	EventName      string `json:"event_name"`
+	JobWorkflowRef string `json:"job_workflow_ref"`
+	RefProtected   string `json:"ref_protected"`
+}
+
+// IdentityFromJWT decodes (does NOT verify) the claims of a GitHub OIDC JWT.
+// Safe only when the JWT was just fetched from GitHub's endpoint via
+// FetchOIDCToken — trust comes from the source, not a signature check. Never
+// call it on a token received as input.
+func IdentityFromJWT(jwt string) (*Identity, error) {
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("malformed JWT: expected 3 dot-separated segments, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("decode JWT payload: %w", err)
+	}
+	var c oidcClaims
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return nil, fmt.Errorf("parse JWT claims: %w", err)
+	}
+	id := &Identity{
+		Repository:     c.Repository,
+		RepositoryID:   c.RepositoryID,
+		SHA:            c.SHA,
+		EventName:      c.EventName,
+		JobWorkflowRef: c.JobWorkflowRef,
+		RefProtected:   c.RefProtected == "true",
+		Source:         "oidc",
+	}
+	if err := id.setRef(c.Ref); err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+// IdentityFromEnv builds identity from the runner's GITHUB_* variables.
+func IdentityFromEnv() (*Identity, error) {
+	id := &Identity{
+		Repository:     os.Getenv("GITHUB_REPOSITORY"),
+		RepositoryID:   os.Getenv("GITHUB_REPOSITORY_ID"),
+		SHA:            os.Getenv("GITHUB_SHA"),
+		EventName:      os.Getenv("GITHUB_EVENT_NAME"),
+		JobWorkflowRef: os.Getenv("GITHUB_WORKFLOW_REF"),
+		Source:         "env",
+	}
+	if err := id.setRef(os.Getenv("GITHUB_REF")); err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+func (id *Identity) setRef(ref string) error {
+	switch {
+	case strings.HasPrefix(ref, "refs/heads/"):
+		id.RefType, id.RefName = "branch", strings.TrimPrefix(ref, "refs/heads/")
+	case strings.HasPrefix(ref, "refs/tags/"):
+		id.RefType, id.RefName = "tag", strings.TrimPrefix(ref, "refs/tags/")
+	default:
+		return fmt.Errorf("cannot determine ref type from %q (need refs/heads/* or refs/tags/*)", ref)
+	}
+	return nil
+}
+
+// FetchOIDCToken requests an OIDC token for the audience from GitHub's runtime
+// endpoint. Requires `id-token: write` on the job.
+func FetchOIDCToken(audience string) (string, error) {
+	reqURL := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL")
+	reqTok := os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	if reqURL == "" || reqTok == "" {
+		return "", fmt.Errorf("OIDC env not present (the job needs `id-token: write`): " +
+			"ACTIONS_ID_TOKEN_REQUEST_URL / ACTIONS_ID_TOKEN_REQUEST_TOKEN")
+	}
+	if audience != "" {
+		reqURL += "&audience=" + url.QueryEscape(audience)
+	}
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "bearer "+reqTok)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request OIDC token: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("OIDC endpoint returned %d: %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", fmt.Errorf("parse OIDC response: %w", err)
+	}
+	if out.Value == "" {
+		return "", fmt.Errorf("OIDC response had empty token value")
+	}
+	return out.Value, nil
+}

--- a/actions/check-ref-protection/pkg/refprotection/identity_test.go
+++ b/actions/check-ref-protection/pkg/refprotection/identity_test.go
@@ -1,0 +1,82 @@
+package refprotection
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+)
+
+// makeJWT builds a syntactically-valid JWT (header.payload.signature) whose
+// payload is the given claims. The signature is a dummy — IdentityFromJWT
+// decodes claims without verifying, which is safe because in production the
+// token is fetched directly from GitHub.
+func makeJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	enc := base64.RawURLEncoding.EncodeToString
+	return "header." + enc(payload) + ".signature"
+}
+
+func TestIdentityFromJWT_Branch(t *testing.T) {
+	jwt := makeJWT(t, map[string]any{
+		"repository":       "example/app",
+		"repository_id":    "123456",
+		"ref":              "refs/heads/release-1",
+		"sha":              "abc123",
+		"event_name":       "push",
+		"job_workflow_ref": "example/workflows/.github/workflows/publish.yml@v1",
+		"ref_protected":    "true",
+	})
+
+	id, err := IdentityFromJWT(jwt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.Repository != "example/app" || id.RepositoryID != "123456" {
+		t.Errorf("repo: got %q/%q", id.Repository, id.RepositoryID)
+	}
+	if id.RefType != "branch" || id.RefName != "release-1" {
+		t.Errorf("ref: got %q/%q, want branch/release-1", id.RefType, id.RefName)
+	}
+	if id.SHA != "abc123" || id.EventName != "push" {
+		t.Errorf("sha/event: got %q/%q", id.SHA, id.EventName)
+	}
+	if !id.RefProtected {
+		t.Errorf("ref_protected: got false, want true")
+	}
+	if id.Source != "oidc" {
+		t.Errorf("source: got %q, want oidc", id.Source)
+	}
+}
+
+func TestIdentityFromJWT_Tag(t *testing.T) {
+	jwt := makeJWT(t, map[string]any{
+		"repository":    "example/app",
+		"ref":           "refs/tags/app-2.9.4",
+		"ref_protected": "false",
+	})
+	id, err := IdentityFromJWT(jwt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.RefType != "tag" || id.RefName != "app-2.9.4" {
+		t.Errorf("ref: got %q/%q, want tag/app-2.9.4", id.RefType, id.RefName)
+	}
+	if id.RefProtected {
+		t.Errorf("ref_protected: got true, want false")
+	}
+}
+
+func TestIdentityFromJWT_Errors(t *testing.T) {
+	if _, err := IdentityFromJWT("not-a-jwt"); err == nil {
+		t.Error("expected error for malformed JWT")
+	}
+	// valid JWT shape but an unsupported ref type (e.g. a PR merge ref)
+	jwt := makeJWT(t, map[string]any{"ref": "refs/pull/42/merge"})
+	if _, err := IdentityFromJWT(jwt); err == nil {
+		t.Error("expected error for non-branch/tag ref")
+	}
+}

--- a/actions/check-ref-protection/pkg/refprotection/match.go
+++ b/actions/check-ref-protection/pkg/refprotection/match.go
@@ -1,0 +1,55 @@
+package refprotection
+
+import (
+	"regexp"
+	"strings"
+)
+
+// RefNameMatches reports whether fullRef matches a ruleset's ref_name
+// conditions: at least one include and no exclude.
+func RefNameMatches(include, exclude []string, fullRef string) bool {
+	matched := false
+	for _, p := range include {
+		if patternMatches(p, fullRef) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+	for _, p := range exclude {
+		if patternMatches(p, fullRef) {
+			return false
+		}
+	}
+	return true
+}
+
+func patternMatches(pattern, ref string) bool {
+	switch pattern {
+	case "~ALL":
+		return true
+	case "~DEFAULT_BRANCH":
+		return false // branch-only token; never matches a tag
+	}
+	return globToRegexp(pattern).MatchString(ref)
+}
+
+// globToRegexp builds an anchored regexp where '*' crosses '/' (GitHub fnmatch).
+func globToRegexp(pattern string) *regexp.Regexp {
+	var b strings.Builder
+	b.WriteString("^")
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteString(".")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	b.WriteString("$")
+	return regexp.MustCompile(b.String())
+}

--- a/actions/check-ref-protection/pkg/refprotection/match_test.go
+++ b/actions/check-ref-protection/pkg/refprotection/match_test.go
@@ -1,0 +1,33 @@
+package refprotection
+
+import "testing"
+
+func TestRefNameMatches(t *testing.T) {
+	cases := []struct {
+		name    string
+		include []string
+		exclude []string
+		ref     string
+		want    bool
+	}{
+		{"all matches tag", []string{"~ALL"}, nil, "refs/tags/v1.9.2", true},
+		{"glob v* matches", []string{"refs/tags/v*"}, nil, "refs/tags/v0.39.0", true},
+		{"glob crosses slash", []string{"refs/tags/*"}, nil, "refs/tags/app/2.9.4", true},
+		{"no match", []string{"refs/tags/v*"}, nil, "refs/tags/app-2.9.4", false},
+		{"exact literal", []string{"refs/tags/v1.0.0"}, nil, "refs/tags/v1.0.0", true},
+		{"excluded wins", []string{"~ALL"}, []string{"refs/tags/v0*"}, "refs/tags/v0.39.0", false},
+		{"included not excluded", []string{"~ALL"}, []string{"refs/tags/v0*"}, "refs/tags/v1.0.0", true},
+		{"default-branch token never matches tag", []string{"~DEFAULT_BRANCH"}, nil, "refs/tags/v1", false},
+		{"empty include", nil, nil, "refs/tags/v1", false},
+		{"question mark single char", []string{"refs/tags/v?"}, nil, "refs/tags/v1", true},
+		{"question mark not slash-greedy", []string{"refs/tags/v?"}, nil, "refs/tags/v12", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := RefNameMatches(c.include, c.exclude, c.ref); got != c.want {
+				t.Errorf("RefNameMatches(%v, %v, %q) = %v, want %v",
+					c.include, c.exclude, c.ref, got, c.want)
+			}
+		})
+	}
+}

--- a/actions/check-ref-protection/pkg/refprotection/policy.go
+++ b/actions/check-ref-protection/pkg/refprotection/policy.go
@@ -1,0 +1,192 @@
+package refprotection
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Check is one policy entry. The match is presence-only (Param == ""), a
+// numeric threshold (Min != nil), or an exact value (Equals != nil).
+type Check struct {
+	ID          string           `json:"id"`
+	Severity    string           `json:"severity"`
+	Description string           `json:"description"`
+	RuleType    string           `json:"ruleType"`
+	Param       string           `json:"param,omitempty"`
+	Min         *float64         `json:"min,omitempty"`
+	Equals      *json.RawMessage `json:"equals,omitempty"`
+}
+
+type Policy struct {
+	Branch []Check `json:"branch"`
+	Tag    []Check `json:"tag"`
+}
+
+func (p *Policy) Checks(refType string) []Check {
+	if refType == "tag" {
+		return p.Tag
+	}
+	return p.Branch
+}
+
+func LoadPolicy(path string) (*Policy, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read policy: %w", err)
+	}
+	return ParsePolicy(data)
+}
+
+func ParsePolicy(data []byte) (*Policy, error) {
+	var p Policy
+	if err := json.Unmarshal(data, &p); err != nil {
+		return nil, fmt.Errorf("parse policy: %w", err)
+	}
+	return &p, nil
+}
+
+type Result struct {
+	Check  Check
+	Pass   bool
+	Reason string
+}
+
+func Evaluate(checks []Check, rules []Rule) []Result {
+	out := make([]Result, 0, len(checks))
+	for _, c := range checks {
+		pass, reason := checkRule(c, rules)
+		out = append(out, Result{Check: c, Pass: pass, Reason: reason})
+	}
+	return out
+}
+
+// checkRule passes if ANY matching rule satisfies the check.
+func checkRule(c Check, rules []Rule) (bool, string) {
+	matching := filterByType(rules, c.RuleType)
+	if len(matching) == 0 {
+		return false, fmt.Sprintf("no '%s' rule applies to this ref", c.RuleType)
+	}
+
+	if c.Param == "" {
+		return true, fmt.Sprintf("'%s' rule is present [%s]", c.RuleType, sources(matching))
+	}
+
+	if c.Min != nil {
+		best, bestRule, found := maxParam(matching, c.Param)
+		if found && best >= *c.Min {
+			return true, fmt.Sprintf("%s = %s (>= %s) [%s]",
+				c.Param, num(best), num(*c.Min), bestRule.Source)
+		}
+		return false, fmt.Sprintf("%s = %s, need >= %s", c.Param, num(best), num(*c.Min))
+	}
+
+	if c.Equals != nil {
+		want := strings.TrimSpace(string(*c.Equals))
+		for _, r := range matching {
+			if paramJSON(r, c.Param) == want {
+				return true, fmt.Sprintf("%s = %s [%s]", c.Param, want, r.Source)
+			}
+		}
+		return false, fmt.Sprintf("%s = %s, need %s", c.Param, paramJSON(matching[0], c.Param), want)
+	}
+
+	return true, fmt.Sprintf("'%s' rule is present [%s]", c.RuleType, sources(matching))
+}
+
+// SourcesLabel renders unique sources for display, e.g.
+// "legacy branch protection + rulesets".
+func SourcesLabel(rules []Rule) string {
+	seen := map[string]bool{}
+	var s []string
+	for _, r := range rules {
+		if r.Source == "" || seen[r.Source] {
+			continue
+		}
+		seen[r.Source] = true
+		if r.Source == "legacy" {
+			s = append(s, "legacy branch protection")
+		} else {
+			s = append(s, "rulesets")
+		}
+	}
+	sort.Strings(s)
+	return strings.Join(s, " + ")
+}
+
+func filterByType(rules []Rule, t string) []Rule {
+	var out []Rule
+	for _, r := range rules {
+		if r.Type == t {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func sources(rules []Rule) string {
+	seen := map[string]bool{}
+	var s []string
+	for _, r := range rules {
+		if r.Source != "" && !seen[r.Source] {
+			seen[r.Source] = true
+			s = append(s, r.Source)
+		}
+	}
+	sort.Strings(s)
+	return strings.Join(s, "+")
+}
+
+func maxParam(rules []Rule, param string) (float64, Rule, bool) {
+	var best float64
+	var bestRule Rule
+	found := false
+	for _, r := range rules {
+		v, ok := r.Parameters[param]
+		if !ok {
+			continue
+		}
+		f, ok := toFloat(v)
+		if !ok {
+			continue
+		}
+		if !found || f > best {
+			best, bestRule, found = f, r, true
+		}
+	}
+	return best, bestRule, found
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	}
+	return 0, false
+}
+
+// paramJSON renders a param as compact JSON so bools/numbers/strings compare
+// cleanly against the policy `equals` value.
+func paramJSON(r Rule, param string) string {
+	v, ok := r.Parameters[param]
+	if !ok {
+		return "null"
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return string(b)
+}
+
+func num(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}

--- a/actions/check-ref-protection/pkg/refprotection/policy_test.go
+++ b/actions/check-ref-protection/pkg/refprotection/policy_test.go
@@ -1,0 +1,115 @@
+package refprotection
+
+import "testing"
+
+// a small policy mirroring the real one's shape: presence, numeric min, and
+// exact-equals checks.
+const testPolicy = `{
+  "branch": [
+    {"id":"requires-pr","severity":"required","description":"PR required","ruleType":"pull_request"},
+    {"id":"min-approvals","severity":"required","description":">=1 approval","ruleType":"pull_request","param":"required_approving_review_count","min":1},
+    {"id":"no-self-approve","severity":"required","description":"no self-approve","ruleType":"pull_request","param":"require_last_push_approval","equals":true},
+    {"id":"block-force-push","severity":"required","description":"no force-push","ruleType":"non_fast_forward"},
+    {"id":"signed","severity":"optional","description":"signed commits","ruleType":"required_signatures"}
+  ],
+  "tag": [
+    {"id":"restrict-creation","severity":"required","description":"restrict creation","ruleType":"creation"}
+  ]
+}`
+
+func mustPolicy(t *testing.T) *Policy {
+	t.Helper()
+	p, err := ParsePolicy([]byte(testPolicy))
+	if err != nil {
+		t.Fatalf("parse policy: %v", err)
+	}
+	return p
+}
+
+func TestEvaluate_AllPass(t *testing.T) {
+	p := mustPolicy(t)
+	rules := []Rule{
+		{Type: "pull_request", Source: "rulesets", Parameters: map[string]any{
+			"required_approving_review_count": float64(2),
+			"require_last_push_approval":      true,
+		}},
+		{Type: "non_fast_forward", Source: "rulesets"},
+	}
+	results := Evaluate(p.Checks("branch"), rules)
+
+	reqFailed := false
+	for _, r := range results {
+		if r.Check.Severity == "required" && !r.Pass {
+			reqFailed = true
+			t.Errorf("required check %q failed: %s", r.Check.ID, r.Reason)
+		}
+	}
+	if reqFailed {
+		t.Fatal("expected all required checks to pass")
+	}
+	// optional signed-commits is absent -> should be a non-pass but not required
+	for _, r := range results {
+		if r.Check.ID == "signed" && r.Pass {
+			t.Error("signed-commits should not pass (no rule present)")
+		}
+	}
+}
+
+func TestEvaluate_MinBelowThreshold(t *testing.T) {
+	p := mustPolicy(t)
+	rules := []Rule{
+		{Type: "pull_request", Source: "rulesets", Parameters: map[string]any{
+			"required_approving_review_count": float64(0),
+			"require_last_push_approval":      true,
+		}},
+		{Type: "non_fast_forward", Source: "rulesets"},
+	}
+	results := Evaluate(p.Checks("branch"), rules)
+	got := resultByID(results, "min-approvals")
+	if got.Pass {
+		t.Errorf("min-approvals should fail at count=0, reason=%q", got.Reason)
+	}
+}
+
+func TestEvaluate_EqualsMismatch(t *testing.T) {
+	p := mustPolicy(t)
+	rules := []Rule{
+		{Type: "pull_request", Source: "rulesets", Parameters: map[string]any{
+			"required_approving_review_count": float64(1),
+			"require_last_push_approval":      false, // policy wants true
+		}},
+	}
+	results := Evaluate(p.Checks("branch"), rules)
+	got := resultByID(results, "no-self-approve")
+	if got.Pass {
+		t.Errorf("no-self-approve should fail when require_last_push_approval=false")
+	}
+}
+
+func TestEvaluate_MissingRuleType(t *testing.T) {
+	p := mustPolicy(t)
+	results := Evaluate(p.Checks("tag"), nil) // no rules at all
+	got := resultByID(results, "restrict-creation")
+	if got.Pass {
+		t.Error("restrict-creation should fail when no creation rule applies")
+	}
+	if got.Reason == "" {
+		t.Error("expected a reason explaining the miss")
+	}
+}
+
+func TestSourcesLabel(t *testing.T) {
+	rules := []Rule{{Type: "x", Source: "rulesets"}, {Type: "y", Source: "legacy"}}
+	if got := SourcesLabel(rules); got != "legacy branch protection + rulesets" {
+		t.Errorf("SourcesLabel = %q", got)
+	}
+}
+
+func resultByID(results []Result, id string) Result {
+	for _, r := range results {
+		if r.Check.ID == id {
+			return r
+		}
+	}
+	return Result{}
+}

--- a/actions/check-ref-protection/pkg/refprotection/rules.go
+++ b/actions/check-ref-protection/pkg/refprotection/rules.go
@@ -1,0 +1,146 @@
+package refprotection
+
+// GitHubAPI is the slice of GitHub we depend on, as an interface so collection
+// can be unit-tested without network access.
+type GitHubAPI interface {
+	BranchRules(repo, branch string) ([]Rule, error)
+	LegacyProtection(repo, branch string) (*LegacyProtection, error)
+	ListRulesets(repo string) ([]RulesetSummary, error)
+	GetRuleset(repo string, id int64) (*Ruleset, error)
+}
+
+type RulesetSummary struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Target      string `json:"target"`
+	Enforcement string `json:"enforcement"`
+}
+
+type Ruleset struct {
+	Name        string `json:"name"`
+	Target      string `json:"target"`
+	Enforcement string `json:"enforcement"`
+	Conditions  struct {
+		RefName struct {
+			Include []string `json:"include"`
+			Exclude []string `json:"exclude"`
+		} `json:"ref_name"`
+	} `json:"conditions"`
+	Rules []struct {
+		Type       string         `json:"type"`
+		Parameters map[string]any `json:"parameters"`
+	} `json:"rules"`
+}
+
+type LegacyProtection struct {
+	RequiredPullRequestReviews *struct {
+		RequiredApprovingReviewCount int  `json:"required_approving_review_count"`
+		DismissStaleReviews          bool `json:"dismiss_stale_reviews"`
+		RequireLastPushApproval      bool `json:"require_last_push_approval"`
+	} `json:"required_pull_request_reviews"`
+	AllowForcePushes *struct {
+		Enabled bool `json:"enabled"`
+	} `json:"allow_force_pushes"`
+	AllowDeletions *struct {
+		Enabled bool `json:"enabled"`
+	} `json:"allow_deletions"`
+	RequiredSignatures *struct {
+		Enabled bool `json:"enabled"`
+	} `json:"required_signatures"`
+	RequiredStatusChecks any `json:"required_status_checks"`
+}
+
+// CollectBranchRules merges effective ruleset rules with legacy branch
+// protection; a check passes if either source satisfies it.
+func CollectBranchRules(api GitHubAPI, repo, branch string) ([]Rule, error) {
+	rules, err := api.BranchRules(repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rules {
+		rules[i].Source = "rulesets"
+	}
+
+	legacy, err := api.LegacyProtection(repo, branch)
+	if err != nil {
+		return nil, err
+	}
+	if legacy != nil {
+		rules = append(rules, legacyToRules(legacy)...)
+	}
+	return rules, nil
+}
+
+// legacyToRules maps classic branch protection onto ruleset-shaped Rules
+// (e.g. dismiss_stale_reviews -> dismiss_stale_reviews_on_push).
+func legacyToRules(l *LegacyProtection) []Rule {
+	var out []Rule
+	if l.RequiredPullRequestReviews != nil {
+		out = append(out, Rule{
+			Type:   "pull_request",
+			Source: "legacy",
+			Parameters: map[string]any{
+				"required_approving_review_count": float64(l.RequiredPullRequestReviews.RequiredApprovingReviewCount),
+				"dismiss_stale_reviews_on_push":   l.RequiredPullRequestReviews.DismissStaleReviews,
+				"require_last_push_approval":      l.RequiredPullRequestReviews.RequireLastPushApproval,
+			},
+		})
+	}
+	if l.AllowForcePushes != nil && !l.AllowForcePushes.Enabled {
+		out = append(out, Rule{Type: "non_fast_forward", Source: "legacy"})
+	}
+	if l.AllowDeletions != nil && !l.AllowDeletions.Enabled {
+		out = append(out, Rule{Type: "deletion", Source: "legacy"})
+	}
+	if l.RequiredSignatures != nil && l.RequiredSignatures.Enabled {
+		out = append(out, Rule{Type: "required_signatures", Source: "legacy"})
+	}
+	if l.RequiredStatusChecks != nil {
+		out = append(out, Rule{Type: "required_status_checks", Source: "legacy"})
+	}
+	return out
+}
+
+// CollectTagRules keeps the rules of ACTIVE tag rulesets that match this tag,
+// and records matching-but-not-enforced rulesets separately (never counted).
+func CollectTagRules(api GitHubAPI, repo, tag string) ([]Rule, []NonActiveRuleset, error) {
+	summaries, err := api.ListRulesets(repo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	fullRef := "refs/tags/" + tag
+	var rules []Rule
+	var nonActive []NonActiveRuleset
+
+	for _, s := range summaries {
+		if s.Target != "tag" {
+			continue
+		}
+		rs, err := api.GetRuleset(repo, s.ID)
+		if err != nil || rs == nil {
+			continue
+		}
+		if !RefNameMatches(rs.Conditions.RefName.Include, rs.Conditions.RefName.Exclude, fullRef) {
+			continue
+		}
+
+		if rs.Enforcement == "active" {
+			for _, r := range rs.Rules {
+				rules = append(rules, Rule{Type: r.Type, Parameters: r.Parameters, Source: "rulesets"})
+			}
+			continue
+		}
+
+		types := make([]string, 0, len(rs.Rules))
+		for _, r := range rs.Rules {
+			types = append(types, r.Type)
+		}
+		nonActive = append(nonActive, NonActiveRuleset{
+			Name:        rs.Name,
+			Enforcement: rs.Enforcement,
+			Rules:       types,
+		})
+	}
+	return rules, nonActive, nil
+}

--- a/actions/check-ref-protection/pkg/refprotection/rules_test.go
+++ b/actions/check-ref-protection/pkg/refprotection/rules_test.go
@@ -1,0 +1,143 @@
+package refprotection
+
+import "testing"
+
+// mockAPI is an in-memory GitHubAPI for deterministic, offline tests.
+type mockAPI struct {
+	branchRules map[string][]Rule
+	legacy      map[string]*LegacyProtection
+	summaries   []RulesetSummary
+	rulesets    map[int64]*Ruleset
+}
+
+func (m *mockAPI) BranchRules(_, branch string) ([]Rule, error) { return m.branchRules[branch], nil }
+func (m *mockAPI) LegacyProtection(_, branch string) (*LegacyProtection, error) {
+	return m.legacy[branch], nil
+}
+func (m *mockAPI) ListRulesets(string) ([]RulesetSummary, error)   { return m.summaries, nil }
+func (m *mockAPI) GetRuleset(_ string, id int64) (*Ruleset, error) { return m.rulesets[id], nil }
+
+func tagRuleset(name, enforcement string, include []string, ruleTypes ...string) *Ruleset {
+	rs := &Ruleset{Name: name, Target: "tag", Enforcement: enforcement}
+	rs.Conditions.RefName.Include = include
+	for _, t := range ruleTypes {
+		rs.Rules = append(rs.Rules, struct {
+			Type       string         `json:"type"`
+			Parameters map[string]any `json:"parameters"`
+		}{Type: t})
+	}
+	return rs
+}
+
+func TestCollectBranchRules_MergesSources(t *testing.T) {
+	api := &mockAPI{
+		branchRules: map[string][]Rule{
+			"main": {{Type: "non_fast_forward"}},
+		},
+		legacy: map[string]*LegacyProtection{
+			"main": {
+				RequiredPullRequestReviews: &struct {
+					RequiredApprovingReviewCount int  `json:"required_approving_review_count"`
+					DismissStaleReviews          bool `json:"dismiss_stale_reviews"`
+					RequireLastPushApproval      bool `json:"require_last_push_approval"`
+				}{RequiredApprovingReviewCount: 1, DismissStaleReviews: true, RequireLastPushApproval: true},
+				AllowDeletions: &struct {
+					Enabled bool `json:"enabled"`
+				}{Enabled: false},
+			},
+		},
+	}
+
+	rules, err := CollectBranchRules(api, "example/app", "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// rulesets source: non_fast_forward; legacy source: pull_request + deletion
+	assertHasRule(t, rules, "non_fast_forward", "rulesets")
+	assertHasRule(t, rules, "pull_request", "legacy")
+	assertHasRule(t, rules, "deletion", "legacy")
+
+	pr := findRule(rules, "pull_request")
+	if pr == nil {
+		t.Fatal("missing pull_request rule")
+	}
+	if pr.Parameters["dismiss_stale_reviews_on_push"] != true {
+		t.Errorf("legacy dismiss_stale not normalized: %v", pr.Parameters)
+	}
+	if pr.Parameters["required_approving_review_count"] != float64(1) {
+		t.Errorf("legacy approval count not normalized: %v", pr.Parameters)
+	}
+}
+
+func TestCollectTagRules_ActiveVsNonActive(t *testing.T) {
+	api := &mockAPI{
+		summaries: []RulesetSummary{
+			{ID: 1, Target: "tag"},
+			{ID: 2, Target: "tag"},
+			{ID: 3, Target: "branch"}, // must be ignored
+		},
+		rulesets: map[int64]*Ruleset{
+			1: tagRuleset("active creation", "active", []string{"refs/tags/v*"}, "creation"),
+			2: tagRuleset("draft signing", "evaluate", []string{"~ALL"}, "non_fast_forward"),
+			3: tagRuleset("branch thing", "active", []string{"~ALL"}, "pull_request"),
+		},
+	}
+
+	rules, nonActive, err := CollectTagRules(api, "example/app", "v1.9.2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// active tag ruleset 1 matches v* -> creation counts
+	if findRule(rules, "creation") == nil {
+		t.Error("expected active 'creation' rule to be counted")
+	}
+	// evaluate-mode ruleset 2 must NOT count, but must be reported
+	if findRule(rules, "non_fast_forward") != nil {
+		t.Error("evaluate-mode rule must not be counted toward the bar")
+	}
+	if len(nonActive) != 1 || nonActive[0].Enforcement != "evaluate" {
+		t.Fatalf("expected one non-active ruleset reported, got %+v", nonActive)
+	}
+	// branch-target ruleset 3 must be ignored entirely
+	if findRule(rules, "pull_request") != nil {
+		t.Error("branch-target ruleset must be ignored on the tag path")
+	}
+}
+
+func TestCollectTagRules_NoMatchingRuleset(t *testing.T) {
+	api := &mockAPI{
+		summaries: []RulesetSummary{{ID: 1, Target: "tag"}},
+		rulesets: map[int64]*Ruleset{
+			1: tagRuleset("only v tags", "active", []string{"refs/tags/v*"}, "creation"),
+		},
+	}
+	// app-2.9.4 does not match refs/tags/v*
+	rules, nonActive, err := CollectTagRules(api, "example/app", "app-2.9.4")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rules) != 0 || len(nonActive) != 0 {
+		t.Errorf("expected no rules for non-matching tag, got rules=%v nonActive=%v", rules, nonActive)
+	}
+}
+
+func findRule(rules []Rule, t string) *Rule {
+	for i := range rules {
+		if rules[i].Type == t {
+			return &rules[i]
+		}
+	}
+	return nil
+}
+
+func assertHasRule(t *testing.T, rules []Rule, ruleType, source string) {
+	t.Helper()
+	for _, r := range rules {
+		if r.Type == ruleType && r.Source == source {
+			return
+		}
+	}
+	t.Errorf("expected rule %q from source %q; got %+v", ruleType, source, rules)
+}

--- a/actions/check-ref-protection/pkg/refprotection/types.go
+++ b/actions/check-ref-protection/pkg/refprotection/types.go
@@ -1,0 +1,19 @@
+// Package refprotection checks whether the ref a workflow publishes from meets
+// a protection policy. Branch and tag paths both normalize into []Rule, which a
+// single policy evaluator then judges.
+package refprotection
+
+// Rule is one normalized protection rule. Both ref paths produce these.
+type Rule struct {
+	Type       string
+	Parameters map[string]any
+	Source     string // "rulesets" | "legacy"
+}
+
+// NonActiveRuleset matches the ref but is not hard-enforced (enforcement !=
+// "active"), so it is reported but never counted toward the bar.
+type NonActiveRuleset struct {
+	Name        string
+	Enforcement string
+	Rules       []string
+}

--- a/actions/check-ref-protection/policy.json
+++ b/actions/check-ref-protection/policy.json
@@ -1,0 +1,60 @@
+{
+  "branch": [
+    {
+      "id": "requires-pr",
+      "severity": "required",
+      "description": "Requires a pull request before merging",
+      "ruleType": "pull_request"
+    },
+    {
+      "id": "min-approvals",
+      "severity": "required",
+      "description": "Requires >= 1 approving review",
+      "ruleType": "pull_request",
+      "param": "required_approving_review_count",
+      "min": 1
+    },
+    {
+      "id": "dismiss-stale",
+      "severity": "required",
+      "description": "Dismisses stale approvals when new commits are pushed",
+      "ruleType": "pull_request",
+      "param": "dismiss_stale_reviews_on_push",
+      "equals": true
+    },
+    {
+      "id": "no-self-approve",
+      "severity": "required",
+      "description": "Requires approval of the most recent push (no self-approve)",
+      "ruleType": "pull_request",
+      "param": "require_last_push_approval",
+      "equals": true
+    },
+    {
+      "id": "block-force-push",
+      "severity": "required",
+      "description": "Blocks force-push",
+      "ruleType": "non_fast_forward"
+    },
+    {
+      "id": "block-deletion",
+      "severity": "required",
+      "description": "Blocks branch deletion",
+      "ruleType": "deletion"
+    }
+  ],
+  "tag": [
+    {
+      "id": "restrict-creation",
+      "severity": "required",
+      "description": "Restricts tag creation to bypass actors only",
+      "ruleType": "creation"
+    },
+    {
+      "id": "block-force-push",
+      "severity": "required",
+      "description": "Blocks force-push on the tag",
+      "ruleType": "non_fast_forward"
+    }
+  ]
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -192,6 +192,11 @@
       "extra-files": ["README.md"],
       "initial-version": "1.0.0"
     },
+    "actions/check-ref-protection": {
+      "package-name": "check-ref-protection",
+      "extra-files": ["README.md"],
+      "initial-version": "0.1.0"
+    },
     "actions/issues-update-project-status": {
       "package-name": "issues-update-project-status",
       "extra-files": ["README.md"],


### PR DESCRIPTION
## Summary

Adds `actions/check-ref-protection`, a composite action that gates prod publishing . It reads the protection that applies to the publishing ref and checks it against [`policy.json`](actions/check-ref-protection/policy.json):

- **Branches** — merge ruleset rules + legacy branch protection (pass if either satisfies a check).
- **Tags** — evaluate the *active* tag rulesets matching the tag; `evaluate`/`disabled` rulesets are reported but never counted.

Ref identity comes from the signed **OIDC token** (`identity: oidc`, the default), never caller inputs, so the gate can't be pointed at a different ref. 

Wired into `docker-build-push-multiarch.yml` :

- `off` (default) — gate job is skipped entirely (no cost; no behavior change for existing callers).
- `warn` — gate runs and reports, but never blocks.
- `enforce` — blocks the build/push when the ref doesn't meet the bar.

The gate only runs for **prod** publishes (`gar-environment == 'prod'`), matching the WIF CEL scope — dev builds are unaffected.

## Test

- `go test ./...` in `actions/check-ref-protection` (12 unit tests, offline/mocked).
- Manually verified against real refs (protected `main` → pass; partially-protected release branches → fail; tags with/without rulesets).

## Notes

- `enforce` mode blocks the whole `build-and-push` job (build + push are one step in this workflow). Identity is OIDC-only (`id-token: write` on the gate job).

Issues: https://github.com/grafana/deployment_tools/issues/554020