### PR TITLE
chore(trigger-argo-workflow): bump go version to 1.26

### DIFF
--- a/actions/trigger-argo-workflow/go.mod
+++ b/actions/trigger-argo-workflow/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/shared-workflows/actions/trigger-argo-workflow
 
-go 1.24.0
+go 1.26
 
 require (
 	github.com/cenkalti/backoff/v5 v5.0.3


### PR DESCRIPTION
This is bumped to 1.26 for two reasons:
1. as this isn't a library it doesn't need to support older version so
   it isn't 1.25
2. I am not using patch version so that we always get the latest one
   from setup-go which uses this to decide what to setup

Closes #2017
