### PR TITLE
chore(renovate): enable dependency dashboard in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,7 +21,7 @@
       datasourceTemplate: "npm",
     },
   ],
-  dependencyDashboard: false,
+  dependencyDashboard: true,
   enabledManagers: [
     "bun",
     "bun-version",


### PR DESCRIPTION
Reenabling dependency dashboard to track Renovate activity via issue for this repo