### PR TITLE
fix(renovate): add go mod as enabled manager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,7 @@
     "bun-version",
     "custom.regex",
     "github-actions",
+    "gomod",
     "npm",
   ],
   forkProcessing: "enabled",
@@ -68,6 +69,7 @@
     },
   ],
   platformCommit: "enabled",
+  postUpdateOptions: ["gomodTidy"],
   rebaseWhen: "behind-base-branch",
   vulnerabilityAlerts: {
     automerge: true,


### PR DESCRIPTION
Enabling gomod and tidy activity on shared workflows to support automated go updates 

Manually actioned PR that brought this to our attention e.g. https://github.com/grafana/shared-workflows/pull/2103

