### PR TITLE
fix(zizmor): remove missing permissions PR comments

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -47,14 +47,6 @@ on:
         type: string
         default: ""
 
-      comment-missing-permissions:
-        description: >
-          Post a non-blocking PR comment when any workflow file in the
-          repository contains jobs that don't declare a `permissions:` block.
-        required: false
-        type: boolean
-        default: true
-
       send-bench-metrics:
         description: If true, run Grafana Bench after analysis (Vault Prometheus creds). Job only runs for grafana org and non-fork PRs; fork PRs have no OIDC/Vault access.
         required: false
@@ -553,71 +545,6 @@ jobs:
           fi
 
           echo "zizmor-exit-code=${zizmor_exit_code}" | tee -a "${GITHUB_OUTPUT}"
-
-      # Comment on PRs when any workflow file in the repo doesn't declare a
-      # `permissions:` block at all. This finding type is Medium severity,
-      # so it is invisible to the main scan. This step re-runs zizmor without
-      # the severity filter and surfaces only the "default permissions used due
-      # to no permissions: block" finding type from the excessive-permissions check.
-      - name: Check for missing permissions blocks
-        id: missing-permissions
-        if: >-
-          inputs.comment-missing-permissions &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          steps.validate-config.outcome != 'failure'
-        continue-on-error: true
-        shell: bash
-        env:
-          NO_COLOR: 1
-          ZIZMOR_CONFIG_PATH: ${{ steps.setup-config.outputs.zizmor-config }}
-          ZIZMOR_CACHE_DIR: ${{ runner.temp }}/.cache/zizmor
-        run: |
-          # Keep only the "default permissions used due to no permissions: block" finding
-          filtered="$(uvx zizmor@"${ZIZMOR_VERSION}" \
-            --format plain \
-            --no-exit-codes \
-            --cache-dir "${ZIZMOR_CACHE_DIR}" \
-            ${RUNNER_DEBUG:+"--verbose"} \
-            ${ZIZMOR_CONFIG_PATH:+--config "${ZIZMOR_CONFIG_PATH}"} \
-            ${ZIZMOR_EXTRA_ARGS:+${ZIZMOR_EXTRA_ARGS}} \
-            . \
-            | awk -v RS='' -v ORS='\n\n' \
-              '/\[excessive-permissions\]/ && /default permissions used due to no permissions: block/ && /--> \.\/\.github\/workflows\//')"
-
-          {
-            if [ -n "${filtered}" ]; then
-              echo "found=true"
-            else
-              echo "found=false"
-            fi
-            echo "results<<MISSING_PERMISSIONS_EOF"
-            printf '%s\n' "${filtered}"
-            echo "MISSING_PERMISSIONS_EOF"
-          } >> "${GITHUB_OUTPUT}"
-
-      - name: Hide previous missing-permissions comments
-        if: steps.missing-permissions.outcome == 'success'
-        id: hide-missing-permissions-comments
-        uses: int128/hide-comment-action@42ef2bf9a7d8751219e33ff76f19752fee8decec # v1.61.0
-        with:
-          ends-with: "<!-- comment-action/${{ github.workflow }}/${{ github.job }}/missing-permissions -->"
-
-      - name: Comment on missing permissions blocks
-        if: steps.missing-permissions.outputs.found == 'true'
-        uses: int128/comment-action@36914110eb9d2010cc18858459e9ad3e5694d9e8 # v1.63.0
-        with:
-          post: |
-            :warning: The workflow jobs listed below don't declare a `permissions:` block and may break when the organization's default `GITHUB_TOKEN` permissions are restricted to read-only.
-
-            <details>
-            <summary>Expand for findings</summary>
-
-            ```
-            ${{ steps.missing-permissions.outputs.results }}
-            ```
-            </details>
-            ${{ steps.hide-missing-permissions-comments.outputs.ends-with }}
 
       - name: Remove zizmor config
         env:


### PR DESCRIPTION
This PR removes the temporary missing-permissions PR comment behavior added in #2078 from the reusable zizmor workflow.

## Why

The org default `GITHUB_TOKEN` permissions switch-over happened on July 29, so workflows without explicit `permissions:` blocks now fail directly.