### PR TITLE
fix(lint-pr-title): increase lint-pr-title workflow's max character limit

### DIFF
--- a/actions/lint-pr-title/commitlint.config.js
+++ b/actions/lint-pr-title/commitlint.config.js
@@ -5,7 +5,7 @@ export default {
     "body-max-line-length": [2, "always", 100],
     "footer-leading-blank": [1, "always"],
     "footer-max-line-length": [2, "always", 100],
-    "header-max-length": [2, "always", 100],
+    "header-max-length": [2, "always", 128],
     "subject-case": [
       2,
       "never",


### PR DESCRIPTION
This PR increases the PR title character limit of the `lint-pr-title` workflow from 100 to 128. Some Renovate PRs can exceed the maximum character limit, requiring us to edit the title before being able to merge an otherwise passing PR.