### PR TITLE
docs(signed-commits-info): update permissions in README

### DIFF
--- a/actions/signed-commits-info/README.md
+++ b/actions/signed-commits-info/README.md
@@ -4,26 +4,35 @@ A GitHub Action that runs on pull requests and reports any commit (introduced
 by the PR over its base ref) that does not have a fully verified signature
 according to GitHub's [commit signature verification][verification].
 
-The result is written to the workflow's `GITHUB_STEP_SUMMARY`. The action does
-not fail the job — it is informational only.
+The result is written to the workflow's `GITHUB_STEP_SUMMARY` and also
+published as comment to the pull-request. The action does not fail the job if a
+commit could not be verified — it is informational only.
 
 ## Usage
 
+<!-- x-release-please-start-version -->
 ```yaml
 name: Signed commits
 
 on:
   pull_request:
+  # zizmor: ignore[dangerous-triggers] The underlying action does not interact in any way with the source code of the fork. It requires the scope of the original repository in order to post a comment to the pull request itself.
   pull_request_target:
 
 jobs:
   signed-commits:
+    permissions:
+      contents: read
+      pull-requests: write
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository)
     runs-on: ubuntu-latest
     steps:
-      - uses: grafana/shared-workflows/actions/signed-commits-info@main
+      - uses: grafana/shared-workflows/actions/signed-commits-info@signed-commits-info/v0.1.0
+        continue-on-error: true
 ```
-
-The default `${{ github.token }}` is sufficient; no extra scopes are required.
+<!-- x-release-please-end-version -->
 
 ## Development
 

--- a/actions/signed-commits-info/README.md
+++ b/actions/signed-commits-info/README.md
@@ -11,6 +11,7 @@ commit could not be verified — it is informational only.
 ## Usage
 
 <!-- x-release-please-start-version -->
+
 ```yaml
 name: Signed commits
 
@@ -32,6 +33,7 @@ jobs:
       - uses: grafana/shared-workflows/actions/signed-commits-info@signed-commits-info/v0.1.0
         continue-on-error: true
 ```
+
 <!-- x-release-please-end-version -->
 
 ## Development


### PR DESCRIPTION
Previously, the sample workflow only used the default permissions which is not sufficient. Additionally, the workflow now also does some gating around pull_request and pull_request_target triggers.