### PR TITLE
feat: add sign-and-attest reusable workflow

### DIFF
--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -1,0 +1,130 @@
+# sign-and-attest
+
+This is a reusable workflow that signs and attests a pushed, digest-pinned
+container image:
+
+1. **Keyless cosign signature**, signed via GitHub Actions OIDC through
+   Sigstore.
+2. **SLSA build provenance attestation**, generated with
+   [`actions/attest-build-provenance`], pushed both to the registry as an OCI
+   referrer and to the calling repository's GitHub attestation store. It ties
+   the image digest to the source commit, workflow, and run that built it.
+
+Both are verified in CI immediately after being produced, using the same
+claims consumers are documented to check below, so a broken signature or
+attestation fails the run before anyone relies on it.
+
+Registry authentication uses the calling repository's Workload Identity
+Federation identity (via [`login-to-gar`]), so the workflow works unchanged
+for any `grafana` repository that can push to GAR. There are no secrets to
+pass; the job in the `grafana/shared-workflows` repository is guarded with
+`if: github.repository_owner == 'grafana'` and skips cleanly elsewhere.
+
+[`actions/attest-build-provenance`]: https://github.com/actions/attest-build-provenance
+[`login-to-gar`]: ../../actions/login-to-gar/README.md
+
+## Usage
+
+Call it after the job that pushes the image, passing the digest-pinned
+reference of the (multi-arch index) manifest:
+
+```yaml
+jobs:
+  build:
+    # ... builds and pushes the image, exposes the digest-pinned ref as an output ...
+
+  sign:
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    uses: grafana/shared-workflows/.github/workflows/sign-and-attest.yml@<sha> # main
+    with:
+      image: ${{ needs.build.outputs.image }} # e.g. us-docker.pkg.dev/…/my-image@sha256:…
+```
+
+Pass a digest (`@sha256:…`), not a tag. Signatures attach to the manifest
+digest; the tag is only resolved to a digest at verify time. This has two
+consequences: one signing call covers every tag pointing at that manifest
+(`latest`, `vX.Y.Z`, …), and passing a tag here would be ambiguous, since the
+tag could have been repointed since your build pushed it. The workflow
+therefore rejects refs without `@sha256:`.
+
+## Inputs
+
+| Name       | Type   | Description                                                                                                   |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| `image`    | string | **Required.** Digest-pinned image reference (must contain `@sha256:`), e.g. `us-docker.pkg.dev/…@sha256:…`    |
+| `registry` | string | GAR hostname to authenticate against when writing the signature and attestation. Default: `us-docker.pkg.dev` |
+
+## Required caller permissions
+
+The calling job's permissions must include (called-workflow permissions can
+never exceed the caller's; check the whole `workflow_call` chain if the
+calling workflow is itself reusable):
+
+```yaml
+permissions:
+  contents: read
+  id-token: write # keyless cosign OIDC, provenance signing, WIF auth to GAR
+  attestations: write # write to the GitHub attestations store
+```
+
+## Verification identity contract
+
+The Fulcio certificate identity for every image signed by this workflow is:
+
+```text
+https://github.com/grafana/shared-workflows/.github/workflows/sign-and-attest.yml@<ref>
+issuer: https://token.actions.githubusercontent.com
+```
+
+> [!WARNING]
+> This path/name is a public verification contract shared by **every**
+> consuming repository. Renaming or moving this workflow breaks verification
+> for all of them and for all previously published verification docs. Don't.
+
+Because the identity is shared org-wide, it only proves "signed by Grafana's
+shared signer workflow", not which repo the image came from.
+Verifiers bind the signature to a specific source repository with the
+certificate's repository claim:
+
+```bash
+# Requires cosign >= v3.0
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/grafana/shared-workflows/\.github/workflows/sign-and-attest\.yml@' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-github-workflow-repository grafana/<repo> \
+  <image>@sha256:...
+```
+
+And for the provenance attestation (`--repo` binds to the repository;
+`--signer-workflow` is the valid companion flag; it is mutually exclusive
+with `--cert-identity`/`--signer-repo`):
+
+```bash
+gh attestation verify oci://<image>@sha256:... \
+  --repo grafana/<repo> \
+  --signer-workflow grafana/shared-workflows/.github/workflows/sign-and-attest.yml
+```
+
+This cross-repository signer pattern is [GitHub's documented architecture for
+artifact attestations with reusable workflows](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3).
+
+## SLSA level
+
+This is **SLSA Build L2**: the provenance is authentic and signed, but the
+image is built in the _calling_ repository's job, not inside this trusted
+workflow, so the build itself is not isolated from the caller. Reaching L3
+would require moving the build into the reusable workflow. Don't claim L3
+when documenting images signed this way.
+
+## Why a reusable workflow and not a composite action?
+
+A composite action runs inside the caller's job, so the Fulcio certificate
+identity (`job_workflow_ref`) stays the _caller's_ workflow: every repo gets
+a different verification identity, there is no shared contract to document,
+and no centrally patchable signer. Only a reusable workflow puts
+`grafana/shared-workflows` in the certificate, which is exactly the
+architecture GitHub documents for cross-repository signing (link above).

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -53,10 +53,10 @@ therefore rejects refs without `@sha256:`.
 
 ## Inputs
 
-| Name       | Type   | Description                                                                                                   |
-| ---------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| `image`    | string | **Required.** Digest-pinned image reference (must contain `@sha256:`), e.g. `us-docker.pkg.dev/…@sha256:…`    |
-| `registry` | string | GAR hostname to authenticate against when writing the signature and attestation. Default: `us-docker.pkg.dev` |
+| Name       | Type   | Description                                                                                       |
+| ---------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `image`    | string | **Required.** Digest-pinned image reference under `registry`, e.g. `us-docker.pkg.dev/…@sha256:…` |
+| `registry` | string | GAR hostname (`*.pkg.dev`) to authenticate against and sign in. Default: `us-docker.pkg.dev`      |
 
 ## Required caller permissions
 

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -1,0 +1,175 @@
+name: Sign and attest container image
+
+# For a pushed, digest-pinned container image this reusable workflow:
+#   1. Keyless-signs it with cosign via GitHub Actions OIDC (proves the image
+#      was produced by this workflow's identity, on behalf of the calling
+#      repository).
+#   2. Generates and attaches a SLSA build provenance attestation that ties the
+#      image digest to the calling repository's source commit, workflow, and
+#      run (proves *how* and *from what* the image was built).
+#
+# Signature verification identity:
+#   https://github.com/grafana/shared-workflows/.github/workflows/sign-and-attest.yml@<ref>
+#   issuer https://token.actions.githubusercontent.com
+#
+# Because this is a reusable workflow, the identity above is shared by every
+# consuming repository. Verifiers bind a signature to a specific repo with the
+# certificate's repository claim, e.g.:
+#
+#   cosign verify \
+#     --certificate-identity-regexp '^https://github\.com/grafana/shared-workflows/\.github/workflows/sign-and-attest\.yml@' \
+#     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+#     --certificate-github-workflow-repository grafana/<repo> \
+#     <image>@sha256:...
+#
+#   gh attestation verify oci://<image>@sha256:... \
+#     --repo grafana/<repo> \
+#     --signer-workflow grafana/shared-workflows/.github/workflows/sign-and-attest.yml
+#
+# NOTE: this OIDC identity is part of the verification contract for EVERY
+# repository that signs with this workflow. Changing the workflow path/name
+# (or moving it to another repo) is an org-wide breaking change for anyone
+# verifying. See sign-and-attest.md for the full contract.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: "Digest-pinned image reference, e.g. us-docker.pkg.dev/grafanalabs-global/dockerhub-tanka-prod-mirror/tanka@sha256:..."
+        required: true
+        type: string
+      registry:
+        description: "GAR (Artifact Registry) hostname to authenticate against when writing the signature and attestation."
+        required: false
+        type: string
+        default: us-docker.pkg.dev
+
+permissions:
+  contents: read
+  id-token: write # keyless cosign OIDC, provenance signing, and WIF auth to GAR
+  attestations: write # write the SLSA provenance attestation to the GitHub attestations store
+
+jobs:
+  sign-and-attest:
+    name: Sign and attest image
+    # Guard on the org, not a single repo: WIF auth to GAR and the verification
+    # contract below only make sense for grafana-owned repos. Callers outside
+    # the org get a clean skip instead of a WIF failure. (Reusable workflows
+    # can't have a workflow-level `if`, so this lives on the job.)
+    if: github.repository_owner == 'grafana'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write # keyless cosign OIDC, provenance signing, and WIF auth to GAR
+      attestations: write # write the SLSA provenance attestation to the GitHub attestations store
+    steps:
+      - name: Parse and validate image
+        id: image
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          if [[ "${IMAGE}" != *"@sha256:"* ]]; then
+            echo "::error::image must be digest-pinned (contain @sha256:), got: ${IMAGE}"
+            exit 1
+          fi
+          # Split "<name>@sha256:<hex>" into the registry path and the digest,
+          # which the attestation action needs as separate inputs.
+          echo "name=${IMAGE%@*}" >> "$GITHUB_OUTPUT"
+          echo "digest=${IMAGE##*@}" >> "$GITHUB_OUTPUT"
+
+      # This must stay a fully-qualified, SHA-pinned reference (not
+      # `./actions/...`): a reusable workflow runs in the caller's context with
+      # no checkout of shared-workflows. The action authenticates via the
+      # *calling* repo's WIF identity, so it works unchanged for any grafana
+      # repo. It runs WIF auth via the calling repo's service account and sets
+      # up gcloud + a gcloud docker *credential helper*. cosign is
+      # credential-helper-aware so it authenticates off this directly. The
+      # "Add static registry credentials" step below then adds a static auths
+      # entry for actions/attest-build-provenance, which does NOT understand
+      # credential helpers.
+      - name: Login to GAR
+        uses: grafana/shared-workflows/actions/login-to-gar@1f541877ceb22c7be7667d8a8df04984aeac9f9d # login-to-gar/v1.0.3
+        with:
+          registry: ${{ inputs.registry }}
+
+      - name: Add static registry credentials
+        # login-to-gar (above) configures a gcloud docker *credential helper*.
+        # cosign understands credential helpers, but actions/attest-build-provenance
+        # (push-to-registry) only reads static `auths` from the docker config and
+        # does not invoke helpers, so without this it fails with "No credentials
+        # found for registry ...". Write a static auth entry (additive; cosign
+        # still works) using a short-lived GAR access token from the gcloud auth
+        # that login-to-gar set up.
+        # Note: oauth2accesstoken is a magic literal string required by GAR,
+        # not a secret. It tells GAR the password field is an OAuth2 access token.
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          token="$(gcloud auth print-access-token)"
+          if [[ -z "$token" ]]; then
+            echo "::error::gcloud auth print-access-token returned an empty token"
+            exit 1
+          fi
+          enc="$(printf 'oauth2accesstoken:%s' "$token" | base64 -w0)"
+          cfg="${HOME}/.docker/config.json"
+          mkdir -p "${HOME}/.docker"
+          [ -f "$cfg" ] || echo '{}' > "$cfg"
+          tmp="$(mktemp)"
+          jq --arg reg "$REGISTRY" --arg a "$enc" '.auths[$reg] = {auth: $a}' "$cfg" > "$tmp"
+          mv "$tmp" "$cfg"
+          chmod 0600 "$cfg"
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.1
+
+      - name: Sign image
+        # Signs the image index by digest. Uploads to the public Rekor
+        # transparency log by default, which is what makes the short-lived
+        # Fulcio cert verifiable after it expires.
+        env:
+          IMAGE: ${{ inputs.image }}
+        run: |
+          cosign sign --yes "${IMAGE}"
+
+      - name: Attest SLSA build provenance
+        # Generates a signed SLSA provenance statement binding the image digest
+        # to the calling workflow, the source commit, and the run, and pushes it
+        # to the registry as an OCI referrer. Because this workflow runs inside
+        # the caller's run, the attestation also lands in the *calling* repo's
+        # GitHub attestations store.
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: ${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.image.outputs.digest }}
+          push-to-registry: true
+
+      - name: Verify signature
+        # Catch a broken signature in CI before anyone relies on it, using the
+        # exact claims consumers are documented to check: the shared-workflow
+        # identity plus the repository claim binding it to the calling repo.
+        # This checks the registry copy we just signed; any async mirroring to
+        # other registries is not verified here.
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPO: ${{ github.repository }}
+        run: |
+          cosign verify \
+            --certificate-identity-regexp '^https://github\.com/grafana/shared-workflows/\.github/workflows/sign-and-attest\.yml@' \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            --certificate-github-workflow-repository "${REPO}" \
+            "${IMAGE}"
+
+      - name: Verify provenance attestation
+        # Confirms the provenance attestation we just pushed verifies against
+        # the calling repository and this signer workflow before anyone relies
+        # on it.
+        env:
+          IMAGE: ${{ inputs.image }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify "oci://${IMAGE}" \
+            --repo "${REPO}" \
+            --signer-workflow grafana/shared-workflows/.github/workflows/sign-and-attest.yml

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -57,7 +57,8 @@ jobs:
     # the org get a clean skip instead of a WIF failure. (Reusable workflows
     # can't have a workflow-level `if`, so this lives on the job.)
     if: github.repository_owner == 'grafana'
-    runs-on: ubuntu-24.04
+    # Self-hosted so the signing job is covered by our runtime security monitoring.
+    runs-on: ubuntu-x64-small
     permissions:
       contents: read
       id-token: write # keyless cosign OIDC, provenance signing, and WIF auth to GAR
@@ -67,9 +68,14 @@ jobs:
         id: image
         env:
           IMAGE: ${{ inputs.image }}
+          REGISTRY: ${{ inputs.registry }}
         run: |
-          if [[ "${IMAGE}" != *"@sha256:"* ]]; then
-            echo "::error::image must be digest-pinned (contain @sha256:), got: ${IMAGE}"
+          if [[ "${REGISTRY}" != *.pkg.dev ]]; then
+            echo "::error::registry must be a GAR host (*.pkg.dev), got: ${REGISTRY}"
+            exit 1
+          fi
+          if [[ "${IMAGE}" != "${REGISTRY}/"*"@sha256:"* ]]; then
+            echo "::error::image must be a digest-pinned ref under ${REGISTRY}/, got: ${IMAGE}"
             exit 1
           fi
           # Split "<name>@sha256:<hex>" into the registry path and the digest,

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -173,3 +173,17 @@ jobs:
           gh attestation verify "oci://${IMAGE}" \
             --repo "${REPO}" \
             --signer-workflow grafana/shared-workflows/.github/workflows/sign-and-attest.yml
+
+      - name: Remove static registry credentials
+        # Remove the auth entry added above, keeping login-to-gar's
+        # credential-helper config in the same file intact.
+        if: always()
+        env:
+          REGISTRY: ${{ inputs.registry }}
+        run: |
+          cfg="${HOME}/.docker/config.json"
+          if [[ -f "$cfg" ]]; then
+            tmp="$(mktemp)"
+            jq --arg reg "$REGISTRY" 'del(.auths[$reg])' "$cfg" > "$tmp"
+            mv "$tmp" "$cfg"
+          fi


### PR DESCRIPTION
Reusable workflow that cosign-signs (keyless, OIDC) and attaches SLSA build provenance to a digest-pinned container image, then self-verifies both in CI. Adapted from grafana/tempo's `sign-and-attest.yml`, including its GAR auth fix (tempo#7565). First consumer: grafana/tanka.

A reusable workflow rather than a composite action so the Fulcio identity is `grafana/shared-workflows`: one org-wide verification identity, centrally patchable ([GitHub's documented pattern](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3)). Verifiers bind signatures to a specific repo via the certificate's repository claim; see `sign-and-attest.md`.

Note: the workflow path/name becomes a public verification identity, so renaming it later is a breaking change for all consumers. If you want a different name, now is the time.

Ref: https://github.com/grafana/deployment_tools/issues/620914