### PR TITLE
feat(sign-and-attest): allow cosign version input

### DIFF
--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -67,9 +67,10 @@ calling workflow is itself reusable):
 
 ```yaml
 permissions:
+  artifact-metadata: write # Write storage record for GitHub attestation
+  attestations: write # Write to the GitHub attestations store
   contents: read
-  id-token: write # keyless cosign OIDC, provenance signing, WIF auth to GAR
-  attestations: write # write to the GitHub attestations store
+  id-token: write # Keyless cosign OIDC, provenance signing, and WIF auth to GAR
 ```
 
 ## Verification identity contract

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -57,7 +57,7 @@ therefore rejects refs without `@sha256:`.
 | ---------------- | ------ | ------------------------------------------------------------------------------------------------- |
 | `image`          | string | **Required.** Digest-pinned image reference under `registry`, e.g. `us-docker.pkg.dev/…@sha256:…` |
 | `registry`       | string | GAR hostname (`*.pkg.dev`) to authenticate against and sign in. Default: `us-docker.pkg.dev`      |
-| `cosign-version` | string | Version of cosign to use for signing and attesting.                                               |
+| `cosign-version` | string | Cosign release tag to install (e.g. `v3.1.1`). Defaults to the workflow's pinned version.         |
 
 ## Required caller permissions
 

--- a/.github/workflows/sign-and-attest.md
+++ b/.github/workflows/sign-and-attest.md
@@ -53,10 +53,11 @@ therefore rejects refs without `@sha256:`.
 
 ## Inputs
 
-| Name       | Type   | Description                                                                                       |
-| ---------- | ------ | ------------------------------------------------------------------------------------------------- |
-| `image`    | string | **Required.** Digest-pinned image reference under `registry`, e.g. `us-docker.pkg.dev/…@sha256:…` |
-| `registry` | string | GAR hostname (`*.pkg.dev`) to authenticate against and sign in. Default: `us-docker.pkg.dev`      |
+| Name             | Type   | Description                                                                                       |
+| ---------------- | ------ | ------------------------------------------------------------------------------------------------- |
+| `image`          | string | **Required.** Digest-pinned image reference under `registry`, e.g. `us-docker.pkg.dev/…@sha256:…` |
+| `registry`       | string | GAR hostname (`*.pkg.dev`) to authenticate against and sign in. Default: `us-docker.pkg.dev`      |
+| `cosign-version` | string | Version of cosign to use for signing and attesting.                                               |
 
 ## Required caller permissions
 

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: string
         default: us-docker.pkg.dev
+      cosign-version:
+        description: "Version of cosign to use for signing and attesting."
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -127,8 +132,11 @@ jobs:
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        env:
+          # renovate: datasource=github-releases depName=cosign packageName=sigstore/cosign
+          COSIGN_VERSION: v3.1.1
         with:
-          cosign-release: v3.1.1
+          cosign-release: ${{ inputs.cosign-version || env.COSIGN_VERSION }}
 
       - name: Sign image
         # Signs the image index by digest. Uploads to the public Rekor

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -47,7 +47,7 @@ on:
         description: "Cosign release tag to install (e.g. v3.1.1). Defaults to the workflow's pinned version."
         required: false
         type: string
-        default: ''
+        default: ""
 
 permissions:
   contents: read

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -50,9 +50,10 @@ on:
         default: ""
 
 permissions:
+  artifact-metadata: write # Write storage record for GitHub attestation
+  attestations: write # Write the SLSA provenance attestation to the GitHub attestations store
   contents: read
-  id-token: write # keyless cosign OIDC, provenance signing, and WIF auth to GAR
-  attestations: write # write the SLSA provenance attestation to the GitHub attestations store
+  id-token: write # Keyless cosign OIDC, provenance signing, and WIF auth to GAR
 
 jobs:
   sign-and-attest:

--- a/.github/workflows/sign-and-attest.yml
+++ b/.github/workflows/sign-and-attest.yml
@@ -44,7 +44,7 @@ on:
         type: string
         default: us-docker.pkg.dev
       cosign-version:
-        description: "Version of cosign to use for signing and attesting."
+        description: "Cosign release tag to install (e.g. v3.1.1). Defaults to the workflow's pinned version."
         required: false
         type: string
         default: ''

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,6 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.12
     hooks:
       - id: actionlint


### PR DESCRIPTION
- Allow the version of cosign used to be specified. This allows that workflows that use cosign themselves can pass in the same version for consistency and get coordinated renovate updates.
- Add a renovate comment to keep the default cosign version updated.
- Add missing `artifact-metadata:write` permission (which required updating actionlint).
