### PR TITLE
fix: avoid noisy notice messages

### DIFF
--- a/actions/docker-build-push-image/action.yaml
+++ b/actions/docker-build-push-image/action.yaml
@@ -365,7 +365,7 @@ runs:
       run: |
         if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
           rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
-          echo "::notice::Successfully deleted credentials file"
+          echo "::debug::Successfully deleted credentials file"
         else
           echo "::warning::Credentials file not found at ${GOOGLE_APPLICATION_CREDENTIALS}"
         fi

--- a/actions/login-to-gar/action.yaml
+++ b/actions/login-to-gar/action.yaml
@@ -42,7 +42,7 @@ runs:
           exit 1
         fi
 
-        echo "::notice::Moving credentials out of GitHub workspace"
+        echo "::debug::Moving credentials out of GitHub workspace"
         mv "${ORIGINAL_CREDS_PATH}" "${TEMP_CREDS_PATH}"
 
         # Update environment for subsequent steps
@@ -50,7 +50,7 @@ runs:
         echo "GOOGLE_APPLICATION_CREDENTIALS=${TEMP_CREDS_PATH}" | tee -a "${GITHUB_ENV}"
         echo "GOOGLE_GHA_CREDS_PATH=${TEMP_CREDS_PATH}" | tee -a "${GITHUB_ENV}"
 
-        echo "::notice::Credentials stored in ${TEMP_CREDS_PATH}"
+        echo "::debug::Credentials stored in ${TEMP_CREDS_PATH}"
 
     - name: Setup `gcloud` CLI
       if: ${{ !steps.check_if_gcloud_is_installed.outputs.gcloud-installed }}

--- a/actions/login-to-gcs/action.yaml
+++ b/actions/login-to-gcs/action.yaml
@@ -90,7 +90,7 @@ runs:
       run: |
         if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
           rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
-          echo "::notice::Successfully deleted credentials file"
+          echo "::debug::Successfully deleted credentials file"
         else
           echo "::warning::Credentials file not found at ${GOOGLE_APPLICATION_CREDENTIALS}"
         fi

--- a/actions/push-to-gcs/action.yaml
+++ b/actions/push-to-gcs/action.yaml
@@ -112,7 +112,7 @@ runs:
       run: |
         if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
           rm -f "${GOOGLE_APPLICATION_CREDENTIALS}"
-          echo "::notice::Successfully deleted credentials file"
+          echo "::debug::Successfully deleted credentials file"
         else
           echo "::warning::Credentials file not found at ${GOOGLE_APPLICATION_CREDENTIALS}"
         fi


### PR DESCRIPTION
Downgrade `notice` messages` to `debug` to avoid noise in GitHub Actions workflow summaries.

In normal usage, consumers don't need to see things like this in the workflow summaries:

<img width="377" height="131" alt="image" src="https://github.com/user-attachments/assets/74e0a03b-11d0-4f0d-90e1-0d7227d7306d" />
