### PR TITLE
fix(signed-commits-info): make wording explicit about signature verification

### DIFF
--- a/actions/signed-commits-info/dist/index.js
+++ b/actions/signed-commits-info/dist/index.js
@@ -22284,7 +22284,7 @@ function buildCommentBody(unverified, total, baseRef, headRef) {
     "| --- | --- | --- | --- |",
     ...rows,
     "",
-    "This repository requires all commits to be signed. See [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)."
+    "This repository requires all commits to be signed and verified. See [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)."
   ].join(`
 `);
 }

--- a/actions/signed-commits-info/src/comment.ts
+++ b/actions/signed-commits-info/src/comment.ts
@@ -27,7 +27,7 @@ export function buildCommentBody(
     "| --- | --- | --- | --- |",
     ...rows,
     "",
-    "This repository requires all commits to be signed. See [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).",
+    "This repository requires all commits to be signed and verified. See [GitHub docs on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).",
   ].join("\n");
 }
 


### PR DESCRIPTION
The current rules require the commits to be both signed AND verified by the GitHub. That is, a user can sign their commits locally. But until they update their GitHub profile, adding the signature's public key, GitHub will mark the commits as "Unverified" (in oppose to "unsigned").

This PR updates the action's comment to be explicit about the requirement.