### PR TITLE
fix(tech-docs): hold goldmark renovate update below 1.8.0

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -67,6 +67,14 @@
       schedule: "* 0-4 * * 1",
       matchDepNames: ["renovate"],
     },
+    {
+      description: [
+        "Hold goldmark below v1.8 until goldmark-markdown supports it",
+      ],
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/yuin/goldmark"],
+      allowedVersions: "<1.8.0",
+    },
   ],
   platformCommit: "enabled",
   postUpdateOptions: ["gomodTidy"],


### PR DESCRIPTION
Part of https://github.com/grafana/deployment_tools/issues/669040
Preventing update until upstream fix 