### PR TITLE
chore(zizmor): pin zizmor-collection-paths to v0.2.0

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -302,7 +302,7 @@ jobs:
       # .github/zizmor-collection-ignore (optional) — see reusable-zizmor.md
       - name: Collect zizmor paths
         id: zizmor-helper
-        uses: grafana/shared-workflows/actions/zizmor-collection-paths@8e6ceaffac6e92e59a9f90e6a414cb7413ad2503 # zizmor-collection-paths/v0.1.0
+        uses: grafana/shared-workflows/actions/zizmor-collection-paths@0488ac5c8514affaad8206148e57f8c44a4e9a27 # zizmor-collection-paths/v0.2.0
 
       - name: Restore config from cache
         id: cache-config


### PR DESCRIPTION
## Summary

Re-pins `actions/zizmor-collection-paths` in `reusable-zizmor.yml` to the `zizmor-collection-paths/v0.2.0` tag SHA from https://github.com/grafana/shared-workflows/pull/2250.

- Was: `8e6ceaff…` `# zizmor-collection-paths/v0.1.0`
- Now: `0488ac5c8514affaad8206148e57f8c44a4e9a27` `# zizmor-collection-paths/v0.2.0`

Follow-up from the review note on https://github.com/grafana/shared-workflows/pull/1945.

## Test plan

- [x] Pin SHA matches `git rev-parse zizmor-collection-paths/v0.2.0`
- [x] After merge, bump `security-github-actions` `self-zizmor.yaml` when you want the org ruleset on this pin