### PR TITLE
Add security reporting guidance

### DIFF
--- a/actions/signed-commits-info/CLAUDE.md
+++ b/actions/signed-commits-info/CLAUDE.md
@@ -35,3 +35,4 @@ Single-entrypoint Node action. `src/main.ts`:
    no need to diff refs manually or call the list-commits endpoint separately.
 4. Filters commits where `commit.verification.verified !== true` and renders
    them in a table via `core.summary` + generates a pull request comment.
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
