### PR TITLE
fix(socket-export-sbom): run the SPDX export in JS to avoid bot-protection 403s

### DIFF
--- a/actions/socket-export-sbom/README.md
+++ b/actions/socket-export-sbom/README.md
@@ -8,14 +8,29 @@ A good use case is including this sbom as part of a public repo's release artifa
 
 ## Inputs
 
-| Name                     | Type     | Description                                                                                                                                                                                                                          | Default Value                 | Required |
-| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------- | -------- |
-| `socket_api_token`       | `string` | API Key used to authenticate to socket.dev, requires the `full-scans:create` (for `socket scan create`) and `report:read` (for the SPDX export) scopes                                                                               | `none`                        | true     |
-| `socket_base_url`        | `string` | Base URL of the socket api endpoint.                                                                                                                                                                                                 | `"https://api.socket.dev/v0"` | false    |
-| `socket_org`             | `string` | Name of the socket org.                                                                                                                                                                                                              | `"grafana"`                   | true     |
-| `branch`                 | `string` | Branch to scan and export the SBOM for. The caller must have already checked out this branch's source tree before invoking this action, since the Socket CLI scans the local manifest files rather than reading a pre-existing scan. | `none`                        | true     |
-| `output_file`            | `string` | Name of the file to save the socket sbom on the runner. Defaults to `<repo>-<branch>.spdx.json`, e.g. `grafana-v1.2.3.spdx.json`.                                                                                                    | `none`                        | false    |
-| `export_timeout_seconds` | `string` | Max seconds to wait, with backoff, for the SBOM export to become available after scan creation. The full scan report is generated lazily by Socket, so raise this for repos larger than grafana/grafana.                             | `"180"`                       | false    |
+| Name                     | Type     | Description                                                                                                                                                                                                                          | Default Value                  | Required |
+| ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------ | -------- |
+| `socket_api_token`       | `string` | API Key used to authenticate to socket.dev, requires the `full-scans:create` (for `socket scan create`) and `report:read` (for the SPDX export) scopes                                                                               | `none`                         | true     |
+| `socket_base_url`        | `string` | Base URL of the socket api endpoint. Must end in a trailing slash: the Socket CLI appends endpoint paths to it without adding a separator.                                                                                           | `"https://api.socket.dev/v0/"` | false    |
+| `socket_org`             | `string` | Name of the socket org.                                                                                                                                                                                                              | `"grafana"`                    | true     |
+| `branch`                 | `string` | Branch to scan and export the SBOM for. The caller must have already checked out this branch's source tree before invoking this action, since the Socket CLI scans the local manifest files rather than reading a pre-existing scan. | `none`                         | true     |
+| `output_file`            | `string` | Name of the file to save the socket sbom on the runner. Defaults to `<repo>-<branch>.spdx.json`, e.g. `grafana-v1.2.3.spdx.json`.                                                                                                    | `none`                         | false    |
+| `export_timeout_seconds` | `string` | Max seconds to wait, with backoff, for the SBOM export to become available after scan creation. The full scan report is generated lazily by Socket, so raise this for repos larger than grafana/grafana.                             | `"180"`                        | false    |
+
+## Export behaviour
+
+Socket generates the full scan report lazily, so the SPDX export endpoint returns a 404 for a while after `socket scan create` finishes. The export step ([`export-sbom.js`](./export-sbom.js)) polls with a 5s backoff, doubling to a 30s cap, until the report is ready or `export_timeout_seconds` elapses.
+
+Not every failure is worth retrying, so the step separates the two cases:
+
+| Response                                         | Behaviour                                                             |
+| ------------------------------------------------ | --------------------------------------------------------------------- |
+| `200` with a parseable JSON body                 | Written to `output_file`, path published as the `path` output         |
+| `200` with a body that does not parse            | Retried — Socket can serve a partial report while the scan is running |
+| `404`, `408`, `429`, any `5xx`, network failures | Retried until the timeout                                             |
+| `400`, `401`, `403`, any other `4xx`             | Fails immediately — no amount of retrying adds a missing scope        |
+
+Only a body that parses as JSON is written to `output_file`, so a rejection page can never be mistaken for an SBOM by a later step.
 
 ## Examples
 

--- a/actions/socket-export-sbom/action.yml
+++ b/actions/socket-export-sbom/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "Socket API token for authentication"
     required: true
   socket_base_url:
-    description: "Socket base url"
+    description: "Socket base url. Must end in a trailing slash: the Socket CLI appends endpoint paths to it without adding a separator, so a base of `https://api.socket.dev/v0` requests `/v0report/supported` and 404s."
     required: false
     default: "https://api.socket.dev/v0/"
   socket_org:
@@ -69,9 +69,13 @@ runs:
         echo "full_scan_id=$FULL_SCAN_ID" >> "$GITHUB_OUTPUT"
         echo "repo_name=$REPO_NAME" >> "$GITHUB_OUTPUT"
 
+    # The export runs in JS rather than curl: curl sends no User-Agent, which we
+    # suspect trips the bot protection in front of the Socket API, and the shell
+    # loop could not tell a 403 from a 404 so it retried both for the full
+    # timeout. See export-sbom.js.
     - name: Export SPDX SBOM from Socket.dev
       id: export-sbom
-      shell: bash
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         SOCKET_API_TOKEN: ${{ inputs.socket_api_token }}
         SOCKET_BASE_URL: ${{ inputs.socket_base_url }}
@@ -82,43 +86,9 @@ runs:
         OUTPUT_FILE: ${{ inputs.output_file }}
         ACTION_PATH: ${{ github.action_path }}
         TIMEOUT_SECONDS: ${{ inputs.export_timeout_seconds }}
-      run: |
-        if [[ -n "$OUTPUT_FILE" ]]; then
-          # Extract basename in case a path was provided
-          OUTPUT_FILE=$(basename "$OUTPUT_FILE")
-        else
-          # e.g. "grafana" + "feature/foo" -> "grafana-feature-foo.spdx.json"
-          OUTPUT_FILE="${REPO_NAME}-${BRANCH//\//-}.spdx.json"
-        fi
-        DEST="$ACTION_PATH/$OUTPUT_FILE"
-        URL="$SOCKET_BASE_URL/orgs/$SOCKET_ORG/export/spdx/$FULL_SCAN_ID"
-
-        # The full scan report is generated lazily by Socket, so this endpoint
-        # can 404/empty for a while after `socket scan create` returns. Poll
-        # with backoff until it's ready or TIMEOUT_SECONDS elapses.
-        START=$(date +%s)
-        DELAY=5
-        ATTEMPT=0
-        while true; do
-          ATTEMPT=$((ATTEMPT + 1))
-          HTTP_CODE=$(curl --silent --max-time 30 --output "$DEST" --write-out "%{http_code}" \
-            --header "Authorization: Bearer $SOCKET_API_TOKEN" "$URL") || HTTP_CODE="curl_error"
-
-          if [[ "$HTTP_CODE" == "200" ]] && jq -e . "$DEST" >/dev/null 2>&1; then
-            echo "SBOM ready after ${ATTEMPT} attempt(s)"
-            break
-          fi
-
-          ELAPSED=$(($(date +%s) - START))
-          if ((ELAPSED >= TIMEOUT_SECONDS)); then
-            echo "SBOM export not ready after ${ELAPSED}s (last HTTP $HTTP_CODE):" >&2
-            cat "$DEST" >&2
-            exit 1
-          fi
-
-          echo "SBOM not ready yet (HTTP $HTTP_CODE), retrying in ${DELAY}s... (${ELAPSED}s/${TIMEOUT_SECONDS}s elapsed)"
-          sleep "$DELAY"
-          DELAY=$((DELAY * 2 > 30 ? 30 : DELAY * 2))
-        done
-
-        echo "path=$DEST" >> "$GITHUB_OUTPUT"
+      with:
+        # ACTION_PATH, not GITHUB_ACTION_PATH: inside a `uses:` step the latter points
+        # at github-script's own directory rather than this action's.
+        script: |
+          const exportSBOM = require(`${process.env.ACTION_PATH}/export-sbom.js`);
+          await exportSBOM({ core });

--- a/actions/socket-export-sbom/export-sbom.js
+++ b/actions/socket-export-sbom/export-sbom.js
@@ -129,7 +129,7 @@ async function fetchSBOM({ fetch, url, token }) {
   } catch (error) {
     return {
       retryable: true,
-      reason: `Socket returned 200 with a body that is not valid JSON: ${error.message}`,
+      reason: `Socket returned 200 with a body that is not valid JSON (${error.message})${bodySnippet(body)}`,
     };
   }
 

--- a/actions/socket-export-sbom/export-sbom.js
+++ b/actions/socket-export-sbom/export-sbom.js
@@ -1,0 +1,220 @@
+// Socket generates the full scan report lazily, so the SPDX export endpoint 404s for a
+// while after `socket scan create` returns. This polls until the report is ready.
+//
+// This replaces a bare `curl` loop that could not tell a 403 from a 404: it retried
+// every non-200 for the full timeout and then reported the failure as "not ready".
+// curl also sends no User-Agent, which we suspect trips bot protection in front of the
+// Socket API. Both are addressed here.
+
+// `actions/github-script` loads this file with require(), so it has to stay CommonJS.
+/* eslint-disable @typescript-eslint/no-require-imports */
+const fsPromises = require("node:fs/promises");
+const path = require("node:path");
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+const REQUEST_TIMEOUT_SECONDS = 30;
+const INITIAL_DELAY_SECONDS = 5;
+const MAX_DELAY_SECONDS = 30;
+
+// Enough of an error body to identify the failure without flooding the log.
+const BODY_SNIPPET_LIMIT = 500;
+
+const USER_AGENT =
+  "grafana-shared-workflows-socket-export-sbom (+https://github.com/grafana/shared-workflows)";
+
+const REQUIRED_ENV = [
+  "SOCKET_API_TOKEN",
+  "SOCKET_BASE_URL",
+  "SOCKET_ORG",
+  "FULL_SCAN_ID",
+  "REPO_NAME",
+  "BRANCH",
+  "ACTION_PATH",
+];
+
+// Socket has not finished generating the report (404), is rate limiting us (429), or is
+// briefly unhealthy (5xx). Every other status -- 400, 401, 403 -- means the request
+// itself is wrong, and retrying only delays the failure until the timeout expires.
+const RETRYABLE_STATUSES = new Set([404, 408, 429]);
+
+// Retrying cannot add a missing scope, and a bot challenge will not clear on its own.
+const AUTH_HINT =
+  "Check that the Socket API token carries the `report:read` scope and that the request is not being blocked by bot protection.";
+
+// Every duration in this file is in seconds, matching the `export_timeout_seconds`
+// input. setTimeout is the only place that needs milliseconds.
+function delay(seconds) {
+  return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+}
+
+function isRetryableStatus(status) {
+  return RETRYABLE_STATUSES.has(status) || status >= 500;
+}
+
+// exportUrl joins the base URL and the endpoint path with exactly one separator.
+// `socket_base_url` ends in a trailing slash -- the Socket CLI needs it, since it
+// appends endpoint paths without adding a separator of its own -- so the slash is
+// stripped here rather than assumed away: `https://api.socket.dev/v0//orgs/...` is
+// not the same path to Socket.
+function exportUrl({ baseUrl, org, scanId }) {
+  const base = baseUrl.replace(/\/+$/, "");
+  const scan = encodeURIComponent(scanId);
+
+  return `${base}/orgs/${encodeURIComponent(org)}/export/spdx/${scan}`;
+}
+
+// outputFileName is the caller's file name, or `<repo>-<branch>.spdx.json` with slashes
+// in the branch flattened: "grafana" + "feature/foo" -> "grafana-feature-foo.spdx.json".
+function outputFileName({ outputFile, repo, branch }) {
+  // basename, because the caller may pass a path but the file goes in the action dir.
+  if (outputFile) {
+    return path.basename(outputFile);
+  }
+
+  return `${repo}-${branch.replaceAll("/", "-")}.spdx.json`;
+}
+
+function bodySnippet(body) {
+  const text = body.trim();
+  if (!text) {
+    return "";
+  }
+
+  const shown =
+    text.length > BODY_SNIPPET_LIMIT
+      ? `${text.slice(0, BODY_SNIPPET_LIMIT)}...`
+      : text;
+
+  return `: ${shown}`;
+}
+
+// fetchSBOM makes one attempt at the export. It returns the SBOM body on success, and
+// otherwise the reason the attempt failed and whether another attempt could succeed.
+async function fetchSBOM({ fetch, url, token }) {
+  let response;
+
+  try {
+    response = await fetch(url, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: "application/json",
+        "user-agent": USER_AGENT,
+      },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_SECONDS * 1000),
+    });
+  } catch (error) {
+    // A stalled, refused or reset connection is worth another attempt.
+    return {
+      retryable: true,
+      reason:
+        error.name === "TimeoutError"
+          ? `the request did not complete within ${REQUEST_TIMEOUT_SECONDS}s`
+          : `the request failed: ${error.message}`,
+    };
+  }
+
+  const body = await response.text();
+
+  if (!response.ok) {
+    return {
+      retryable: isRetryableStatus(response.status),
+      reason: `Socket returned ${response.status} ${response.statusText}${bodySnippet(body)}`,
+    };
+  }
+
+  // Socket has served a 200 holding a partial report while the scan is still being
+  // generated, so the body has to parse before the export counts as done.
+  try {
+    JSON.parse(body);
+  } catch (error) {
+    return {
+      retryable: true,
+      reason: `Socket returned 200 with a body that is not valid JSON: ${error.message}`,
+    };
+  }
+
+  return { body };
+}
+
+// exportSBOM writes the SPDX SBOM for FULL_SCAN_ID into the action directory and
+// publishes its location as the `path` output. It marks the step as failed when the
+// export cannot be retrieved.
+//
+// env, fetch, sleep, now and writeFile exist so tests can drive the polling loop.
+module.exports = async function exportSBOM({
+  core,
+  env = process.env,
+  fetch = globalThis.fetch,
+  sleep = delay,
+  now = Date.now,
+  writeFile = fsPromises.writeFile,
+}) {
+  const missing = REQUIRED_ENV.filter((name) => !env[name]);
+  if (missing.length > 0) {
+    core.setFailed(`Missing required environment: ${missing.join(", ")}`);
+    return;
+  }
+
+  const timeoutSeconds = Number(env.TIMEOUT_SECONDS);
+  if (!Number.isFinite(timeoutSeconds) || timeoutSeconds < 0) {
+    core.setFailed(
+      `export_timeout_seconds must be a non-negative number, got "${env.TIMEOUT_SECONDS}"`,
+    );
+    return;
+  }
+
+  const url = exportUrl({
+    baseUrl: env.SOCKET_BASE_URL,
+    org: env.SOCKET_ORG,
+    scanId: env.FULL_SCAN_ID,
+  });
+
+  const dest = path.join(
+    env.ACTION_PATH,
+    outputFileName({
+      outputFile: env.OUTPUT_FILE,
+      repo: env.REPO_NAME,
+      branch: env.BRANCH,
+    }),
+  );
+
+  // now() stays a millisecond clock (Date.now); the deadline it feeds is seconds.
+  const deadlineSeconds = now() / 1000 + timeoutSeconds;
+  let delaySeconds = INITIAL_DELAY_SECONDS;
+
+  for (let attempt = 1; ; attempt++) {
+    const { body, retryable, reason } = await fetchSBOM({
+      fetch,
+      url,
+      token: env.SOCKET_API_TOKEN,
+    });
+
+    if (body !== undefined) {
+      // Only a validated body reaches the destination, so a rejection page can never
+      // be mistaken for an SBOM by a later step.
+      await writeFile(dest, body);
+      core.info(`SBOM ready after ${attempt} attempt(s)`);
+      core.setOutput("path", dest);
+      return;
+    }
+
+    if (!retryable) {
+      core.setFailed(`Failed to export the SBOM: ${reason}. ${AUTH_HINT}`);
+      return;
+    }
+
+    const remainingSeconds = deadlineSeconds - now() / 1000;
+    if (remainingSeconds <= 0) {
+      core.setFailed(
+        `SBOM export not ready after ${attempt} attempt(s) and ${timeoutSeconds}s: ${reason}`,
+      );
+      return;
+    }
+
+    // Never sleep past the deadline; the next check would only report the timeout.
+    const waitSeconds = Math.min(delaySeconds, remainingSeconds);
+    core.info(`SBOM not ready yet (${reason}); retrying in ${waitSeconds}s`);
+    await sleep(waitSeconds);
+    delaySeconds = Math.min(delaySeconds * 2, MAX_DELAY_SECONDS);
+  }
+};


### PR DESCRIPTION
The export-sbom stage now runs in JS (`export-sbom.js`, via `actions/github-script`) instead of `curl`. It was hitting 403s in real use: `curl` sends no `User-Agent`, which we suspect trips the bot protection in front of the Socket API, and the shell loop couldn't tell a 403 from a 404 — it retried auth rejections for the full 180s timeout and then reported them as "not ready". Full retry table is in the [README](actions/socket-export-sbom/README.md#export-behaviour).

Behaviour changes worth a reviewer's attention:

- `401`/`403`/other `4xx` now fail on the first response. `404`/`408`/`429`/`5xx` and network errors still retry with the same 5s-doubling-to-30s backoff.
- Only a body that parses as JSON is written to `output_file`. `curl --output` wrote the 403 challenge page straight to the SBOM destination, so a later step could have uploaded an HTML error page as a release asset.
- `socket_base_url` loses its trailing slash, which had been producing `.../v0//orgs/...`. `exportUrl` strips trailing slashes as well, so a caller passing their own can't reintroduce it.