### PR TITLE
docs: remove "public-facing" phrase from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![OpenSSF Scorecard][scorecard image]][scorecard]
 
-A public-facing, centralized place to store reusable workflows and GitHub Actions used by Grafana Labs.
+A centralized place to store reusable workflows and GitHub Actions used by Grafana Labs.
 Refer to the [`actions/`](./actions) directory for the individual actions themselves.
 
 > **Note:** As of May 4th 2026, all action releases are immutable. Once a version tag is created, it will not be moved or overwritten.


### PR DESCRIPTION
That definition feels out of place simply because the repository itself is public.

Follow-up to https://github.com/grafana/shared-workflows/pull/475