### PR TITLE
chore(deps): update zizmor to v1.29.0

### DIFF
--- a/.github/workflows/reusable-zizmor.yml
+++ b/.github/workflows/reusable-zizmor.yml
@@ -282,7 +282,7 @@ jobs:
       MIN_SEVERITY: ${{ inputs.min-severity }}
       MIN_CONFIDENCE: ${{ inputs.min-confidence }}
       # renovate: datasource=pypi depName=zizmor
-      ZIZMOR_VERSION: 1.28.0
+      ZIZMOR_VERSION: 1.29.0
       GH_TOKEN: ${{ inputs.github-token || github.token }}
       ZIZMOR_EXTRA_ARGS: ${{ inputs.extra-args }}
       DEFAULT_ZIZMOR_CONFIG_DOWNLOADED: ${{ needs.job-workflow-ref.outputs.sha }}


### PR DESCRIPTION
Upgrade zizmor to v1.29.0 so required-workflow scans understand GitHub self-repository action references (`uses: $/path/to/action`).

GitHub recommends this syntax for same-repository actions because it resolves from the workflow run commit without depending on the checked-out workspace. Zizmor 1.28.0 rejects the syntax; 1.29.0 adds support for auditing it.

**Testing:** Ran the zizmor collection helper unit tests, parsed the reusable workflow YAML, and audited the workflow with zizmor 1.29.0.