### PR TITLE
fix(check-catalog-info): stage before diffing so drift is actually detected

### DIFF
--- a/.github/workflows/check-catalog-info.yaml
+++ b/.github/workflows/check-catalog-info.yaml
@@ -26,9 +26,13 @@ jobs:
         run: |
           make catalog-info.yaml
 
+      # `git diff --staged` compares the index against HEAD, and nothing here is
+      # ever staged -- so this check passed unconditionally and let 18 actions go
+      # unregistered. Stage first so new and modified files both show up.
       - name: Check for drift
         run: |
+          git add -A
           if ! git diff --staged --exit-code; then
-            echo "catalog-info.yaml is not up-to-date, please run \`make catalog-info.yaml\` to update this file."
+            echo "::error::catalog-info.yaml is not up-to-date, please run \`make catalog-info.yaml\` to update this file."
             exit 1
           fi

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -17,6 +17,24 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: Annotate uncovered lines in a PR diff using Go coverage data
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/annotate-coverage/README.md
+  name: shared-workflows-annotate-coverage
+  title: annotate-coverage
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Lint Argo workflow files
   links:
   - title: README
@@ -53,6 +71,83 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: Signs files in a GitHub Actions artifact using Azure Trusted Signing
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/azure-trusted-signing/README.md
+  name: shared-workflows-azure-trusted-signing
+  title: azure-trusted-signing
+spec:
+  lifecycle: production
+  owner: group:o11y-dept
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: |
+    This action will query for branches that are not in an open PR, and will delete them if 'dry-run' is 'false'.
+    Protected branches are excluded as well.
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/cleanup-branches/README.md
+  name: shared-workflows-cleanup-branches
+  title: cleanup-branches
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Detects which components changed based on component dependencies configuration
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/component-change-detection/README.md
+  name: shared-workflows-component-change-detection
+  title: component-change-detection
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: |
+    Get an ephemeral GitHub App installation token from Vault. Registers a
+    post-job step that revokes the underlying Vault token, which cascade-revokes
+    the GitHub App token as soon as the job finishes (success or failure).
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/create-github-app-token/README.md
+  name: shared-workflows-create-github-app-token
+  title: create-github-app-token
+spec:
+  lifecycle: production
+  owner: group:platform-infrasec
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Auto dismiss Dependabot alerts based on manifest path
   links:
   - title: README
@@ -71,12 +166,85 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: Composite action to push a docker image to GAR or DockerHub
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/docker-build-push-image/README.md
+  name: shared-workflows-docker-build-push-image
+  title: docker-build-push-image
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Composite action to export and upload a docker manifest
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/docker-export-digest/README.md
+  name: shared-workflows-docker-export-digest
+  title: docker-export-digest
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Composite action to export and upload a docker manifest
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/docker-import-digests-push-manifest/README.md
+  name: shared-workflows-docker-import-digests-push-manifest
+  title: docker-import-digests-push-manifest
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Using the shared Grafana Labs DockerHub credentials, log in to DockerHub
   links:
   - title: README
     url: https://github.com/grafana/shared-workflows/blob/main/actions/dockerhub-login/README.md
   name: shared-workflows-dockerhub-login
   title: dockerhub-login
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Downloads an artifact from the last successful run of a workflow on
+    a specific branch
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/download-branch-workflow-artifact/README.md
+  name: shared-workflows-download-branch-workflow-artifact
+  title: download-branch-workflow-artifact
 spec:
   lifecycle: production
   owner: group:platform-productivity
@@ -163,6 +331,44 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: Detect and analyze flaky Go tests using Loki logs
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/go-flaky-tests/README.md
+  name: shared-workflows-go-flaky-tests
+  title: go-flaky-tests
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: |
+    Updates a GitHub Project (v2) issue status field when an issue is assigned.
+    Requires the calling job to have `id-token: write` permission for Vault authentication.
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/issues-update-project-status/README.md
+  name: shared-workflows-issues-update-project-status
+  title: issues-update-project-status
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Run lint on the PR title to check if It matches the commitlint specification.
   links:
   - title: README
@@ -171,7 +377,7 @@ metadata:
   title: lint-pr-title
 spec:
   lifecycle: production
-  owner: group:infra-o11y-frontend
+  owner: group:o11y-frontend
   subcomponentOf: component:shared-workflows
   type: github-action
 
@@ -241,6 +447,24 @@ metadata:
     url: https://github.com/grafana/shared-workflows/blob/main/actions/remove-checkout-credentials/README.md
   name: shared-workflows-remove-checkout-credentials
   title: remove-checkout-credentials
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Capslock compare
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/run-capslock/README.md
+  name: shared-workflows-run-capslock
+  title: run-capslock
 spec:
   lifecycle: production
   owner: group:platform-productivity
@@ -328,6 +552,42 @@ kind: Component
 metadata:
   annotations:
     github.com/project-slug: grafana/shared-workflows
+  description: Reports pull-request commits that lack a verified signature
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/signed-commits-info/README.md
+  name: shared-workflows-signed-commits-info
+  title: signed-commits-info
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Export SPDX SBOM from Socket.dev API for a given repository.
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/socket-export-sbom/README.md
+  name: shared-workflows-socket-export-sbom
+  title: socket-export-sbom
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
   description: Rewrite links inside techdocs pointing to outside resources
   links:
   - title: README
@@ -370,6 +630,82 @@ metadata:
     url: https://github.com/grafana/shared-workflows/blob/main/actions/validate-policy-bot-config/README.md
   name: shared-workflows-validate-policy-bot-config
   title: validate-policy-bot-config
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Validates Renovate configuration files using renovate-config-validator
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/validate-renovate-config/README.md
+  name: shared-workflows-validate-renovate-config
+  title: validate-renovate-config
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Enforces Grafana policy on a repo-local zizmor.yml (used from reusable-zizmor
+    before running zizmor).
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/validate-zizmor-config/README.md
+  name: shared-workflows-validate-zizmor-config
+  title: validate-zizmor-config
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Poll an OCI registry until the given image reference is published,
+    or fail after a timeout. Designed for waiting on the DockerHub side of Grafana's
+    async GAR→DockerHub mirror.
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/wait-for-docker-publish/README.md
+  name: shared-workflows-wait-for-docker-publish
+  title: wait-for-docker-publish
+spec:
+  lifecycle: production
+  owner: group:platform-productivity
+  subcomponentOf: component:shared-workflows
+  type: github-action
+
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: grafana/shared-workflows
+  description: Parses optional .github/zizmor-collection-ignore and emits explicit
+    zizmor scan paths (or signals default "." scanning). Used by reusable-zizmor.
+  links:
+  - title: README
+    url: https://github.com/grafana/shared-workflows/blob/main/actions/zizmor-collection-paths/README.md
+  name: shared-workflows-zizmor-collection-paths
+  title: zizmor-collection-paths
 spec:
   lifecycle: production
   owner: group:platform-productivity

--- a/scripts/generate-catalog-info/main.go
+++ b/scripts/generate-catalog-info/main.go
@@ -180,11 +180,18 @@ func main() {
 		}
 	}
 
+	// writeYAML puts a blank line after every document, which reads well between
+	// them but leaves a trailing one at EOF. pre-commit's end-of-file-fixer
+	// strips that, so emitting it would make the generated file differ from the
+	// committed one by a single byte -- and the drift check would then fail on
+	// every PR. Normalize to exactly one trailing newline.
+	normalized := append(bytes.TrimRight(output.Bytes(), "\n"), '\n')
+
 	if outputPath == "-" {
-		fmt.Println(output.String())
+		fmt.Print(string(normalized))
 		return
 	}
-	if err := os.WriteFile(outputPath, output.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(outputPath, normalized, 0644); err != nil {
 		logger.Error("writing to output failed", "err", err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
`check-catalog-info.yaml` has never worked. It runs `make catalog-info.yaml` and then:

```sh
git diff --staged --exit-code
```

`--staged` compares the index against HEAD, and nothing in the job is ever `git add`ed — so the diff is always empty and the check passes unconditionally, whatever the generator produced.

## What that let through

`catalog-info.yaml` had drifted by 338 lines. **18 of 39 actions were missing from the catalog entirely** , so they never appeared in Backstage:

`annotate-coverage`, `azure-trusted-signing`, `cleanup-branches`, `component-change-detection`, `create-github-app-token`, `docker-build-push-image`, `docker-export-digest`, `docker-import-digests-push-manifest`, `download-branch-workflow-artifact`, `go-flaky-tests`, `issues-update-project-status`, `run-capslock`, `signed-commits-info`, `socket-export-sbom`, `validate-renovate-config`, `validate-zizmor-config`, `wait-for-docker-publish`, `zizmor-collection-paths`

## The fix, in two parts

**1. Stage before diffing** (`.github/workflows/check-catalog-info.yaml`):

```diff
   - name: Check for drift
     run: |
+      git add -A
       if ! git diff --staged --exit-code; then
```

`git diff` alone would have covered modified files but still missed newly created ones — which is the case that actually mattered here, since a brand-new action has no catalog entry to modify. Also switched the failure to `::error::` so it surfaces as an annotation rather than a line in the log.

**2. Normalize the generator's trailing newline** (`scripts/generate-catalog-info/main.go`).

This part is not cosmetic — without it the fixed check fails on every PR. `writeYAML` appends a blank line after each document, which reads well between them but leaves a trailing one at EOF, so the generator emits `\n\n`. The committed file has a single `\n`, because pre-commit's `end-of-file-fixer` had been quietly stripping the extra one before every commit.

That mismatch was invisible while the check was broken. Once the check works, CI regenerates the file, gets `\n\n` back, and the diff shows a one-byte change — so it would have gone from never failing to never passing. I hit exactly this in CI on the first push of this PR.

```go
normalized := append(bytes.TrimRight(output.Bytes(), "\n"), '\n')
```

Applied at the write site so the `-` (stdout) path gets the same treatment.

## Verification

- Simulated the fixed check against the drifted tree: correctly fails.
- `pre-commit run end-of-file-fixer --files catalog-info.yaml`: **Passed**.
- Two consecutive `make catalog-info.yaml` runs: byte-identical.
- Regenerated file parses as 39 documents / 39 components, no duplicates.
- `actionlint`, `gofmt`, `go vet`: clean.

## Notes

Of the 351 changed lines, 17 are the actual fix — the rest is generated catalog content clearing three months of accumulated drift.

Found while working on #2276, which added an equivalent drift check for action docs. That one already uses `git add -A && git diff --staged --exit-code`, and hit the same "generated output must satisfy the formatter" problem with prettier — worth remembering that any generate-and-diff check has both failure modes.

Touches no release-please package, so no version bumps.
