### PR TITLE
feat(generate-openapi-clients): support JavaScript clients

### DIFF
--- a/.github/workflows/test-generate-openapi-clients.yml
+++ b/.github/workflows/test-generate-openapi-clients.yml
@@ -1,0 +1,30 @@
+name: Test OpenAPI client generation
+
+on:
+  pull_request:
+    paths:
+      - actions/generate-openapi-clients/**
+      - .github/workflows/test-generate-openapi-clients.yml
+  push:
+    branches: [main]
+    paths:
+      - actions/generate-openapi-clients/**
+      - .github/workflows/test-generate-openapi-clients.yml
+  merge_group:
+
+permissions: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: python3 -m unittest discover -s actions/generate-openapi-clients -v

--- a/actions/generate-openapi-clients/README.md
+++ b/actions/generate-openapi-clients/README.md
@@ -2,7 +2,20 @@
 
 This action generates clients from an OpenAPI spec. It's meant to generate clients in an uniform way across our organization
 
-_Note: For now, it only generates Go code. But it's structured in a way that any of the languages supported by the openapi-generator could be supported at the same time._
+By default, this action generates Go code under `go/<package-name>`. Set
+`language: javascript` to generate a Fetch-based TypeScript package under
+`js/<package-name>` and compile it to JavaScript with type declarations. Call the
+action once per language to generate both from the same spec.
+
+Go generation requires Go and Java. JavaScript generation requires Node.js/npm
+and Java. The JavaScript package has no runtime dependencies; callers need a
+Fetch implementation (built into modern browsers and Node.js 18+). The action
+pins TypeScript, builds the package, and retains its npm lockfile. Generated
+`dist/` and `node_modules/` directories are ignored by Git.
+
+JavaScript models retain the API's property names and raw JSON values, without
+runtime model conversion or validation. Packages use version `0.0.0`; the spec
+version remains in generated source headers. This action does not publish to npm.
 
 ## Inputs
 
@@ -16,6 +29,7 @@ _Note: For now, it only generates Go code. But it's structured in a way that any
 | `commit-user-email`  | String  | No       | `41898282+github-actions[bot]@users.noreply.github.com`                          | Use a different email address for the commit                                                                                                                                                                                                                                                                                                                                                      |
 | `commit-user-name`   | String  | No       | `github-actions[bot]`                                                            | Use a different username for the commit                                                                                                                                                                                                                                                                                                                                                           |
 | `generator-version`  | String  | No       | `7.7.0`                                                                          | The version of the OpenAPI generator to use                                                                                                                                                                                                                                                                                                                                                       |
+| `language`           | String  | No       | `go`                                                                             | Client language: go or javascript (TypeScript sources compiled to JavaScript). Outputs to go/&lt;package-name> or js/&lt;package-name>.                                                                                                                                                                                                                                                           |
 | `modify-spec-script` | String  | No       |                                                                                  | The path to an executable script that modifies the OpenAPI spec before generating the client. The spec will be piped into the script and the script should output the modified spec to stdout. Note: This is used as a workaround for the OpenAPI generator not supporting certain features. By using this feature, the spec will be modified temporarily, and the changes will not be committed. |
 | `output-dir`         | String  | No       | `.`                                                                              | The directory to output the generated client to                                                                                                                                                                                                                                                                                                                                                   |
 | `package-name`       | String  | Yes      |                                                                                  | The name of the package to generate                                                                                                                                                                                                                                                                                                                                                               |

--- a/actions/generate-openapi-clients/action.yaml
+++ b/actions/generate-openapi-clients/action.yaml
@@ -13,6 +13,10 @@ inputs:
     description: "The directory to output the generated client to"
     required: false
     default: "."
+  language:
+    description: "Client language: go or javascript (TypeScript sources compiled to JavaScript). Outputs to go/<package-name> or js/<package-name>."
+    required: false
+    default: "go"
   commit-changes:
     description: If true, the action will commit and push the changes to the repository, if there's a diff.
     required: false
@@ -90,6 +94,7 @@ runs:
         OUTPUT_DIR: ${{ inputs.output-dir }}
         PACKAGE_NAME: ${{ inputs.package-name }}
         SPEC_PATH: ${{ steps.modify-spec.outputs.spec-path }}
+        CLIENT_LANGUAGE: ${{ inputs.language }}
 
     # Cleanup files that shouldn't be committed
     - name: Cleanup

--- a/actions/generate-openapi-clients/generate-javascript.sh
+++ b/actions/generate-openapi-clients/generate-javascript.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+JS_DIR="${OUTPUT_DIR}/js/${PACKAGE_NAME}"
+rm -rf "${JS_DIR}"
+java -jar openapi-generator-cli.jar generate \
+  -i "${SPEC_PATH}" \
+  -g typescript-fetch \
+  -o "${JS_DIR}" \
+  --git-user-id "grafana" \
+  --git-repo-id "${REPO_NAME}" \
+  --additional-properties="npmName=${REPO_NAME}-${PACKAGE_NAME},npmVersion=0.0.0,supportsES6=true,hideGenerationTimestamp=true,disallowAdditionalPropertiesIfNotPresent=false,withoutRuntimeChecks=true,modelPropertyNaming=original" \
+  -t "${GITHUB_ACTION_PATH}/templates/typescript-fetch"
+
+# There are no runtime dependencies. Pin the compiler in the package template
+# and commit its lockfile alongside the source; node_modules and dist are ignored.
+pushd "${JS_DIR}"
+npm install --ignore-scripts --no-audit --no-fund
+npm run build
+popd

--- a/actions/generate-openapi-clients/generate.sh
+++ b/actions/generate-openapi-clients/generate.sh
@@ -1,7 +1,13 @@
 #! /usr/bin/env bash
 set -euo pipefail
 
-# Generate Go client (TODO: Add support for other languages)
+case "${CLIENT_LANGUAGE:-go}" in
+  go) ;;
+  javascript) exec "${GITHUB_ACTION_PATH}/generate-javascript.sh" ;;
+  *) echo "Unsupported client language: ${CLIENT_LANGUAGE}. Expected go or javascript." >&2; exit 1 ;;
+esac
+
+# Generate Go client
 GO_DIR="${OUTPUT_DIR}/go/${PACKAGE_NAME}"
 rm -rf "${GO_DIR}"
 java -jar openapi-generator-cli.jar generate \

--- a/actions/generate-openapi-clients/templates/typescript-fetch/README.mustache
+++ b/actions/generate-openapi-clients/templates/typescript-fetch/README.mustache
@@ -1,0 +1,36 @@
+# {{npmName}}
+
+Generated from the OpenAPI specification by OpenAPI Generator. Do not edit the
+generated sources manually.
+
+This package contains a Fetch-based client usable from JavaScript or TypeScript.
+It has no runtime dependencies. Use a browser with Fetch support or Node.js 18+,
+or supply a Fetch implementation through `Configuration.fetchApi`.
+
+## Build and use locally
+
+```sh
+npm ci
+npm run build
+```
+
+The build writes CommonJS JavaScript and type declarations to `dist/`. From a
+consuming project, install this package by its local directory:
+
+```sh
+npm install /path/to/this/package
+```
+
+Set `Configuration.basePath` to your API endpoint; the default server URL comes
+from the spec. Configure authentication with `Configuration.headers` or the
+authentication options defined by the spec.
+
+API classes and their request parameter interfaces are in `src/apis/`; model
+types are exported from `src/models/`. Models preserve the API's wire-format
+property names and JSON values. Response schemas are not validated at runtime.
+Non-success HTTP responses reject with `ResponseError`, which retains the
+original response.
+
+Sources and the npm lockfile are committed. Build output and installed
+dependencies are ignored. Version `0.0.0` is a placeholder for local consumption;
+this workflow does not publish an npm package.

--- a/actions/generate-openapi-clients/templates/typescript-fetch/package.mustache
+++ b/actions/generate-openapi-clients/templates/typescript-fetch/package.mustache
@@ -1,0 +1,19 @@
+{
+  "name": "{{npmName}}",
+  "version": "{{npmVersion}}",
+  "description": "Generated API client for {{npmName}}",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/{{gitUserId}}/{{gitRepoId}}.git"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build"
+  },
+  "devDependencies": {
+    "typescript": "5.9.3"
+  }
+}

--- a/actions/generate-openapi-clients/test_generate.py
+++ b/actions/generate-openapi-clients/test_generate.py
@@ -1,0 +1,96 @@
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ACTION = Path(__file__).resolve().parent
+
+
+class GenerateClientTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.env = {
+            **os.environ,
+            "PATH": f"{self.bin}:{os.environ['PATH']}",
+            "OUTPUT_DIR": str(self.root / "clients with spaces"),
+            "PACKAGE_NAME": "sample",
+            "SPEC_PATH": str(self.root / "spec with spaces.yaml"),
+            "REPO_NAME": "public-clients",
+            "GITHUB_ACTION_PATH": str(ACTION),
+            "TEST_LOG": str(self.root / "commands"),
+        }
+        self.stub("java", '''
+if [ "${FAIL_GENERATION:-}" = 1 ]; then exit 42; fi
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = -o ]; then mkdir -p "$2"; touch "$2/generated"; fi
+  shift
+done
+''')
+        self.stub("npm", '''
+printf 'npm %s in %s\n' "$*" "$PWD" >> "$TEST_LOG"
+if [ "${FAIL_BUILD:-}" = 1 ] && [ "$1" = run ]; then exit 43; fi
+''')
+        self.stub("go", 'printf "go %s\\n" "$*" >> "$TEST_LOG"')
+        self.stub("goimports", ':')
+
+    def stub(self, name, body):
+        path = self.bin / name
+        path.write_text("#!/usr/bin/env bash\nset -eu\n" + body + "\n")
+        path.chmod(0o755)
+
+    def generate(self, **env):
+        return subprocess.run(
+            ["bash", str(ACTION / "generate.sh")],
+            cwd=self.root,
+            env={**self.env, **env},
+            capture_output=True,
+            text=True,
+        )
+
+    def test_default_still_generates_go_without_npm(self):
+        result = self.generate()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue((Path(self.env["OUTPUT_DIR"]) / "go/sample/generated").exists())
+        self.assertEqual((self.root / "commands").read_text(), "go mod tidy\n")
+
+    def test_javascript_replaces_only_its_package_and_builds(self):
+        output = Path(self.env["OUTPUT_DIR"])
+        for name in ["js/sample/stale", "js/other/keep", "go/sample/keep"]:
+            path = output / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+        result = self.generate(CLIENT_LANGUAGE="javascript")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse((output / "js/sample/stale").exists())
+        self.assertTrue((output / "js/sample/generated").exists())
+        self.assertTrue((output / "js/other/keep").exists())
+        self.assertTrue((output / "go/sample/keep").exists())
+        commands = (self.root / "commands").read_text()
+        self.assertIn("npm install --ignore-scripts --no-audit --no-fund", commands)
+        self.assertIn(f"npm run build in {output / 'js/sample'}", commands)
+        self.assertNotIn("go mod", commands)
+
+    def test_generation_failure_does_not_install_or_build(self):
+        result = self.generate(CLIENT_LANGUAGE="javascript", FAIL_GENERATION="1")
+        self.assertEqual(result.returncode, 42)
+        self.assertFalse((self.root / "commands").exists())
+
+    def test_build_failure_is_propagated(self):
+        result = self.generate(CLIENT_LANGUAGE="javascript", FAIL_BUILD="1")
+        self.assertEqual(result.returncode, 43)
+
+    def test_unknown_language_fails_before_generation(self):
+        result = self.generate(CLIENT_LANGUAGE="typo")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unsupported client language", result.stderr)
+        self.assertFalse(Path(self.env["OUTPUT_DIR"]).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Add an opt-in `language: javascript` mode to `generate-openapi-clients`. It generates a Fetch-based TypeScript package under `js/<package-name>`, installs the pinned compiler, and builds JavaScript and declarations. Existing callers default to the unchanged Go generation path.

The package has no runtime dependencies, preserves wire-format model properties and raw JSON values, and commits its compiler lockfile. Version `0.0.0` is a placeholder for repository/local consumption; this change does not publish to npm. Callers can invoke the action once per language and commit both outputs together.

This supports generating the three Asserts JS clients alongside their Go counterparts in grafana/grafana-asserts-public-clients.

## Validation

- Five generator orchestration tests: default Go behavior, isolated JS regeneration, unsupported language, generation failure, and build failure.
- Generated and compiled all three current Asserts specs with OpenAPI Generator 7.7.0 and TypeScript 5.9.3.
- Six downstream runtime tests covering base paths, authentication/tenant headers, JSON payload preservation, deep-object query encoding, HTTP errors, and empty 204 responses.
- Shared action documentation consistency check and shell syntax checks passed.
